### PR TITLE
feat(claude-code): 15 keşif sayfasına TreScout notu + 5 başlık düzeltmesi

### DIFF
--- a/assets/discover/catalog.json
+++ b/assets/discover/catalog.json
@@ -1029,7 +1029,8 @@
       ],
       "kaynak": "PyPI · paddleocr (resmî paket)"
     },
-    "headline": "Belgeleri yapay zekâ ile dijitalleştirin"
+    "headline": "Belgeleri yapay zekâ ile dijitalleştirin",
+    "trescout_notu": "Belge tarama ve tablo çıkarmada ücretsiz seçenekler arasında en yetkinlerinden. Kurulumun ağır tarafı altındaki paddlepaddle çalışma zamanı, sanal ortamda kurun · ekran kartı olmadan da çalışır ama yavaşlar. Latin alfabesi modeli Türkçe belgelerde iş görür, yine de kendi örneklerinizle sınayın, sonuç belge kalitesine çok bağlı."
   },
   {
     "slug": "spec-kit",
@@ -1286,7 +1287,9 @@
       ],
       "kaynak": "svelte.dev (resmî CLI)"
     },
-    "headline": "Hızlı web uygulamaları için yapay zekâ destekli derleme"
+    "headline": "Derleme zamanında çalışan arayüz çerçevesi",
+    "trescout_notu": "Derleme aşamasında iş yaptığı için tarayıcıya inen kod küçülür, öğrenmesi de React'e göre kolaydır. Bedeli ekosistem: hazır bileşen kütüphanesi, topluluk çözümleri ve işe alım havuzu React'in yanında dar kalır. Küçük ve orta ölçekli arayüzlerde rahat, ekip standardı yapmadan önce bu farkı tartın.",
+    "headline_locked": true
   },
   {
     "slug": "nginx",
@@ -1329,7 +1332,8 @@
       ],
       "kaynak": "go.dev/doc/install (resmî) · veya go.dev/dl'den indirin"
     },
-    "headline": "Yüksek Performanslı Yazılımlar Geliştirin"
+    "headline": "Yüksek Performanslı Yazılımlar Geliştirin",
+    "trescout_notu": "Tek bir çalıştırılabilir dosya üretmesi dağıtımı sadeleştirir, sunucuya kopyalayıp çalıştırırsınız. Karşılığında dilin ifade gücü dardır: hata kontrolü tekrar eder, jenerikler dile geç eklendi. Servis ve komut satırı aracı yazıyorsanız yerinde bir tercih, ağır iş mantığı modelleyecekseniz zorlar."
   },
   {
     "slug": "career-ops",
@@ -1385,7 +1389,8 @@
       ],
       "kaynak": "vite.dev (resmî dokümantasyon)"
     },
-    "headline": "Modern Web Projelerini Hızlandırın"
+    "headline": "Modern Web Projelerini Hızlandırın",
+    "trescout_notu": "Asıl kazanç geliştirme sunucusunun anında açılması · büyük projede dakikalara çıkan bekleme saniyeye iner. Eski Webpack eklentilerine bağımlıysanız geçişte karşılıklarını aramanız gerekir. Bugün sıfırdan ön yüz projesi kuruyorsanız varsayılan tercih olarak düşünebilirsiniz."
   },
   {
     "slug": "mxc",
@@ -1435,7 +1440,8 @@
         }
       ],
       "kaynak": "Resmî depo · docs/vibevoice-asr.md (microsoft/VibeVoice). Kurulabilir model VibeVoice-ASR; TTS kodu depodan çıkarıldı."
-    }
+    },
+    "trescout_notu": "Depo yayımlandıktan sonra değişti: metinden konuşma tarafı geri çekildi, bugün kurulabilir olan konuşmadan metne modeli. Uzun kayıtları tek parça işleyebilmesi ayırt edici yanı. Hızlı değişen bir proje, üretim işine koymadan önce deponun güncel durumuna bakın."
   },
   {
     "slug": "opencv",
@@ -1459,7 +1465,9 @@
       ],
       "kaynak": "PyPI · opencv-python (resmî paket)"
     },
-    "headline": "Görüntü İşleme İçin yapay zekâ Rehberi"
+    "headline": "Görüntü işlemenin açık kaynak standardı",
+    "trescout_notu": "Yapay zekâ modeli eğitmek için değil, görüntüyü işlemek için: kırpma, eşikleme, kenar bulma, kamera akışı okuma. Derin öğrenme tarafında PyTorch'un yerini tutmaz, ikisi genelde birlikte kullanılır. opencv-python çoğu iş için yeter, video kodekleri ve arayüz pencereleri için ek paket gerekebilir.",
+    "headline_locked": true
   },
   {
     "slug": "aitoearn",
@@ -1844,7 +1852,8 @@
       ],
       "kaynak": "restic.readthedocs.io (resmî)"
     },
-    "headline": "Verilerinizi Hızlıca Şifreleyerek Yedekleyin"
+    "headline": "Verilerinizi Hızlıca Şifreleyerek Yedekleyin",
+    "trescout_notu": "Yedeği şifreleyip tekrar eden veriyi ayıkladığı için depolama maliyeti düşük kalır. Arayüzü yoktur, zamanlanmış görevi ve saklama politikasını siz kurarsınız · forget ve prune adımlarını atlarsanız depo şişer. Geri yükleme senaryosunu kurduğunuz gün bir kez deneyin, yedeğin çalıştığını ancak öyle bilirsiniz."
   },
   {
     "slug": "agency-agents",
@@ -1884,7 +1893,8 @@
       ],
       "kaynak": "developers.chatwoot.com/self-hosted/deployment/docker (resmî)"
     },
-    "headline": "Müşteri desteğini yapay zekâ ile yönetin"
+    "headline": "Müşteri desteğini yapay zekâ ile yönetin",
+    "trescout_notu": "Zendesk ya da Intercom yerine kendi sunucunuzda çalışan destek masası. Kurulum tek konteyner değildir: veritabanı, kuyruk ve önbellek ister, küçük bir sunucuda zorlanır. WhatsApp kanalı için Meta tarafında iş ortağı onayı gerekir, bunu kurulum öncesinde hesaba katın."
   },
   {
     "slug": "agentsview",
@@ -1955,7 +1965,8 @@
       ],
       "kaynak": "docs.mattermost.com (resmî · önizleme imajı)"
     },
-    "headline": "Yazılım ekipleri için güvenli iş birliği"
+    "headline": "Yazılım ekipleri için güvenli iş birliği",
+    "trescout_notu": "Slack yerine kendi sunucunuzda çalışan sürüm, asıl gerekçe genelde verinin sizde kalması olur. Sayfadaki komut deneme imajıdır, üretimde ayrı veritabanıyla kurulur. Mobil bildirim tarafı ek kurulum ister, ekip beklentisini buna göre ayarlayın."
   },
   {
     "slug": "fanqiang",
@@ -2049,7 +2060,9 @@
       ],
       "kaynak": "Microsoft Learn (resmî)"
     },
-    "headline": "Windows deneyiminizi yapay zekâ ile özelleştirin"
+    "headline": "Windows'u kendinize göre ayarlayın",
+    "trescout_notu": "Tek bir uygulama değil, birbirinden bağımsız araçlar paketi · çoğu kişi aslında FancyZones ve PowerToys Run için kuruyor. Kurumsal cihazlarda yönetici izni gerekebilir. macOS'tan Windows'a geçenler için pencere yönetimi ve hızlı başlatma boşluğunu kapatır.",
+    "headline_locked": true
   },
   {
     "slug": "aisuite",
@@ -2089,7 +2102,9 @@
       ],
       "kaynak": "swc.rs (resmî dokümantasyon)"
     },
-    "headline": "Web projelerinizi yapay zekâ hızında derleyin"
+    "headline": "Web projelerinizi Rust hızında derleyin",
+    "trescout_notu": "Babel'in yaptığı işi Rust ile çok daha hızlı yapar · Next.js bunu zaten içeride kullanıyor, farkında olmadan kullanıyor olabilirsiniz. Tür denetimi yapmaz, yalnız dönüştürür, tsc yerine geçmez. Babel eklentilerine bağlıysanız karşılıklarının olup olmadığına bakın, eklenti ekosistemi daha dar.",
+    "headline_locked": true
   },
   {
     "slug": "freecodecamp",
@@ -2209,7 +2224,8 @@
         }
       ],
       "kaynak": "npm (resmî paket yöneticisi) · pnpm / yarn"
-    }
+    },
+    "trescout_notu": "Playwright ile aynı işi yapar ama daha dar kapsamlıdır: Chrome merkezlidir, çok tarayıcı ve hazır test koşucusu isteyen ekipler Playwright'ta daha rahat eder. Kurulum tarayıcıyı da indirdiği için sürekli tümleştirme ortamında imaj boyutunu hesaba katın. Tek seferlik kazıma ve PDF üretimi için fazlasıyla yeterli."
   },
   {
     "slug": "teslamate",
@@ -2289,7 +2305,8 @@
         }
       ],
       "kaynak": "Resmî Win11Debloat README (Raphire/Win11Debloat)"
-    }
+    },
+    "trescout_notu": "Betiği uzaktan indirip çalıştırdığınız için ne yaptığını önce okumanız gerekir, kaldırılan bazı bileşenleri geri getirmek kolay değildir. Kişisel makinede önyüklü uygulamalardan ve telemetriden kurtulmak için pratik. Kurum cihazında ya da başkalarıyla paylaştığınız bilgisayarda kullanmayın."
   },
   {
     "slug": "self-hosting-guide",
@@ -2486,7 +2503,8 @@
         }
       ],
       "kaynak": "npm (@continuedev/cli) · VS Code Marketplace (Continue.continue)"
-    }
+    },
+    "trescout_notu": "Kapalı kutu asistanlardan farkı modelin sizde olması, kendi anahtarınızı ya da yerel modeli bağlarsınız · kodun nereye gittiği sorusunun cevabı sizde kalır. Karşılığında kurulum ve model seçimi sizin işiniz, kutudan çıkan deneyim ticari alternatifler kadar cilalı değil. Şirket politikası kodun dışarı çıkmasını kısıtlıyorsa iyi bir çıkış yolu."
   },
   {
     "slug": "penpot",
@@ -2681,7 +2699,7 @@
     ],
     "stars": 38124,
     "lite": false,
-    "headline": "Modern web uygulamaları için yapay zekâ destekli çerçeve",
+    "headline": "Kurumsal web uygulamaları için platform",
     "cmds": {
       "kurulum": [
         {
@@ -2700,7 +2718,9 @@
         }
       ],
       "kaynak": "Resmî Microsoft .NET dokümantasyonu (learn.microsoft.com/aspnet/core)"
-    }
+    },
+    "trescout_notu": "Windows'a bağlı olduğu algısı eskidir, Linux üzerinde ve konteynerde sorunsuz çalışır. Kurumsal tarafta güçlüdür: kimlik doğrulama, veri erişimi ve izleme parçaları kutudan çıkar. C# bilmiyorsanız öğrenme maliyeti Node ya da Python'a göre yüksektir, tek bir küçük uç nokta için ağır kalır.",
+    "headline_locked": true
   },
   {
     "slug": "awesome-artificial-intelligence",

--- a/scripts/discover-sync.py
+++ b/scripts/discover-sync.py
@@ -392,7 +392,9 @@ def base_entry(n, rich, reason, key=None):
        "tags":n["tags"],"stars":n["stars"]}
     if rich:
         c["lite"]=False
-        if rich.get("baslik"):  # detay sayfası editöryel H1
+        if n.get("headline_locked") and n.get("headline"):  # elle yazılmış başlık · model üzerine yazamaz
+            c["headline"]=n["headline"]; c["headline_locked"]=True
+        elif rich.get("baslik"):  # detay sayfası editöryel H1
             nb=vet_headline(normalize_headline(rich["baslik"].strip()), n, key)
             eski=n.get("headline")
             if nb: c["headline"]=nb
@@ -499,7 +501,8 @@ def reprocess(cat, by_slug, key, targets, label):
         rows.append({"slug":c["slug"],"title":c["title"],"tagline":c["tagline"],"summary":summary,"headline":c.get("headline"),
                      "url":m.group(1) if m else "","lang":lang,"stars":c.get("stars",stars),
                      "momentum":momentum,"date":c.get("date",TODAY),"tags":c.get("tags") or infer_tags(summary),
-                     "shot":c.get("shot"),"cmds":c.get("cmds"),"trescout_notu":c.get("trescout_notu")})
+                     "shot":c.get("shot"),"cmds":c.get("cmds"),"trescout_notu":c.get("trescout_notu"),
+                     "headline_locked":c.get("headline_locked")})
     print(f"{label}: {len(rows)} entry yeniden değerlendirilecek")
     if DRY:
         for n in rows: print(f"  ~ {n['slug']}  ({n['url']})")


### PR DESCRIPTION
İlgili: #42 · altyapı #41 · başlık guard'ı #40

## 1. TreScout notları (15 sayfa)

Her not iki üç cümle ve deponun kendi anlatmadığı şeyi söylüyor: kime uygun değil, kurulumda nerede zorlanırsınız, neyin yerine geçmez. Örnekler:

- **VibeVoice:** depo yayımlandıktan sonra değişti, metinden konuşma tarafı geri çekildi, kurulabilir olan konuşmadan metne modeli (bunu #29 denetiminde biz bulmuştuk)
- **Mattermost:** sayfadaki komut deneme imajıdır, üretimde ayrı veritabanı ister
- **restic:** `forget` ve `prune` adımlarını atlarsanız depo şişer, geri yüklemeyi kurduğunuz gün deneyin
- **Win11Debloat:** kurum cihazında kullanmayın, geri alma sınırlı

## 2. Beş başlık düzeltmesi

Aynı sayfalarda #35'in konusu olan hata duruyordu:

| slug | eski | yeni |
|---|---|---|
| powertoys | Windows deneyiminizi **yapay zekâ ile** özelleştirin | Windows'u kendinize göre ayarlayın |
| opencv | Görüntü İşleme İçin **yapay zekâ** Rehberi | Görüntü işlemenin açık kaynak standardı |
| svelte | Hızlı web uygulamaları için **yapay zekâ destekli** derleme | Derleme zamanında çalışan arayüz çerçevesi |
| aspnetcore | Modern web uygulamaları için **yapay zekâ destekli** çerçeve | Kurumsal web uygulamaları için platform |
| swc | Web projelerinizi **yapay zekâ hızında** derleyin | Web projelerinizi Rust hızında derleyin |

Bu beşi #35'in listesinden çıkarıyorum, aynı sayfalara iki kez dokunmayalım.

## 3. `headline_locked` · elle yazılan başlık artık kalıcı

Denetimde çıkan boşluk: `cmds`, `shot` ve `trescout_notu` reprocess'te korunuyordu ama **başlık korunmuyordu.** Bugün 9 girdiyi yeniden render ettiğimizde başlıklar Gemini tarafından yeniden üretildi. Yani #35'te elle düzeltilecek 30 başlık, bir sonraki render'da sessizce geri gelirdi.

`headline_locked: true` olan kayıtta model başlığa dokunmuyor. Beş düzeltilmiş başlık kilitli.

## Doğrulama

- JSON geçerli (366 kayıt), diff yalnız 15 girdiye ve `discover-sync.py`'ye dokunuyor
- Kilit yerelde iki senaryoda sınandı: kilitliyken elle yazılan başlık korunuyor, kilitsizken model kazanıyor
- `py_compile` temiz

Merge sonrası bu 15 slug için render tetiklenecek (`dict-sync.yml` · `reprocess_slugs`), kilit orada da doğrulanacak.

## AI Traceability

### Plan Agent
- Outputs used: #42 kapsamı, Google yapay zekâ optimizasyon kılavuzu, catalog derinlik ölçümü

### Skills Agent
- [ ] Kullanılmadı

### Türkçe İçerik
- Notlar Claude tarafından yazıldı, Burhan onayladı · Gemini turu bu partide atlandı (yerelde anahtar yok, metinler kısa ve marka kuralları elle denetlendi: em dash yok, "siz" dili, hype yok)

### Manuel
- Beş başlığın yenisi elle yazıldı, kilit mekanizması yerelde sınandı