### PR TITLE
fix(claude-code): açıklanmamış ürün adı maddeye girmesin

### DIFF
--- a/scripts/discover-sync.py
+++ b/scripts/discover-sync.py
@@ -225,6 +225,8 @@ ENRICH_SYS=("Sen TreScout için Türkçe içerik editörüsün; kod bilmeyene bi
  "OKUR YAZILIMCI OLMAYABİLİR: bir ürün, servis ya da teknoloji adı geçiriyorsan (Zendesk, Docker, Redis, Slack gibi) "
  "yanına 2-4 kelimeyle ne olduğunu ekle ('destek yazılımı Zendesk', 'veriyi saklayan PostgreSQL'). Kısaltmayı ilk "
  "geçtiği yerde aç. Bunu yan cümleyle yap, madde sayısını ve cümle sayısını artırma; metni uzatmak değil anlaşılır kılmak amaç. "
+ "Yer yoksa adı HİÇ YAZMA: açıklanmamış ürün adı ('Captain ile', 'Dify ve RAGFlow ile uyumlu') okura hiçbir şey söylemez, "
+ "onun yerine ne işe yaradığını yaz ('hazır sorulara otomatik yanıt verir'). Bu kural özellikle kısa maddeler için geçerli. "
  'ÇIKTI yalnızca JSON: {'
  '"baslik"(aracın ne yaptığını yakalayan KISA çekici Türkçe başlık, 2-6 kelime, blog başlığı gibi; repo adını tekrarlama, abartı/hype yok, em dash yok, AI yerine "yapay zekâ" (şapkalı/küçük), nokta opsiyonel · ör. "yapay zekâ ajanınıza kalıcı hafıza"),'
  '"kazanimlar"(3 kısa somut madde),'


### PR DESCRIPTION
#45'in denemesi beş sayfada yapıldı ve **amacına ulaşmadı.** İki sayfada geri gitti:

| sayfa | önce | sonra |
|---|---|---|
| chatwoot | Yapay zekâ destekli otomatik yanıtlar ile iş yükünü azaltır | Yapay zekâ destekli **Captain** ile soruları otomatik yanıtlar |
| paddleocr | Düşük kaynak kullanımıyla yüksek doğrulukta belge analizi sağlar | **Dify ve RAGFlow** gibi popüler yapay zekâ araçlarıyla uyumlu çalışır |

Model, "adı geçerse açıkla" kuralını "ad geçirmek iyidir" diye okumuş ve kısa maddeye açıklanmamış yeni adlar sokmuş. Kuralların çakışması: madde 5-8 kelime olmak zorunda, yan cümleye yer yok.

Bu PR negatif kuralı ekliyor: **yer yoksa adı hiç yazma, ne işe yaradığını yaz.** Açıklanmamış ürün adı, maddeyi okur için değersiz kılıyor.

Merge sonrası aynı beş sayfada tekrar denenecek.

## AI Traceability

### Plan Agent
- Outputs used: #45 deneme çıktısının önce/sonra karşılaştırması

### Skills Agent
- [ ] Kullanılmadı

### Türkçe İçerik
- İstem metni

### Manuel
- Karşılaştırma elle okundu, regresyon iki sayfada tespit edildi