### PR TITLE
content(claude-code): enrichment kuyruğu kapanışı · son 4 girdi

### DIFF
--- a/assets/discover/catalog.json
+++ b/assets/discover/catalog.json
@@ -1139,9 +1139,7 @@
       "Geliştirici aracı"
     ],
     "stars": 1596,
-    "lite": false,
-    "needs_enrichment": true,
-    "enrich_reason": "komutsuz"
+    "lite": false
   },
   {
     "slug": "mempalace",
@@ -1334,7 +1332,7 @@
     "stars": 48569,
     "lite": false,
     "needs_enrichment": true,
-    "enrich_reason": "komutsuz"
+    "enrich_reason": "resmî Microsoft repo geri çekildi · doğrulanabilir komut yok"
   },
   {
     "slug": "opencv",
@@ -1517,9 +1515,7 @@
       "Geliştirici aracı"
     ],
     "stars": 12983,
-    "lite": false,
-    "needs_enrichment": true,
-    "enrich_reason": "komutsuz"
+    "lite": false
   },
   {
     "slug": "whichllm",
@@ -1609,7 +1605,7 @@
     "stars": 8362,
     "lite": false,
     "needs_enrichment": true,
-    "enrich_reason": "komutsuz"
+    "enrich_reason": "firmware (ESPHome) · standart pip/npm kurulum komutu yok"
   },
   {
     "slug": "agent-skills",


### PR DESCRIPTION
Kuyruğun son 4 girdisi:

- **pm-skills, plugins** · referans/koleksiyon repo (kurulum komutu modeline uymaz) → `--done`, kuyruktan çıkarıldı.
- **espectre** (ESPHome firmware), **vibevoice** (resmî Microsoft repo geri çekildi) · gerçek araç ama şu an doğrulanabilir komut yok → flaglı bırakıldı, `enrich_reason` ile belgelendi.

Bununla [issue#22](https://github.com/trescout/landing/issues/22) kuyruğu: 14 render edilmiş komut + 6 N/A temiz + 2 belgelenmiş edge-case. Sadece catalog.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)