### PR TITLE
fix(claude-code): normalize_headline · 'AI' → 'yapay zekâ'

### DIFF
--- a/scripts/discover-sync.py
+++ b/scripts/discover-sync.py
@@ -383,7 +383,8 @@ HEADLINE_SYS=("Sen TreScout için Türkçe içerik editörüsün. Verilen GitHub
   "abartı/hype yok; em dash (—) YASAK. 'AI/yapay zeka' yerine MUTLAKA 'yapay zekâ' (şapkalı â, küçük harf) yaz. "
   "ÇIKTI yalnızca JSON: {\"baslik\":\"...\"}. Başka metin yok.")
 def normalize_headline(s):
-    """Marka düzeltmeleri · 'Yapay Zeka/Zekayla' → 'yapay zekâ...' (şapkalı â, küçük harf); em dash → ·"""
+    """Marka düzeltmeleri · 'AI' → 'yapay zekâ'; 'Yapay Zeka/Zekayla' → 'yapay zekâ...' (şapkalı, küçük); em dash → ·"""
+    s=re.sub(r'\bAI\b','yapay zekâ',s)
     s=re.sub(r'(?i)yapay\s+zek[aâ](\w*)', lambda m: 'yapay zekâ'+m.group(1), s)
     return s.replace('—','·').strip()
 


### PR DESCRIPTION
Backfill'de 1 başlık (`claude-mem` → "AI Ajanınıza...") 'AI' yazdı; marka kuralı 'yapay zekâ'. `normalize_headline`'a standalone `\bAI\b` → 'yapay zekâ' eklendi. Mevcut başlığı düzeltir + ileride güvence (prompt zaten yapay zekâ diyor, bu son katman).

Doğrulama: 'AI Ajanınıza...' → 'yapay zekâ Ajanınıza...'; 'Email' gibi kelimeler etkilenmez (\b sınırı). Merge sonrası `--headlines --limit=1` ile o 1 başlık düzelir (Gemini'siz normalize pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)