### PR TITLE
fix(claude-code): sync script sertleştirmesi + CSP sadeleştirme

### DIFF
--- a/scripts/dict-sync.py
+++ b/scripts/dict-sync.py
@@ -115,8 +115,9 @@ def gemini(existing, candidates, key):
              "\n\nADAY terimler:\n"+json.dumps(candidates,ensure_ascii=False))
     body={"systemInstruction":{"parts":[{"text":SYS}]},"contents":[{"parts":[{"text":payload}]}],
           "generationConfig":{"temperature":0.5,"responseMimeType":"application/json","maxOutputTokens":8192}}
-    url=f"https://generativelanguage.googleapis.com/v1beta/models/{MODEL}:generateContent?key={key}"
-    req=urllib.request.Request(url,data=json.dumps(body).encode(),headers={"Content-Type":"application/json"},method="POST")
+    # key header'da taşınır · URL query param'ı log/proxy'lerde sızabilir
+    url=f"https://generativelanguage.googleapis.com/v1beta/models/{MODEL}:generateContent"
+    req=urllib.request.Request(url,data=json.dumps(body).encode(),headers={"Content-Type":"application/json","x-goog-api-key":key},method="POST")
     last=None
     for attempt in range(5):  # geçici 429/500/503/timeout için retry + backoff
         try:
@@ -257,6 +258,9 @@ def main():
     if not key: print("HATA: GEMINI_API_KEY yok (ortam değişkeni ya da app/.env.local)."); sys.exit(1)
     existing=[(m["slug"],m["en"]) for m in manifest]
     new=gemini(existing, [{"term":c["term"],"aciklama":c["explanation"]} for c in candidates], key)
+    # güvenlik: Gemini'nin döndürdüğü slug'ı normalize et · ham slug path'e
+    # girince "../x" gibi bir değer os.path.join ile dictionary/ dışına yazardı
+    for n in new: n["slug"]=slugify(n.get("slug") or "")
     # geçerlilik + slug çakışması filtre
     new=[n for n in new if n.get("slug") and n["slug"] not in existing_slugs and n.get("en") and n.get("kisa") and n.get("tanim")]
     if not new: print("Gemini yeni terim üretmedi (hepsi eş-anlamlı/mevcut) · sözlük güncel ✅"); return

--- a/scripts/discover-sync.py
+++ b/scripts/discover-sync.py
@@ -239,8 +239,9 @@ def gemini_enrich(title,summary,readme,blocks,key):
              "\n\nAYIKLANAN GERÇEK KOMUTLAR (komutu yalnızca bunlardan, birebir seç):\n"+json.dumps(blocks,ensure_ascii=False))
     body={"systemInstruction":{"parts":[{"text":ENRICH_SYS}]},"contents":[{"parts":[{"text":payload}]}],
           "generationConfig":{"temperature":0.4,"responseMimeType":"application/json","maxOutputTokens":2048}}
-    url=f"https://generativelanguage.googleapis.com/v1beta/models/{MODEL}:generateContent?key={key}"
-    req=urllib.request.Request(url,data=json.dumps(body).encode(),headers={"Content-Type":"application/json"},method="POST")
+    # key header'da taşınır · URL query param'ı log/proxy'lerde sızabilir
+    url=f"https://generativelanguage.googleapis.com/v1beta/models/{MODEL}:generateContent"
+    req=urllib.request.Request(url,data=json.dumps(body).encode(),headers={"Content-Type":"application/json","x-goog-api-key":key},method="POST")
     for attempt in range(4):
         try:
             raw=json.loads(urllib.request.urlopen(req,timeout=120).read().decode())["candidates"][0]["content"]["parts"][0]["text"]

--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,7 @@
         { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         { "key": "X-DNS-Prefetch-Control", "value": "on" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.resend.com; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" }
       ]
     },
     {


### PR DESCRIPTION
## Özet

Tüm-sistem güvenlik denetiminin landing bulguları (3 küçük sertleştirme):

| Bulgu | Düzeltme |
|---|---|
| Düşük-orta · Gemini'nin döndürdüğü `slug` doğrulanmadan `os.path.join`'e gidiyordu (`../x` → dictionary/ dışına yazma; rapor glossary metni üzerinden dolaylı prompt-injection yüzeyi) | Mevcut `slugify()` Gemini çıktısına da uygulanır; `[a-z0-9-]` dışındaki her şey temizlenir |
| Düşük · `GEMINI_API_KEY` URL query param'ında (`?key=`) gönderiliyordu, log/proxy sızıntı riski | İki script'te de `x-goog-api-key` header'ına taşındı |
| Bilgi · CSP `connect-src`'de `api.resend.com` gereksizdi | Kaldırıldı; Resend'i tarayıcı değil edge function çağırıyor (repo genelinde grep ile doğrulandı, tek geçtiği yer `api/subscribe.js` sunucu tarafı) |

## Denetimden düzeltme gerektirmeyen notlar

- **Guard kapsama boşluğu bulgusu bayat çıktı:** `dict-sync.yml` zaten 4 guard'ı (inline-CSP, nav, footer, logo) üretici çıktısına uyguluyor (satır 60-69). Drift boşluğu yok.
- **Açık kalan tek orta bulgu:** `/api/subscribe`'da rate limit yok (inbox flood / Resend kota riski). Kod tarafında durumsuz edge function olduğu için altyapı kararı gerekiyor (Vercel WAF kuralı veya Upstash). PR kapsamı dışında bırakıldı, karar bekliyor.
- Doğrulanan güçlü yanlar: tek kaynaklı strict CSP, SRI gerektirecek üçüncü taraf script yok, tüm `target=_blank`'lerde `rel=noopener`, workflow'larda `pull_request_target` yok.

## Doğrulama

- `python3 -m py_compile` iki script için temiz; `vercel.json` JSON parse temiz.
- Slug normalize etme davranışı: geçerli slug'lar (`ascii-kucuk-tireli`) `slugify`'dan değişmeden geçer; yalnızca geçersiz karakter içerenler temizlenir, mevcut sözlük sayfaları etkilenmez.

## AI Traceability

### Plan Agent
- Outputs used: Tüm-sistem güvenlik denetimi raporu (Claude Code oturumu, 2026-06-09)
- Tool: claude-code

### Skills Agent
- [ ] Bu PR'da Skills Agent kullanılmadı

### Türkçe İçerik
- Kullanıcı-yüzü Türkçe metin yok (kod yorumları dahili teknik metin)

### Manuel
- Yok · tüm değişiklikler Claude Code ile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
