### PR TITLE
ci(claude-code): üretici çıktısına nav/footer/logo guard'larını da uygula

### DIFF
--- a/.github/workflows/dict-sync.yml
+++ b/.github/workflows/dict-sync.yml
@@ -57,8 +57,16 @@ jobs:
           python3 scripts/discover-md.py
           python3 scripts/llms-txt.py
 
-      - name: CSP guard
+      # Sayfa guard'ları · üretilen sayfalar [skip ci] ile push'landığı için csp-inline-guard.yml
+      # bot commit'lerinde çalışmaz; aynı 4 guard'ı burada üretici çıktısına da uyguluyoruz.
+      - name: Inline CSS/JS kontrolü
         run: python3 scripts/check-no-inline-csp.py
+      - name: Nav tutarlılık kontrolü
+        run: python3 scripts/check-nav-consistency.py
+      - name: Footer tutarlılık kontrolü
+        run: python3 scripts/check-footer-consistency.py
+      - name: Logo geometri kontrolü
+        run: python3 scripts/check-logo-consistency.py
 
       - name: Değişiklik varsa commit'le
         run: |


### PR DESCRIPTION
## Sorun

`dict-sync.yml` üretilen HTML sayfalarını **`[skip ci]`** içeren commit mesajıyla `main`'e push'luyor. Bu nedenle push-tetikli `csp-inline-guard.yml` bu bot commit'lerinde **hiç çalışmıyor**. Workflow'un kendisi ise yalnızca `check-no-inline-csp.py`'ı ("CSP guard" adımı) çalıştırıyordu.

Sonuç: üretici çıktısında oluşabilecek **nav / footer / logo** tutarlılık driftleri ancak bir sonraki insan HTML PR'ında yakalanıyordu — yani üretilen sayfalar bu üç guard'dan muaftı.

## Değişiklik

`dict-sync.yml`'de tek "CSP guard" adımını, `csp-inline-guard.yml`'deki **4 guard'ı aynalayan** ayrı adımlarla değiştirdim:

- `check-no-inline-csp.py` (mevcut)
- `check-nav-consistency.py` (yeni)
- `check-footer-consistency.py` (yeni)
- `check-logo-consistency.py` (yeni)

Bu adımlar generator'lar ile commit adımı arasında, üretici çıktısı üzerinde çalışır. Right-sized: yeni script yok, refactor yok — yalnızca mevcut guard'ları üretici çıktısına da bağladık.

🤖 Generated with [Claude Code](https://claude.com/claude-code)