### PR TITLE
feat(claude-code): keşif sayfasına TreScout notu alanı

### DIFF
--- a/scripts/discover-sync.py
+++ b/scripts/discover-sync.py
@@ -336,6 +336,8 @@ def build_page(e, rich=None):
         if chips: relsec=f'<section class="disc-sec"><h2>İlgili sözlük terimleri</h2><div class="disc-related">{chips}</div></section>'
     mom=f'<span class="disc-momentum">🚀 {esc(momentum)}</span>' if momentum else ''
     rich_html=rich_sections(rich, e.get("cmds")) if rich else ''
+    notu=(e.get("trescout_notu") or "").strip()   # elle yazılan editöryel yargı · README özetinden farkımız
+    not_html=f'<aside class="disc-note"><p><strong>TreScout notu:</strong> {esc(notu)}</p></aside>\n      ' if notu else ''
     sh=e.get("shot"); shot_html=''
     if sh:   # lisansı temiz gerçek ekran görüntüsü (catalog 'shot' alanı · reprocess'te korunur)
         shot_html=(f'<figure class="disc-shot"><img src="{esc(sh["src"])}" width="{sh.get("w","")}" height="{sh.get("h","")}" '
@@ -353,7 +355,7 @@ def build_page(e, rich=None):
       '<a class="disc-back" href="/discover/">← Keşif</a>\n'
       f'<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub{eyebrow_repo}</span>{mom}</div>\n'
       f'<h1 class="disc-title">{esc(headline)}</h1>\n<p class="disc-lead">{esc(summary)}</p>\n'
-      f'<ul class="disc-meta">{metas}</ul>\n      {shot_html}{rich_html}{relsec}\n'
+      f'<ul class="disc-meta">{metas}</ul>\n      {not_html}{shot_html}{rich_html}{relsec}\n'
       f'<section class="disc-sec"><h2>Bağlantılar</h2><ul class="disc-links"><li><a href="{esc(url)}" target="_blank" rel="noopener">GitHub deposu →</a></li></ul></section>\n'
       '<aside class="disc-cta"><p><strong>Bunun gibi araçları her gün TreScout yakalıyor.</strong> GitHub, Hacker News ve HuggingFace taranır, öne çıkanlar Türkçe özetlenir.</p>'
       +FORM+'<a class="btn btn-ghost disc-cta-all" href="/discover/">Tüm keşifler →</a></aside>\n'
@@ -397,6 +399,7 @@ def base_entry(n, rich, reason, key=None):
             elif eski and not _ai_iddiasi(eski): c["headline"]=eski  # reddedildi · mevcut başlık temizse korunur
         if n.get("shot"): c["shot"]=n["shot"]
         if n.get("cmds"): c["cmds"]=n["cmds"]
+        if n.get("trescout_notu"): c["trescout_notu"]=n["trescout_notu"]
         if not (rich.get("kurulum") or rich.get("calistirma") or n.get("cmds")):  # hiç komut yok → kuyrukta (insan komut bulur/ekler, --done ile kapatır)
             c["needs_enrichment"]=True; c["enrich_reason"]="komutsuz"
     else:
@@ -496,7 +499,7 @@ def reprocess(cat, by_slug, key, targets, label):
         rows.append({"slug":c["slug"],"title":c["title"],"tagline":c["tagline"],"summary":summary,"headline":c.get("headline"),
                      "url":m.group(1) if m else "","lang":lang,"stars":c.get("stars",stars),
                      "momentum":momentum,"date":c.get("date",TODAY),"tags":c.get("tags") or infer_tags(summary),
-                     "shot":c.get("shot"),"cmds":c.get("cmds")})
+                     "shot":c.get("shot"),"cmds":c.get("cmds"),"trescout_notu":c.get("trescout_notu")})
     print(f"{label}: {len(rows)} entry yeniden değerlendirilecek")
     if DRY:
         for n in rows: print(f"  ~ {n['slug']}  ({n['url']})")


### PR DESCRIPTION
## Neden

[Google'ın yapay zekâ optimizasyon kılavuzu](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide?hl=tr) en başa şunu koyuyor: mevcut bilginin özeti olan içerik değil, özgün bakış ve birinci elden deneyim. Keşif sayfalarımız şu an ağırlıkla deponun README'sinden üretilmiş Türkçe özet. 366 sayfa, sayfa başına medyan ~275 kelime (menü ve altbilgi dahil). Ayırt edici katma değer ince, bu da ölçekli içerik tarafında zayıf nokta.

## Değişiklik

catalog kaydına opsiyonel `trescout_notu` alanı. Doluysa sayfada meta listesinin hemen altında, mevcut `.disc-note` stiliyle basılır:

```html
<aside class="disc-note"><p><strong>TreScout notu:</strong> …</p></aside>
```

- Alan yoksa çıktı bit bazında aynı, mevcut 366 sayfa etkilenmez
- `base_entry` ve `reprocess` passthrough'una eklendi · yeniden render'da not kaybolmaz (`cmds` ve `shot` ile aynı desen)
- Yeni CSS yok, mevcut sınıf kullanıldı · tutarlılık guard'larına dokunmuyor
- Markdown alternatifi (`/discover/<slug>.md`) HTML'den türediği için notu kendiliğinden alır

## Doğrulama

Yerelde iki senaryo: notlu kayıtta bölüm doğru yerde basılıyor, notsuz kayıtta `disc-note` hiç görünmüyor. `py_compile` temiz.

İçeriğin kendisi (hangi sayfaya ne yazılacağı) ayrı issue ile ele alınacak · not yazmak insan yargısı gerektiriyor, ajanla ölçeklenmemesi işin değerli tarafı.

## AI Traceability

### Plan Agent
- Outputs used: Google yapay zekâ optimizasyon kılavuzu, keşif sayfası içerik derinliği ölçümü

### Skills Agent
- [ ] Kullanılmadı

### Türkçe İçerik
- Şablon metni yalnız "TreScout notu:" etiketi · not içeriği ayrı issue'da Gemini akışından geçecek

### Manuel
- Render iki senaryoda yerelde doğrulandı