### PR TITLE
docs(claude-code): public landing'den ops/altyapı topolojisini çıkar

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ Bu repo Vercel'a bağlı. `main` branch'a her push otomatik production deploy.
 - Vercel default URL: `trescout-landing.vercel.app` (preview'lar için bu pattern)
 - Her PR için ayrı preview URL
 
-## İletişim altyapısı
+## İletişim
 
-| Kanal | Adres / Hesap | Not |
-|---|---|---|
-| Genel iletişim | `hello@trescout.com` | Cloudflare Email Routing → yaani inbox |
-| Operasyonel | `admin@trescout.com` | Servis hesapları, password reset |
-| Erken erişim formu | Tally form `9qp1XY` | Submit → bildirim `hello@`'a |
-| Outbound mail | Resend (`trescout.com` apex · Free tier) | DKIM/SPF verified · Pro'ya geçince `send.trescout.com` subdomain'ine ayrılır |
+| Kanal | Adres |
+|---|---|
+| Genel iletişim | `hello@trescout.com` |
+| Erken erişim formu | landing hero formu → `/api/subscribe` |
+
+> Operasyonel hesaplar, e-posta yönlendirme topolojisi ve mail altyapısı detayları
+> `trescout-internal` reposunda tutulur (bu repo public).
 
 ## Sosyal medya
 

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -73,31 +73,12 @@ npx vercel dev    # local server (api/ route'ları dahil)
 
 `dict-sync.yml` workflow'u (sözlük + keşif oto-büyüme) Vercel env'lerinden **ayrı** bir kasaya bakar: GitHub Actions secret store.
 
-| Key | Nerede | Açıklama |
-|---|---|---|
-| `GEMINI_API_KEY` | **Org secret** (`trescout`) | dict-sync + discover-sync (zengin-oto) Gemini'yi çağırır |
-| `GITHUB_TOKEN` | otomatik (`github.token`) | README/meta çekme · ekstra kurulum gerekmez |
+| Key | Açıklama |
+|---|---|
+| `GEMINI_API_KEY` | dict-sync + discover-sync (zengin-oto) Gemini'yi çağırır · repo/org secret olarak Actions store'da |
+| `GITHUB_TOKEN` | otomatik (`github.token`) · README/meta çekme · ekstra kurulum gerekmez |
 
-### Org secret · görünürlük kısıtı (ÖNEMLİ)
-
-- `GEMINI_API_KEY` **org-seviyesi** secret olarak eklendi (trescout → Settings → Secrets and variables → Actions).
-- **Mevcut GitHub planında org secret'ları yalnızca PUBLIC repolara scope'lanabiliyor.**
-- `trescout/landing` **public** → kapsanıyor ✅ (Action çalışır).
-- `app` · `internal` · `brand-kit` · `kit-app` **private** → org public-secret onlara ulaşmaz; her biri kendi repo secret'ını kullanır (`trescout/app`'te `GEMINI_API_KEY` repo secret olarak zaten var, 2026-05-30).
-
-### ⚠️ İleride bak (plan / görünürlük değişiklikleri)
-
-- **landing private olursa** → org public-secret artık kapsamaz → Action `GEMINI_API_KEY`'i bulamaz. Çözüm: landing'e repo-level secret ekle, YA DA GitHub Team/Enterprise'a yüksel (org secret'ları private repolara da açılır).
-- **Plan yükseltmesi (Free → Team)** → org secret'ları private repolara da scope'lanabilir → app vb. repo secret'ları org'a taşıyıp tek kaynak yapabilirsin.
-- Her durumda: merge sonrası **ilk Action koşusunda** dict-sync adımının geçtiğini doğrula (secret gerçekten erişiliyor mu).
-
-## Secret / env tam haritası (nerede ne var)
-
-| Sır | Kasa | Kullanan |
-|---|---|---|
-| `RESEND_API_KEY` · `RESEND_AUDIENCE_ID` | Vercel env (runtime) | `api/subscribe` (erken-erişim funnel) |
-| `GEMINI_API_KEY` | GitHub **org** secret (public repolar) | landing Action (oto-büyüme) |
-| `GEMINI_API_KEY` | `trescout-app/.env.local` (yerel) | script'leri yerelde çalıştırma |
-| `GEMINI_API_KEY` · `LANDING_PUSH_TOKEN` | `trescout/app` repo secret | app workflow'ları (rapor üretimi + landing'e push) |
-
-> Üç ayrı kasa karışmasın: Vercel (funnel runtime) · GitHub Actions (CI oto-büyüme) · yerel .env.local (geliştirme). Aynı isimli secret farklı kasalarda ayrı ayrı durur.
+> Org secret görünürlük kısıtları, plan/görünürlük değişikliği senaryoları ve
+> tüm repolar arası secret-kasa haritası (nerede ne var) `trescout-internal`
+> reposunda tutulur. Bu repo public olduğu için altyapı topolojisi burada
+> tekrarlanmaz.


### PR DESCRIPTION
## Özet

`trescout/landing` tek **public** repo (diğer 5 repo private · denetimde teyit edildi). README ve docs/ENV.md, saldırgan-keşif değeri taşıyan ama public katkıcı için faydası olmayan ops/altyapı topolojisini içeriyordu. **Sır değeri ifşa olmamıştı** — sadece isimler, kasalar ve topoloji. Bu PR o yüzeyi daraltır.

| Dosya | Çıkarılan | Korunan |
|---|---|---|
| `README.md` | `admin@` parola-sıfırlama hesabı, `hello@ → yaani inbox` yönlendirme hedefi | Public iletişim (`hello@`), form akışı, sosyal medya |
| `docs/ENV.md` | Tam secret-kasa haritası (sır→kasa→kullanan), org-secret görünürlük topolojisi, repo private/public listesi | Resend/Vercel kurulum adımları, local dev, genel güvenlik notları |

Çıkarılan içerik `trescout-internal`'a taşınmalı (her iki yerde pointer bıraktım). Internal'a ekleme ayrı bir iş (chip mevcut: hesap envanteri + bu detaylar birlikte).

## Neden

Public repoda `admin@trescout.com · password reset` + e-posta yönlendirme hedefi + tam secret-kasa haritası, hedefli oltalama/sosyal mühendislik için hazır bir yol haritası. Denetim bunu "düşük" işaretlemişti ama bu repodaki tek-public gerçeğiyle birlikte değeri artıyor.

## Kapsam

- Sadece doküman; kod/CI'a dokunulmadı.
- Git geçmişi yeniden yazılmadı (sır değeri yok · HEAD'den çıkarmak keşfedilebilirliği yeterince düşürür).

## AI Traceability

### Plan Agent
- Outputs used: Tüm-sistem güvenlik denetimi + repo görünürlük teyidi (Claude Code, 2026-06-10)
- Tool: claude-code

### Türkçe İçerik
- Dahili dev/ops dokümanı · kullanıcı-yüzü site metni değil (AGENTS.md §2 Gemini akışı kapsamı dışında)

### Manuel
- Yok

🤖 Generated with [Claude Code](https://claude.com/claude-code)
