### PR TITLE
feat(claude-code): keşif enrichment · VibeVoice cmds + Espectre kuyruktan çıkarıldı

### DIFF
--- a/assets/discover/catalog.json
+++ b/assets/discover/catalog.json
@@ -1418,7 +1418,26 @@
     "lite": false,
     "needs_enrichment": true,
     "enrich_reason": "resmî Microsoft repo geri çekildi · doğrulanabilir komut yok",
-    "headline": "Açık kaynaklı yapay zekâ ses çerçevesi"
+    "headline": "Açık kaynaklı yapay zekâ ses çerçevesi",
+    "cmds": {
+      "kurulum": [
+        {
+          "baslik": "GitHub'dan kur",
+          "komut": "git clone https://github.com/microsoft/VibeVoice.git\ncd VibeVoice\npip install -e ."
+        }
+      ],
+      "calistirma": [
+        {
+          "baslik": "Gradio demo",
+          "komut": "python demo/vibevoice_asr_gradio_demo.py --model_path microsoft/VibeVoice-ASR --share"
+        },
+        {
+          "baslik": "Dosyadan transkripsiyon",
+          "komut": "python demo/vibevoice_asr_inference_from_file.py --model_path microsoft/VibeVoice-ASR --audio_files [ses-dosyasi]"
+        }
+      ],
+      "kaynak": "Resmî depo · docs/vibevoice-asr.md (microsoft/VibeVoice). Kurulabilir model VibeVoice-ASR; TTS kodu depodan çıkarıldı."
+    }
   },
   {
     "slug": "opencv",
@@ -1706,8 +1725,6 @@
     ],
     "stars": 8362,
     "lite": false,
-    "needs_enrichment": true,
-    "enrich_reason": "firmware (ESPHome) · standart pip/npm kurulum komutu yok",
     "headline": "Wi-Fi ile yapay zekâ destekli hareket algılama"
   },
   {


### PR DESCRIPTION
## Özet
landing#22 (elle zenginleştirme kuyruğu · 2 entry) ele alındı.

### VibeVoice → zenginleştirildi (cmds eklendi)
Kuyruktaki bloke gerekçesi (`resmî Microsoft repo geri çekildi · doğrulanabilir komut yok`) **bayatmıştı**: repo şu an canlı (HTTP 200, arşivli değil), modeller HuggingFace'te (`VibeVoice-ASR`, `-1.5B`, `-Realtime-0.5B`), ASR Transformers'a entegre.

Resmî depo ve `docs/vibevoice-asr.md`'den **doğrulanmış** komutlar `cmds` olarak eklendi:
- Kurulum: `git clone` + `pip install -e .`
- Çalıştırma: Gradio demo · dosyadan transkripsiyon (`microsoft/VibeVoice-ASR`)

Not: TTS kodu 2025-09'da sorumlu-YZ gerekçesiyle depodan çıkarılmış; kurulabilir model **VibeVoice-ASR**, komutlar buna göre.

`needs_enrichment` bilinçli bırakıldı → CI reprocess başarılı render'da temizler (mekanizma gereği cmds yalnız Gemini'li render'da sayfaya basılır).

### Espectre → kuyruktan çıkarıldı (`--done`)
ESP-32 firmware'i (Wi-Fi CSI hareket algılama, ESPHome ile donanıma flash). Makineye `pip`/`npm` ile kurulan bir araç değil → issue'nun *"uygun değilse olduğu gibi bırakın"* kuralına uyuyor.

## Render adımı (merge sonrası)
\`\`\`
gh workflow run dict-sync.yml -R trescout/landing -f reprocess_slugs=vibevoice
\`\`\`
Bu, VibeVoice sayfasını Gemini prozu + eklenen komutlarla yeniden üretir (anahtar org secret'ta).

Refs #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)