### PR TITLE
chore: nav tutarlılık guard'ı (CI önlemi)

### DIFF
--- a/.github/workflows/csp-inline-guard.yml
+++ b/.github/workflows/csp-inline-guard.yml
@@ -1,8 +1,8 @@
 name: CSP Inline Guard
 
-# Strict CSP (script-src/style-src 'self') varken sayfalara inline CSS/JS sızmasın.
-# Bu seansta CSP bir kez inline kalıntı yüzünden kırılmıştı · bu guard tekrarını önler.
-# HTML değişen PR'larda + main push'larında (cron'un ürettiği rapor sayfaları dahil) çalışır.
+# Sayfa guard'ları · HTML değişen PR'larda + main push'larında (cron/app'in ürettiği rapor sayfaları dahil) çalışır.
+# 1) Strict CSP (script-src/style-src 'self') varken inline CSS/JS sızmasın (bir kez kırılmıştı).
+# 2) Nav tutarlılığı: shared-component (nav) sayfa tipine göre kaymasın — 'link kayboluyor' bug'ı tekrarlamasın.
 
 on:
   pull_request:
@@ -22,3 +22,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Inline CSS/JS kontrolü
         run: python3 scripts/check-no-inline-csp.py
+      - name: Nav tutarlılık kontrolü
+        run: python3 scripts/check-nav-consistency.py

--- a/scripts/check-nav-consistency.py
+++ b/scripts/check-nav-consistency.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+Nav tutarlılık guard'ı (CI)
+===========================
+nav-actions içeren TÜM sayfalar aynı linkleri içermeli. "Shared component"
+(nav) sayfa tipine göre kaymasın → kullanıcının bildirdiği 'link kayboluyor'
+bug'ı bir daha kaçmaz. CSP guard gibi statik + hızlı.
+Kullanım: python3 scripts/check-nav-consistency.py
+"""
+import os, re, glob, sys
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+EXPECTED = ('Keşif', 'Sözlük', 'Raporlar', 'Erken erişim')
+
+def nav_links(p):
+    t = open(p, encoding='utf-8').read()
+    m = re.search(r'<div class="nav-actions">(.*?)</div>', t, re.S)
+    if not m:
+        return None
+    return tuple(x.strip() for x in re.findall(r'>([^<]+)</a>', m.group(1)) if x.strip())
+
+bad, n = [], 0
+for p in sorted(glob.glob(os.path.join(ROOT, '**', '*.html'), recursive=True)):
+    if '/node_modules/' in p:
+        continue
+    links = nav_links(p)
+    if links is None:
+        continue
+    n += 1
+    if links != EXPECTED:
+        bad.append((os.path.relpath(p, ROOT), links))
+
+if bad:
+    print(f"❌ Nav tutarsız ({len(bad)}/{n} sayfa · beklenen: {' · '.join(EXPECTED)}):")
+    for f, l in bad[:40]:
+        print(f"   {f}: {l}")
+    sys.exit(1)
+print(f"✅ Nav tutarlı: {n} sayfanın hepsinde {' · '.join(EXPECTED)}")


### PR DESCRIPTION
Post-mortem önlemi: nav-actions olan tüm sayfaların aynı linkleri içerdiğini CI'da doğrular (shared-component tutarsızlığı = 'link kayboluyor' bug'ı bir daha kaçmaz). 157/157 sayfa geçiyor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)