### PR TITLE
chore(claude-code): CSP inline-content guard (CI)

### DIFF
--- a/.github/workflows/csp-inline-guard.yml
+++ b/.github/workflows/csp-inline-guard.yml
@@ -1,0 +1,24 @@
+name: CSP Inline Guard
+
+# Strict CSP (script-src/style-src 'self') varken sayfalara inline CSS/JS sızmasın.
+# Bu seansta CSP bir kez inline kalıntı yüzünden kırılmıştı · bu guard tekrarını önler.
+# HTML değişen PR'larda + main push'larında (cron'un ürettiği rapor sayfaları dahil) çalışır.
+
+on:
+  pull_request:
+    paths: ['**.html']
+  push:
+    branches: [main]
+    paths: ['**.html']
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Inline CSS/JS kontrolü
+        run: python3 scripts/check-no-inline-csp.py

--- a/scripts/check-no-inline-csp.py
+++ b/scripts/check-no-inline-csp.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""CSP inline-content guard.
+
+Strict CSP yürürlükte (`script-src 'self'; style-src 'self'`). Bu yüzden hiçbir
+HTML sayfasında şunlar OLMAMALI (tarayıcı bloklar → sayfa stilsiz/işlevsiz kalır):
+  • inline <style> bloğu
+  • style="..." attribute
+  • inline çalıştırılan <script> (harici src yok)
+
+İZİNLİ:
+  • <script src="..."> (harici dosya · 'self' kapsar)
+  • <script type="application/ld+json"> (data block · CSP'ye tabi değil)
+
+Yerel kullanım:  python3 scripts/check-no-inline-csp.py
+Çıkış kodu 1 → ihlal var (CI fail eder).
+"""
+import sys, re, glob, os
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+files = set(glob.glob(os.path.join(ROOT, "*.html")))
+files |= set(glob.glob(os.path.join(ROOT, "reports", "**", "*.html"), recursive=True))
+
+STYLE_ATTR = re.compile(r'\sstyle\s*=')
+SCRIPT_OPEN = re.compile(r'<script\b([^>]*)>', re.IGNORECASE)
+LDJSON = re.compile(r'type\s*=\s*["\']application/ld\+json["\']', re.IGNORECASE)
+
+violations = []
+for f in sorted(files):
+    rel = os.path.relpath(f, ROOT)
+    text = open(f, encoding="utf-8").read()
+
+    for i, line in enumerate(text.splitlines(), 1):
+        if "<style" in line.lower():
+            violations.append((rel, i, "inline <style> bloğu", line.strip()[:90]))
+        if STYLE_ATTR.search(line):
+            violations.append((rel, i, "inline style= attribute", line.strip()[:90]))
+
+    for m in SCRIPT_OPEN.finditer(text):
+        attrs = m.group(1)
+        if "src=" in attrs.lower():
+            continue                      # harici · izinli
+        if LDJSON.search(attrs):
+            continue                      # JSON-LD data block · CSP-muaf
+        line_no = text[:m.start()].count("\n") + 1
+        violations.append((rel, line_no, "inline çalıştırılan <script>", m.group(0)[:90]))
+
+if violations:
+    print("❌ CSP guard: inline içerik bulundu — strict CSP bunu bloklar:\n")
+    for rel, ln, kind, snippet in violations:
+        print(f"  {rel}:{ln} · {kind}")
+        print(f"      {snippet}")
+    print(f"\nToplam {len(violations)} ihlal. Inline CSS/JS'i /assets/ altında harici dosyaya taşıyın.")
+    print("(JSON-LD ve <script src> izinlidir.)")
+    sys.exit(1)
+
+print(f"✅ CSP guard: {len(files)} sayfada inline <style>/<script>/style= yok.")


### PR DESCRIPTION
## Özet

Strict CSP'yi (`script-src 'self'; style-src 'self'`) koruyan CI guard. Bu seansta CSP bir kez inline kalıntı yüzünden kırılmıştı; bu, tekrarını önler.

- `scripts/check-no-inline-csp.py` — HTML'lerde inline `<style>`, `style=`, inline çalıştırılan `<script>` arar. **İzinli:** `<script src>` (harici) + `<script type=application/ld+json>` (CSP-muaf). Yerel de çalışır.
- `.github/workflows/csp-inline-guard.yml` — HTML değişen PR + main push (cron'un ürettiği rapor sayfaları dahil) + manuel.

## Test (yerelde doğrulandı)
- [x] Temiz repo (11 sayfa) → PASS
- [x] Sahte inline `<style>`+`style=`+bare `<script>` → 3 ihlal yakalandı, FAIL
- [x] `ld+json` ve `<script src>` → doğru şekilde bayraklanmadı

## AI kullanımı
- Araç: claude-code · İş tipi: mixed · regresyon koruması
- Türkçe içerik Gemini'den geçti mi? yok (CI/script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)