### PR TITLE
fix(claude-code): başlık isteminde uydurma yapay zekâ iddiasını engelle

### DIFF
--- a/scripts/discover-sync.py
+++ b/scripts/discover-sync.py
@@ -380,7 +380,10 @@ def base_entry(n, rich, reason):
 
 HEADLINE_SYS=("Sen TreScout için Türkçe içerik editörüsün. Verilen GitHub aracı için KISA çekici bir başlık yaz: "
   "2-6 kelime, aracın ne yaptığını yakalasın, blog başlığı gibi. 'siz' dili; repo adını tekrarlama; "
-  "abartı/hype yok; em dash (—) YASAK. 'AI/yapay zeka' yerine MUTLAKA 'yapay zekâ' (şapkalı â, küçük harf) yaz. "
+  "abartı/hype yok; em dash (—) YASAK. Yalnızca tanıtımda GEÇEN yeteneği yaz, yetenek uydurma: "
+  "araç yapay zekâ ile ilgili değilse başlıkta 'yapay zekâ' GEÇMESİN (web sunucusu, derleyici, kütüphane, "
+  "veri deposu gibi araçlara yapay zekâ iddiası eklemek yanlış bilgidir). Yapay zekâdan söz edeceksen "
+  "MUTLAKA 'yapay zekâ' (şapkalı â, küçük harf) yaz, 'AI/yapay zeka' yazma. "
   "ÇIKTI yalnızca JSON: {\"baslik\":\"...\"}. Başka metin yok.")
 def normalize_headline(s):
     """Marka düzeltmeleri · 'AI' → 'yapay zekâ'; 'Yapay Zeka/Zekayla' → 'yapay zekâ...' (şapkalı, küçük); em dash → ·"""


### PR DESCRIPTION
## Özet

Keşif başlıkları Gemini ile otomatik üretiliyor. Denetimde, aracın yapay zekâ ile ilgisi olmadığı hâlde başlığında `yapay zekâ` iddiası geçen **30 girdi** çıktı (360 kayıtta). Net yanlışlardan bazıları:

- `nginx` → "Web Sunucunuzu yapay zekâyla Hızlandırın"
- `svelte` → "Hızlı web uygulamaları için yapay zekâ destekli derleme"
- `opencv` → "Görüntü İşleme İçin yapay zekâ Rehberi"
- `chinatextbook` → "Çin eğitim müfredatına yapay zekâ ile erişin"

Dağılım: Haziran 26/174, Temmuz 4/146. Ana kütle Haziran'daki toplu başlık backfill'inden geliyor, akış düşük oranda sürüyor.

## Kök sebep

`HEADLINE_SYS` içindeki "'AI/yapay zeka' yerine MUTLAKA 'yapay zekâ' yaz" kuralı bir yazım düzeltmesi olarak konmuştu, ancak model bunu konuya dair bir yönlendirme gibi okuyup alakasız araçlara da yapay zekâ iddiası ekliyor.

## Değişiklik

İstem, tanıtımda geçmeyen yeteneği uydurmayı açıkça yasaklıyor ve yazım kuralını yalnız yapay zekâdan söz edilen durumla sınırlıyor. `normalize_headline` davranışı değişmedi.

## Kapsam dışı

Yayında duran 30 başlığın düzeltilmesi ayrı issue ile ele alınacak (delege edilecek içerik işi). Bu PR yalnız kaynağı kesiyor.

## AI Traceability

### Plan Agent
- Outputs used: `scripts/discover-sync.py` denetimi, catalog taraması

### Skills Agent
- [ ] Bu PR'da Skills Agent kullanılmadı

### Türkçe İçerik
- İstem metni · kullanıcı yüzü içerik değil, üretim talimatı

### Manuel
- İstem yüklenmesi ve `normalize_headline` davranışı yerelde doğrulandı