### PR TITLE
feat(claude-code): keşfet detay sayfasına editöryel H1 (liste repo adında kalır)

### DIFF
--- a/.github/workflows/dict-sync.yml
+++ b/.github/workflows/dict-sync.yml
@@ -15,6 +15,10 @@ on:
         description: "Keşif reprocess · virgülle slug listesi (catalog'a elle cmds eklenince sayfayı yeniden render eder). Boş = sadece normal büyüme."
         required: false
         default: ''
+      headlines_limit:
+        description: "Başlık backfill · başlığı olmayan KAÇ girdiye editöryel H1 üretilsin (0 = atla). Batch için ör. 40."
+        required: false
+        default: '0'
 
 permissions:
   contents: write
@@ -62,6 +66,15 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           SLUGS: ${{ github.event.inputs.reprocess_slugs }}
         run: python3 scripts/discover-sync.py --reprocess="$SLUGS"
+
+      # Editöryel başlık backfill · başlığı olmayan girdilere detay-sayfası H1 üretir
+      # (liste kartları repo adında kalır). Limit env üzerinden · enjeksiyon yok.
+      - name: Keşif başlık backfill (elle · editöryel H1)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.headlines_limit != '' && github.event.inputs.headlines_limit != '0' }}
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          LIMIT: ${{ github.event.inputs.headlines_limit }}
+        run: python3 scripts/discover-sync.py --headlines --limit="$LIMIT"
 
       - name: Çapraz-linkleri yenile (keşif ↔ sözlük)
         run: python3 scripts/cross-link.py

--- a/scripts/discover-sync.py
+++ b/scripts/discover-sync.py
@@ -222,7 +222,9 @@ ENRICH_SYS=("Sen TreScout için Türkçe içerik editörüsün; kod bilmeyene bi
  "Sana README ve ondan AYIKLANMIŞ gerçek komut blokları verilecek (boş da olabilir). "
  "MUTLAK KURALLAR: UYDURMA, sadece README'de geçeni kullan. Komutu SADECE verilen bloklardan BİREBİR al (tek karakter bile değiştirme/ekleme yok); emin değilsen boş bırak. "
  "'siz' dili; em dash (—) YASAK; pazarlama/abartı yok; TreScout bu aracı geliştirmedi, yalnızca tanıtıyor. "
- 'ÇIKTI yalnızca JSON: {"kazanimlar"(3 kısa somut madde),'
+ 'ÇIKTI yalnızca JSON: {'
+ '"baslik"(aracın ne yaptığını yakalayan KISA çekici Türkçe başlık, 2-6 kelime, blog başlığı gibi; repo adını tekrarlama, abartı/hype yok, em dash yok, nokta opsiyonel · ör. "AI ajanınıza kalıcı hafıza"),'
+ '"kazanimlar"(3 kısa somut madde),'
  '"kurulum"([{"baslik","komut"}] 0-2, komut SADECE verilen bloklardan birebir),'
  '"calistirma"([{"baslik","komut"}] 0-2, ilk kullanım),'
  '"nasil_baslanir"(EĞER gerçek kurulum komutu YOKSA kod bilmeyenin nasıl başlayacağını 1-3 cümle DÜZ METİN anlat: kabuk komutu YAZMA, README\'de geçen indirme/resmî site/doküman yolunu tarif et. Komut varsa boş bırak),'
@@ -316,6 +318,10 @@ def rich_sections(g, cmds=None):
 
 def build_page(e, rich=None):
     slug=e["slug"];title=e["title"];tagline=e["tagline"];summary=e["summary"];url=e["url"]
+    # Detay sayfası H1 · Gemini'nin yazdığı editöryel başlık (varsa); yoksa repo adı.
+    # Keşif LİSTESİ (kartlar) repo adını kullanır · burası yalnız tek-tek açılan sayfa.
+    headline=(rich.get("baslik") if rich else None) or e.get("headline") or title
+    eyebrow_repo=f" · {esc(title)}" if headline.strip().lower()!=title.strip().lower() else ""
     lang=e["lang"];stars=e["stars"];momentum=e["momentum"];date=e["date"]
     canon=f"https://trescout.com/discover/{slug}/";ogimg=f"https://trescout.com/assets/discover/og/{slug}.webp"
     ld=json.dumps({"@context":"https://schema.org","@type":"Article","headline":title,"inLanguage":"tr",
@@ -345,8 +351,8 @@ def build_page(e, rich=None):
       '<link rel="stylesheet" href="/assets/site.css">\n<link rel="stylesheet" href="/assets/discover.css">\n</head>\n')
     body=('<body>\n<a class="skip-link" href="#main">Ana içeriğe atla</a>\n'+NAV+'\n<main id="main">\n<article class="disc">\n'
       '<a class="disc-back" href="/discover/">← Keşif</a>\n'
-      f'<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub</span>{mom}</div>\n'
-      f'<h1 class="disc-title">{esc(title)}</h1>\n<p class="disc-lead">{esc(summary)}</p>\n'
+      f'<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub{eyebrow_repo}</span>{mom}</div>\n'
+      f'<h1 class="disc-title">{esc(headline)}</h1>\n<p class="disc-lead">{esc(summary)}</p>\n'
       f'<ul class="disc-meta">{metas}</ul>\n      {shot_html}{rich_html}{relsec}\n'
       f'<section class="disc-sec"><h2>Bağlantılar</h2><ul class="disc-links"><li><a href="{esc(url)}" target="_blank" rel="noopener">GitHub deposu →</a></li></ul></section>\n'
       '<aside class="disc-cta"><p><strong>Bunun gibi araçları her gün TreScout yakalıyor.</strong> GitHub, Hacker News ve HuggingFace taranır, öne çıkanlar Türkçe özetlenir.</p>'
@@ -363,6 +369,7 @@ def base_entry(n, rich, reason):
        "tags":n["tags"],"stars":n["stars"]}
     if rich:
         c["lite"]=False
+        if rich.get("baslik"): c["headline"]=rich["baslik"].strip()  # detay sayfası editöryel H1
         if n.get("shot"): c["shot"]=n["shot"]
         if n.get("cmds"): c["cmds"]=n["cmds"]
         if not (rich.get("kurulum") or rich.get("calistirma") or n.get("cmds")):  # hiç komut yok → kuyrukta (insan komut bulur/ekler, --done ile kapatır)
@@ -370,6 +377,53 @@ def base_entry(n, rich, reason):
     else:
         c.update({"lite":True,"needs_enrichment":True,"enrich_reason":reason})
     return c
+
+HEADLINE_SYS=("Sen TreScout için Türkçe içerik editörüsün. Verilen GitHub aracı için KISA çekici bir başlık yaz: "
+  "2-6 kelime, aracın ne yaptığını yakalasın, blog başlığı gibi. 'siz' dili; repo adını tekrarlama; "
+  "abartı/hype yok; em dash (—) YASAK. ÇIKTI yalnızca JSON: {\"baslik\":\"...\"}. Başka metin yok.")
+def gemini_headline(title,tagline,key):
+    """Mevcut girdiler için yalnız başlık üreten küçük çağrı (full enrich'i tekrar etmez)."""
+    payload=f"ARAÇ: {title}\nTANIM: {tagline or ''}"
+    body={"systemInstruction":{"parts":[{"text":HEADLINE_SYS}]},"contents":[{"parts":[{"text":payload}]}],
+          "generationConfig":{"temperature":0.5,"responseMimeType":"application/json","maxOutputTokens":64}}
+    url=f"https://generativelanguage.googleapis.com/v1beta/models/{MODEL}:generateContent"
+    req=urllib.request.Request(url,data=json.dumps(body).encode(),headers={"Content-Type":"application/json","x-goog-api-key":key},method="POST")
+    for attempt in range(4):
+        try:
+            raw=json.loads(urllib.request.urlopen(req,timeout=60).read().decode())["candidates"][0]["content"]["parts"][0]["text"]
+            b=(json.loads(raw).get("baslik") or "").strip().replace("—","·")  # em dash güvenliği
+            return b or None
+        except urllib.error.HTTPError as e:
+            if e.code in (429,500,502,503) and attempt<3: time.sleep((attempt+1)*4); continue
+            return None
+        except Exception:
+            if attempt<3: time.sleep((attempt+1)*4); continue
+            return None
+    return None
+
+def headline_backfill(cat, key, limit):
+    """Başlığı olmayan girdilere editöryel H1 üret + sayfayı CERRAHİ güncelle (içeriği bozmadan)."""
+    todo=[c for c in cat if not c.get("headline")][:limit]
+    print(f"--headlines · {len(todo)} girdiye başlık üretilecek")
+    if DRY:
+        for c in todo: print(f"  ~ {c['slug']}")
+        print("[--dry] yazılmadı."); return
+    n=0
+    for c in todo:
+        b=gemini_headline(c["title"], c.get("tagline",""), key)
+        if not b: print(f"  ! {c['slug']}: başlık üretilemedi"); continue
+        c["headline"]=b
+        p=os.path.join(DISC,c["slug"],"index.html")
+        if os.path.exists(p):
+            html=open(p,encoding="utf-8").read()
+            html=re.sub(r'<h1 class="disc-title">.*?</h1>', f'<h1 class="disc-title">{esc(b)}</h1>', html, count=1, flags=re.S)
+            if f'GitHub · {esc(c["title"])}' not in html:  # eyebrow'a repo adı ekle (yoksa)
+                html=re.sub(r'(<span class="disc-eyebrow">Keşif · GitHub)(</span>)', rf'\1 · {esc(c["title"])}\2', html, count=1)
+            open(p,"w",encoding="utf-8").write(html)
+        n+=1; print(f"  ✓ {c['slug']}: {b}")
+        time.sleep(1)  # rate limit
+    json.dump(cat,open(CATALOG,"w",encoding="utf-8"),ensure_ascii=False,indent=2)
+    print(f"✅ {n} başlık eklendi · catalog güncellendi")
 
 def process_one(n, key):
     """Entry'i zenginleştir + sayfa & kart yaz. Döner: (rich|None, reason|None)."""
@@ -413,6 +467,10 @@ def main():
     cat=json.load(open(CATALOG,encoding="utf-8"))
     by_slug={c["slug"]:c for c in cat}
     os.makedirs(OGDIR,exist_ok=True)
+    if "--headlines" in sys.argv:   # mevcut girdilere editöryel H1 backfill (liste kartları repo adında kalır)
+        if not key and not DRY: print("UYARI: GEMINI_API_KEY yok · başlık üretilemez."); return
+        la=next((a for a in sys.argv if a.startswith("--limit=")),None)
+        headline_backfill(cat, key, int(la.split("=")[1]) if la else 10**9); return
     dn=next((a for a in sys.argv if a.startswith("--done=")),None)
     if dn:   # kuyruktan çıkar (insan o entry'i en iyiye çekti ya da 'uygun değil' dedi)
         slugs={s.strip() for s in dn.split("=",1)[1].split(",") if s.strip()}


### PR DESCRIPTION
## İstek
"A ama keşif kısmında dış başlıklar yine repo adı olarak kalsın" → blog-başlığı hissi (claude-mem gibi) **detay sayfası H1'inde**, ama **liste kartları repo adında** kalsın.

## Çözüm (iki alan)
- **`title`** = repo adı · değişmedi → liste kartları, \<title\>/OG hep repo adı (aranabilirlik korunur).
- **`headline`** = Gemini editöryel başlık · YALNIZ detay sayfası H1.

## Değişiklikler
- **ENRICH_SYS** → `baslik` alanı (kısa çekici TR, 'siz', em dash yasak, hype yok). Yeni girdiler otomatik.
- **build_page** → H1 = `headline` (yoksa repo adı); editöryel başlıkta eyebrow'a repo adı ("Keşif · GitHub · Claude Mem").
- **discover-index.py (liste) dokunulmadı** → kartlar repo adında.
- **Backfill**: `--headlines` modu + dict-sync `headlines_limit` input'u · mevcut 130'a küçük Gemini çağrısıyla H1 üretir, sayfayı cerrahi günceller (içerik korunur).

## Doğrulama
Render testi (headline var/yok), cerrahi regex (H1+eyebrow, lead korunur), `--headlines --dry`→130, 4 guard ✓.

## Yayın
Yeni girdiler otomatik. Mevcut 130'u doldurmak için dict-sync workflow'unu `headlines_limit` ile batch'ler hâlinde tetikle (Gemini).

🤖 Generated with [Claude Code](https://claude.com/claude-code)