### PR TITLE
feat(claude-code): /ornek · en son raporu canlı gösteren örnek sayfa

### DIFF
--- a/assets/ornek.css
+++ b/assets/ornek.css
@@ -1,0 +1,79 @@
+/* TreScout · /ornek/ · örnek rapor sayfası · site.css (iskelet + token) üzerine biner */
+
+.ornek-main { max-width: 800px; margin: 0 auto; padding: 56px 24px 64px; }
+
+.ornek-eyebrow {
+  font-size: 12px; letter-spacing: .22em; text-transform: uppercase;
+  color: var(--accent); font-weight: 700; margin-bottom: 12px;
+}
+.ornek-title {
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(32px, 6vw, 48px); line-height: 1.1;
+  font-weight: 700; letter-spacing: -.015em; color: #fff;
+}
+.ornek-lead {
+  margin-top: 18px; font-size: 18px; line-height: 1.7; color: var(--ink-muted);
+}
+.ornek-lead strong { color: var(--ink); }
+
+/* rapor gövdesi */
+.ornek-report { margin-top: 40px; }
+.ornek-loading { color: var(--ink-muted); font-size: 15px; padding: 24px 0; }
+.ornek-fallback { color: var(--ink-muted); font-size: 15px; padding: 24px 0; }
+.ornek-fallback a { color: var(--accent); font-weight: 600; }
+
+.ornek-date {
+  font-size: 13px; letter-spacing: .04em; color: var(--brand-light);
+  text-transform: uppercase; font-weight: 600; margin-bottom: 14px;
+}
+.ornek-editorial {
+  font-size: 17px; line-height: 1.75; color: var(--ink);
+  padding: 18px 20px; background: var(--bg-elevated);
+  border-left: 3px solid var(--accent); border-radius: 0 12px 12px 0;
+  margin-bottom: 36px;
+}
+
+.ornek-sec { margin-bottom: 34px; }
+.ornek-sec-title {
+  font-size: 13px; letter-spacing: .14em; text-transform: uppercase;
+  color: var(--brand-light); font-weight: 700; margin-bottom: 14px;
+  padding-bottom: 8px; border-bottom: 1px solid rgba(95, 168, 211, 0.16);
+}
+
+.ornek-item {
+  padding: 16px 0; border-bottom: 1px solid rgba(95, 168, 211, 0.10);
+}
+.ornek-item:last-child { border-bottom: none; }
+.ornek-item-title {
+  display: inline; font-size: 16.5px; font-weight: 600; color: #fff;
+  transition: color .15s;
+}
+.ornek-item-title:hover { color: var(--accent); }
+.ornek-item-meta {
+  display: block; font-size: 12.5px; color: var(--ink-muted);
+  opacity: .8; margin-top: 4px;
+}
+.ornek-item-sum {
+  margin-top: 8px; font-size: 14.5px; line-height: 1.6; color: var(--ink-muted);
+}
+
+/* alt CTA */
+.ornek-cta {
+  margin-top: 44px; padding: 28px; text-align: center;
+  background: var(--bg-elevated); border: 1px solid rgba(244, 211, 94, .22);
+  border-radius: 16px;
+}
+.ornek-cta p { font-size: 16px; line-height: 1.6; color: var(--ink-muted); margin-bottom: 18px; }
+.ornek-cta p strong { color: var(--ink); }
+.ornek-cta .btn { margin: 4px 6px; }
+.ornek-cta .btn-large, .ornek-cta .btn-primary { padding: 13px 26px; }
+
+/* "ve N daha" vurgusu */
+.ornek-more {
+  margin-top: 18px; font-size: 14px; color: var(--accent); font-weight: 600;
+}
+
+@media (max-width: 560px) {
+  .ornek-main { padding: 36px 18px 44px; }
+  .ornek-editorial { font-size: 16px; padding: 14px 16px; }
+}

--- a/assets/ornek.js
+++ b/assets/ornek.js
@@ -1,0 +1,81 @@
+/* TreScout · /ornek/ · en son günlük raporu çekip render eder.
+ * Veri: /sitemap.xml → en güncel /reports/YYYY-MM-DD/ → /reports/trescout-rapor-<date>.json
+ * Hep güncel · generator'a bağımlı değil · CSP-temiz (same-origin fetch, harici script). */
+(function () {
+  var root = document.getElementById('report-root');
+  if (!root) return;
+
+  // Kaynak başına gösterilecek item limiti (geri kalanı "ve N daha" → FOMO)
+  var CAPS = [5, 4, 4];
+  var MONTHS = ['Ocak', 'Şubat', 'Mart', 'Nisan', 'Mayıs', 'Haziran',
+                'Temmuz', 'Ağustos', 'Eylül', 'Ekim', 'Kasım', 'Aralık'];
+
+  function esc(s) {
+    var d = document.createElement('div');
+    d.textContent = s == null ? '' : String(s);
+    return d.innerHTML;
+  }
+  function safeUrl(u) {
+    u = String(u || '');
+    return /^https?:\/\//i.test(u) ? u : '';
+  }
+  function fmtDate(iso) {
+    var m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(iso || ''));
+    if (!m) return esc(iso);
+    return parseInt(m[3], 10) + ' ' + MONTHS[parseInt(m[2], 10) - 1] + ' ' + m[1];
+  }
+  function fail() {
+    root.innerHTML = '<p class="ornek-fallback">Rapor şu an yüklenemedi. ' +
+      '<a href="/reports/">Tüm raporları görün →</a></p>';
+  }
+
+  function render(d) {
+    if (!d || !d.sections || !d.sections.length) return fail();
+    var html = '';
+    html += '<p class="ornek-date">' + fmtDate(d.date) + ' · Günlük Rapor</p>';
+    if (d.editorial) html += '<p class="ornek-editorial">' + esc(d.editorial) + '</p>';
+
+    var shown = 0, total = 0;
+    d.sections.forEach(function (s, idx) {
+      var items = (s && s.items) || [];
+      total += items.length;
+      if (!items.length) return;
+      var cap = CAPS[idx] != null ? CAPS[idx] : 3;
+      html += '<section class="ornek-sec"><h2 class="ornek-sec-title">' + esc(s.sourceName) + '</h2>';
+      items.slice(0, cap).forEach(function (it) {
+        shown++;
+        var url = safeUrl(it.url);
+        var title = url
+          ? '<a class="ornek-item-title" href="' + esc(url) + '" target="_blank" rel="noopener">' + esc(it.title) + '</a>'
+          : '<span class="ornek-item-title">' + esc(it.title) + '</span>';
+        html += '<article class="ornek-item">' + title +
+          (it.meta ? '<span class="ornek-item-meta">' + esc(it.meta) + '</span>' : '') +
+          (it.summary ? '<p class="ornek-item-sum">' + esc(it.summary) + '</p>' : '') +
+          '</article>';
+      });
+      html += '</section>';
+    });
+
+    var more = total - shown;
+    if (more > 0) {
+      html += '<p class="ornek-more">+ ' + more + ' gelişme daha bu raporda.</p>';
+    }
+    root.innerHTML = html;
+  }
+
+  fetch('/sitemap.xml')
+    .then(function (r) { return r.text(); })
+    .then(function (xml) {
+      var dates = (xml.match(/\/reports\/(\d{4}-\d{2}-\d{2})\//g) || [])
+        .map(function (m) { return m.replace(/\D/g, '').replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3'); });
+      if (!dates.length) return fail();
+      var latest = dates.sort().pop();
+      return fetch('/reports/trescout-rapor-' + latest + '.json')
+        .then(function (r) {
+          if (!r.ok) throw new Error('json ' + r.status);
+          return r.json();
+        })
+        .then(render);
+    })
+    .catch(fail);
+})();

--- a/ornek/index.html
+++ b/ornek/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Örnek Rapor · TreScout</title>
+<meta name="description" content="Bir TreScout günlük raporu nasıl görünür? En son raporun öne çıkanları: GitHub, Hacker News ve HuggingFace'ten seçilmiş gelişmeler, Türkçe özetlerle.">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="canonical" href="https://trescout.com/ornek/">
+<meta property="og:title" content="Örnek Rapor · TreScout">
+<meta property="og:description" content="Bir TreScout günlük raporu nasıl görünür? En son raporun öne çıkanları, Türkçe özetlerle.">
+<meta property="og:url" content="https://trescout.com/ornek/">
+<meta property="og:type" content="website">
+<meta property="og:locale" content="tr_TR">
+<meta property="og:image" content="https://trescout.com/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@GetTreScout">
+<meta name="twitter:title" content="Örnek Rapor · TreScout">
+<meta name="twitter:description" content="Bir TreScout günlük raporu nasıl görünür? Türkçe özetlerle öne çıkanlar.">
+<meta name="twitter:image" content="https://trescout.com/og-image.png">
+<link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="stylesheet" href="/assets/site.css">
+<link rel="stylesheet" href="/assets/ornek.css">
+</head>
+<body>
+  <a class="skip-link" href="#main">Ana içeriğe atla</a>
+  <nav>
+    <div class="container nav-inner">
+      <a class="logo-link" href="/" aria-label="TreScout anasayfa">
+        <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
+          <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
+          <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
+          <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
+          <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
+          <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
+          <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
+        </svg>
+        <span>TreScout</span>
+      </a>
+      <div class="nav-actions">
+        <a href="/reports/" class="btn btn-ghost">Raporlar</a>
+        <a href="/#top" class="btn btn-primary">Erken erişim</a>
+      </div>
+    </div>
+  </nav>
+
+  <main id="main">
+    <article class="ornek-main">
+      <div class="ornek-eyebrow">Örnek Rapor</div>
+      <h1 class="ornek-title">Bir TreScout raporu nasıl görünür?</h1>
+      <p class="ornek-lead">Aşağıda <strong>en son günlük raporumuzun</strong> öne çıkanları. Her sabah GitHub, Hacker News ve HuggingFace taranır, yapay zekâ ile Türkçe özetlenir. Siz sadece okursunuz.</p>
+
+      <div id="report-root" class="ornek-report" aria-live="polite">
+        <p class="ornek-loading">En son rapor yükleniyor…</p>
+      </div>
+
+      <aside class="ornek-cta">
+        <p><strong>Tamamı her sabah e-postanızda.</strong> 5 dakikada okunan Türkçe rapor · kendi temponuzda.</p>
+        <a class="btn btn-primary" href="/#top">Erken erişim listesine katılın →</a>
+        <a class="btn btn-ghost" href="/reports/">Tüm raporları görün</a>
+      </aside>
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-brand-block">
+          <div class="footer-logo">
+            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
+              <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
+              <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
+              <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
+              <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
+              <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
+              <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
+            </svg>
+            <span>TreScout</span>
+          </div>
+          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+        </div>
+        <div class="footer-col">
+          <div class="footer-col-title">Ürün</div>
+          <ul>
+            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+            <li><a href="/reports/">Raporlar</a></li>
+            <li><a href="/#top">Erken Erişim</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <div class="footer-col-title">İletişim</div>
+          <ul>
+            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <div class="footer-col-title">Sosyal medya</div>
+          <ul>
+            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      </div>
+    </div>
+  </footer>
+
+  <script src="/assets/ornek.js" defer></script>
+</body>
+</html>

--- a/scripts/check-no-inline-csp.py
+++ b/scripts/check-no-inline-csp.py
@@ -18,8 +18,7 @@ import sys, re, glob, os
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-files = set(glob.glob(os.path.join(ROOT, "*.html")))
-files |= set(glob.glob(os.path.join(ROOT, "reports", "**", "*.html"), recursive=True))
+files = set(glob.glob(os.path.join(ROOT, "**", "*.html"), recursive=True))
 
 STYLE_ATTR = re.compile(r'\sstyle\s*=')
 SCRIPT_OPEN = re.compile(r'<script\b([^>]*)>', re.IGNORECASE)


### PR DESCRIPTION
## Özet
Outreach'te link verebileceğin, ziyaretçinin **kayıt olmadan gerçek değeri deneyimlediği** ayrı sayfa: `trescout.com/ornek`.

- En son günlük raporu **client-side** çeker (sitemap → en güncel rapor JSON → render) → **hep güncel**, generator'a bağımlı değil.
- Gösterir: tarih + editorial + kaynak başlıkları (GitHub/HN/HF) + top item'lar (başlık + Türkçe **özet** + meta) + "+N gelişme daha" (FOMO) + erken-erişim CTA.
- **Mevcut sayfalara dokunulmadı** (istediğin gibi ayrı sayfa).
- CSP-temiz: harici JS (`/assets/ornek.js`), same-origin fetch, tüm dinamik içerik XSS-escape'li.
- Bonus: CSP guard artık `**/*.html` (tüm alt dizinler) tarıyor.

## Test (yerelde)
- [x] ornek.js syntax (node --check)
- [x] Render testi · gerçek 2026-06-01 verisiyle 13 item + editorial + FOMO + XSS-güvenli
- [x] Sayfa + asset'ler + fetch hedefleri 200 · sayfa inline-free
- [x] CSP guard (12 sayfa) PASS
- [ ] Vercel preview · görsel + Türkçe render

## Not
Henüz hiçbir yerden link vermedim (mevcut sayfalara dokunmadım). İstersen homepage'e küçük bir CTA ekleyebiliriz · ya da sadece outreach'te `/ornek` linkini kullan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)