### PR TITLE
chore(claude-code): COOP başlığı ekle (başlık setini tamamla)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,7 @@
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), interest-cohort=(), payment=(), usb=()" },
         { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         { "key": "X-DNS-Prefetch-Control", "value": "on" },
         { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" }


### PR DESCRIPTION
## Özet

trescout.com başlık setini tamamlamak için tek ekleme: `Cross-Origin-Opener-Policy: same-origin`. Browsing context'i izole eder (cross-window saldırı / XS-Leak sınıfı). Statik landing için pratik etki düşük ama risksiz ve "tam başlık seti" için iyi.

## Denetim notu (dürüstlük)

Bu turda canlı başlıkları incelerken `Permissions-Policy`'nin **eksik olduğunu** sanmıştım; `vercel.json`'ı okuyunca **zaten ekli** olduğunu gördüm (kamera/mikrofon/konum/payment/usb kapalı). `X-Frame-Options: SAMEORIGIN` de CSP `frame-ancestors 'self'` ile zaten tutarlı. Yani başlık seti zaten güçlüydü; geriye yalnızca COOP kalıyordu.

## Bilerek eklenMEYEN

- `Cross-Origin-Embedder-Policy` / `Cross-Origin-Resource-Policy`: og-image.png'in sosyal/link önizleme crawler'larınca (Twitter, LinkedIn, Slack) cross-origin çekilmesini bozardı. Marketing sitesi için yanlış tradeoff.

## Doğrulama

- `vercel.json` geçerli JSON. Görünür davranış değişmez.

🤖 Generated with [Claude Code](https://claude.com/claude-code)