### PR TITLE
fix(claude-code): bugünün rapor bağlantıları içerik damgalı

### DIFF
--- a/reports/2026-08-02/index.html
+++ b/reports/2026-08-02/index.html
@@ -56,8 +56,8 @@
       <div class="rep-chips"><span class="chip">GitHub Trending · 15</span><span class="chip">Hacker News · 5</span><span class="chip">HuggingFace · Günün Modelleri · 5</span><span class="chip">HuggingFace · Günün Makaleleri · 5</span><span class="chip">Lobsters · 3</span><span class="chip chip-total">33 öne çıkan</span></div>
       <p class="rep-editorial">Bugünün teknoloji gündeminde büyük dil modelleri (large language models) için geliştirilen verimlilik odaklı sıkıştırma teknikleri ve yeni nesil açık kaynaklı model mimarileri öne çıkıyor. Yazılım dokümantasyonu standartları üzerine yapılan tartışmalar ile sistem seviyesinde güncellemeler, teknik altyapıdaki güncel eğilimleri destekleyen önemli başlıklar arasında yer alıyor.</p>
       <div class="rep-actions">
-        <a class="act act-read" href="/reports/trescout-rapor-2026-08-02.pdf" target="_blank" rel="noopener">PDF raporu aç →</a>
-        <a class="act act-dl" href="/reports/trescout-rapor-2026-08-02.pdf" download>İndir</a>
+        <a class="act act-read" href="/reports/trescout-rapor-2026-08-02.pdf?v=94bae31d" target="_blank" rel="noopener">PDF raporu aç →</a>
+        <a class="act act-dl" href="/reports/trescout-rapor-2026-08-02.pdf?v=94bae31d" download>İndir</a>
       </div>
       <p class="rep-note">Tam rapor PDF olarak · 33 öne çıkan gelişme, kaynak bağlantıları ve geçen terimlerin sözlüğü ile.</p>
       <aside class="signup-cta">

--- a/reports/index.html
+++ b/reports/index.html
@@ -68,7 +68,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-08-02/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-08-02.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-08-02.pdf?v=94bae31d" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -79,7 +79,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-08-01/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-08-01.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-08-01.pdf?v=bb619819" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -90,7 +90,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-31/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-31.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-31.pdf?v=38fca134" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -101,7 +101,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-30/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-30.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-30.pdf?v=4bc88175" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -112,7 +112,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-29/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-29.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-29.pdf?v=2388d752" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -123,7 +123,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-28/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-28.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-28.pdf?v=65235599" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -134,7 +134,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-27/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-27.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-27.pdf?v=bde45ad8" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -145,7 +145,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-26/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-26.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-26.pdf?v=5c6ee124" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -156,7 +156,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-25/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-25.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-25.pdf?v=6f9636ed" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -167,7 +167,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-24/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-24.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-24.pdf?v=235c9dcd" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -178,7 +178,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-23/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-23.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-23.pdf?v=36ab45c3" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -189,7 +189,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-22/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-22.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-22.pdf?v=f1e62042" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -200,7 +200,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-21/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-21.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-21.pdf?v=4314636f" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -211,7 +211,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-20/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-20.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-20.pdf?v=7324a58b" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -222,7 +222,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-19/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-19.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-19.pdf?v=8610d1b8" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -233,7 +233,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-18/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-18.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-18.pdf?v=5f029ce2" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -244,7 +244,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-17/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-17.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-17.pdf?v=977f1ede" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -255,7 +255,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-16/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-16.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-16.pdf?v=0ffebfe0" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -266,7 +266,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-15/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-15.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-15.pdf?v=7585e76e" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -277,7 +277,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-14/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-14.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-14.pdf?v=ea2e9e34" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -288,7 +288,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-13/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-13.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-13.pdf?v=bbbcb719" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -299,7 +299,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-12/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-12.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-12.pdf?v=b41ef548" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -310,7 +310,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-11/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-11.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-11.pdf?v=62ea9451" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -321,7 +321,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-10/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-10.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-10.pdf?v=357f1668" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -332,7 +332,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-09/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-09.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-09.pdf?v=b5ec9d8d" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -343,7 +343,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-08/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-08.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-08.pdf?v=2d40899c" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -354,7 +354,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-07/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-07.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-07.pdf?v=4520d866" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -365,7 +365,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-06/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-06.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-06.pdf?v=9d6d820c" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -376,7 +376,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-05/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-05.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-05.pdf?v=46bce120" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -387,7 +387,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-04/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-04.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-04.pdf?v=349771b5" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -398,7 +398,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-03/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-03.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-03.pdf?v=a0a55391" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -409,7 +409,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-02/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-02.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-02.pdf?v=98cddab1" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -420,7 +420,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-07-01/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-01.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-07-01.pdf?v=47bedeb3" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -431,7 +431,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-30/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-30.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-30.pdf?v=098f7feb" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -442,7 +442,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-29/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-29.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-29.pdf?v=266072f5" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -453,7 +453,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-28/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-28.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-28.pdf?v=9faaed72" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -464,7 +464,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-27/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-27.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-27.pdf?v=21f4b536" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -475,7 +475,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-26/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-26.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-26.pdf?v=756a30a3" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -486,7 +486,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-25/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-25.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-25.pdf?v=e4cac564" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -497,7 +497,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-24/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-24.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-24.pdf?v=a0278243" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -508,7 +508,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-23/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-23.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-23.pdf?v=8d1e9d9d" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -519,7 +519,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-22/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-22.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-22.pdf?v=dc00e299" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -530,7 +530,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-21/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-21.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-21.pdf?v=45764329" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -541,7 +541,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-20/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-20.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-20.pdf?v=8fc4693e" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -552,7 +552,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-19/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-19.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-19.pdf?v=3e34b34d" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -563,7 +563,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-18/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-18.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-18.pdf?v=6fda2173" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -574,7 +574,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-17/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-17.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-17.pdf?v=77282cdc" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -585,7 +585,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-16/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-16.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-16.pdf?v=0a48214d" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -596,7 +596,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-15/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-15.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-15.pdf?v=0b8ddb1c" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -607,7 +607,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-14/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-14.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-14.pdf?v=134b96cb" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -618,7 +618,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-13/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-13.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-13.pdf?v=2b29de30" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -629,7 +629,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-12/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-12.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-12.pdf?v=fe82e281" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -640,7 +640,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-11/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-11.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-11.pdf?v=432ea95a" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -651,7 +651,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-10/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-10.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-10.pdf?v=d8ac3c7c" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -662,7 +662,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-09/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-09.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-09.pdf?v=8dcafed6" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -673,7 +673,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-08/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-08.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-08.pdf?v=955b9547" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -684,7 +684,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-07/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-07.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-07.pdf?v=7842ce53" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -695,7 +695,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-06/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-06.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-06.pdf?v=43b706bc" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -706,7 +706,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-05/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-05.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-05.pdf?v=6ac09c73" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -717,7 +717,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-04/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-04.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-04.pdf?v=43aa4c0c" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -728,7 +728,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-03/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-03.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-03.pdf?v=188e47d0" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -739,7 +739,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-02/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-02.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-02.pdf?v=28e3a5f3" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -750,7 +750,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-06-01/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-01.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-06-01.pdf?v=7ab17135" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -761,7 +761,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-05-31/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-05-31.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-05-31.pdf?v=a0a2d453" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -772,7 +772,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-05-30/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-05-30.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-05-30.pdf?v=79f558fc" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -783,7 +783,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-05-29/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-05-29.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-05-29.pdf?v=beb8311a" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -794,7 +794,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-05-28/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-05-28.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-05-28.pdf?v=761bd2b1" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -805,7 +805,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-05-27/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-05-27.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-05-27.pdf?v=694102fc" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -816,7 +816,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/2026-05-26/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-2026-05-26.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-2026-05-26.pdf?v=0fbdcb38" download>İndir</a>
           </div>
         </article>
       </div>

--- a/reports/tekrarsiz/2026-08-02/index.html
+++ b/reports/tekrarsiz/2026-08-02/index.html
@@ -56,8 +56,8 @@
       <div class="rep-chips"><span class="chip">GitHub Trending · 7</span><span class="chip">Hacker News · 5</span><span class="chip">HuggingFace · Günün Modelleri · 1</span><span class="chip">HuggingFace · Günün Makaleleri · 5</span><span class="chip">Lobsters · 3</span><span class="chip chip-total">21 öne çıkan</span></div>
       <p class="rep-editorial">Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.</p>
       <div class="rep-actions">
-        <a class="act act-read" href="/reports/trescout-rapor-tekrarsiz-2026-08-02.pdf" target="_blank" rel="noopener">PDF raporu aç →</a>
-        <a class="act act-dl" href="/reports/trescout-rapor-tekrarsiz-2026-08-02.pdf" download>İndir</a>
+        <a class="act act-read" href="/reports/trescout-rapor-tekrarsiz-2026-08-02.pdf?v=de15eac9" target="_blank" rel="noopener">PDF raporu aç →</a>
+        <a class="act act-dl" href="/reports/trescout-rapor-tekrarsiz-2026-08-02.pdf?v=de15eac9" download>İndir</a>
       </div>
       <p class="rep-note">Önceki günlerde paylaşılanlar hariç · 21 yeni gelişme, 1 yeniden gündemde.</p>
       <aside class="signup-cta">

--- a/reports/tekrarsiz/index.html
+++ b/reports/tekrarsiz/index.html
@@ -68,7 +68,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-08-02/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-08-02.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-08-02.pdf?v=de15eac9" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -79,7 +79,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-08-01/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-08-01.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-08-01.pdf?v=a1720f75" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -90,7 +90,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-31/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-31.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-31.pdf?v=fd7b42dc" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -101,7 +101,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-30/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-30.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-30.pdf?v=744c9733" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -112,7 +112,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-29/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-29.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-29.pdf?v=fda8f955" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -123,7 +123,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-28/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-28.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-28.pdf?v=176e0121" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -134,7 +134,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-27/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-27.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-27.pdf?v=e775c928" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -145,7 +145,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-26/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-26.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-26.pdf?v=6b145e59" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -156,7 +156,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-25/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-25.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-25.pdf?v=3753cacd" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -167,7 +167,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-24/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-24.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-24.pdf?v=482af7a8" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -178,7 +178,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-23/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-23.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-23.pdf?v=a4b41eeb" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -189,7 +189,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-22/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-22.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-22.pdf?v=6a2c55ac" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -200,7 +200,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-21/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-21.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-21.pdf?v=ed2adb06" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -211,7 +211,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-20/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-20.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-20.pdf?v=64e2f331" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -222,7 +222,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-19/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-19.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-19.pdf?v=8a13ca15" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -233,7 +233,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-18/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-18.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-18.pdf?v=01c0cf3b" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -244,7 +244,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-17/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-17.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-17.pdf?v=05c031ae" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -255,7 +255,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-16/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-16.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-16.pdf?v=091d3c37" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -266,7 +266,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-15/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-15.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-15.pdf?v=adc3090c" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -277,7 +277,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-14/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-14.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-14.pdf?v=ec02e74e" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -288,7 +288,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-13/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-13.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-13.pdf?v=a42f3474" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -299,7 +299,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-12/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-12.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-12.pdf?v=6fe3a745" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -310,7 +310,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-11/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-11.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-11.pdf?v=e39641c2" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -321,7 +321,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-10/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-10.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-10.pdf?v=f83e283e" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -332,7 +332,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-09/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-09.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-09.pdf?v=1a9084ee" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -343,7 +343,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-08/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-08.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-08.pdf?v=cb97e3e4" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -354,7 +354,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-07/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-07.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-07.pdf?v=f64eeb17" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -365,7 +365,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-06/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-06.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-06.pdf?v=073c4aa1" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -376,7 +376,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-05/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-05.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-05.pdf?v=d46db172" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -387,7 +387,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-04/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-04.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-04.pdf?v=25e89412" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -398,7 +398,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-03/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-03.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-03.pdf?v=3782308c" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -409,7 +409,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-02/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-02.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-02.pdf?v=ac7fa1db" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -420,7 +420,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-07-01/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-01.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-07-01.pdf?v=b1875e08" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -431,7 +431,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-30/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-30.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-30.pdf?v=a76e0e7c" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -442,7 +442,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-29/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-29.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-29.pdf?v=bc902568" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -453,7 +453,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-28/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-28.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-28.pdf?v=04715620" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -464,7 +464,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-27/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-27.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-27.pdf?v=ecd29fe8" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -475,7 +475,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-26/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-26.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-26.pdf?v=c83d5f1b" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -486,7 +486,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-25/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-25.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-25.pdf?v=23feadb8" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -497,7 +497,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-24/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-24.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-24.pdf?v=b1fffe9f" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -508,7 +508,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-23/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-23.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-23.pdf?v=ae5763e7" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -519,7 +519,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-22/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-22.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-22.pdf?v=a91a7707" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -530,7 +530,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-21/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-21.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-21.pdf?v=d5c9ec26" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -541,7 +541,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-20/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-20.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-20.pdf?v=01e9a8f9" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -552,7 +552,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-19/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-19.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-19.pdf?v=5f2d8f1a" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -563,7 +563,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-18/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-18.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-18.pdf?v=8adfc2ce" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -574,7 +574,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-17/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-17.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-17.pdf?v=3007f374" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -585,7 +585,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-16/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-16.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-16.pdf?v=57297f63" download>İndir</a>
           </div>
         </article>
         <article class="card">
@@ -596,7 +596,7 @@
           </a>
           <div class="card-actions">
             <a class="act act-read" href="/reports/tekrarsiz/2026-06-15/">Aç →</a>
-            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-15.pdf" download>İndir</a>
+            <a class="act act-pdf" href="/reports/trescout-rapor-tekrarsiz-2026-06-15.pdf?v=881a2b54" download>İndir</a>
           </div>
         </article>
       </div>


### PR DESCRIPTION
app#26'nın landing yarısı · PDF bağlantıları artık `?v=<içerik-hash>` taşıyor, yeniden üretilen rapor okura eski hâliyle gösterilmiyor.

Kapsam bilinçli olarak dar: Bugünün rapor sayfaları ve iki arşiv dizini. Geçmiş rapor sayfalarına dokunulmadı, `sitemap.xml` değiştirilmedi.

## AI Traceability

### Plan Agent
- Outputs used: canlı önbellek başlığı ölçümü

### Skills Agent
- [ ] Kullanılmadı

### Türkçe İçerik
- Yok · yalnız bağlantı biçimi

### Manuel
- Arşiv sayfalarının dışarıda bırakılması elle yapıldı