### PR TITLE
fix(claude-code): 128 rapor arşivi sayfasında footer normalize edildi

### DIFF
--- a/reports/2026-05-26/index.html
+++ b/reports/2026-05-26/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-05-26/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-05-26/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-05-27/index.html
+++ b/reports/2026-05-27/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-05-27/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-05-27/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-05-28/index.html
+++ b/reports/2026-05-28/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-05-28/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-05-28/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-05-29/index.html
+++ b/reports/2026-05-29/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-05-29/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-05-29/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-05-30/index.html
+++ b/reports/2026-05-30/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-05-30/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-05-30/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-05-31/index.html
+++ b/reports/2026-05-31/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-05-31/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-05-31/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-01/index.html
+++ b/reports/2026-06-01/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-01/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-01/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-02/index.html
+++ b/reports/2026-06-02/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-02/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-02/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-03/index.html
+++ b/reports/2026-06-03/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-03/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-03/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-04/index.html
+++ b/reports/2026-06-04/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-04/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-04/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-05/index.html
+++ b/reports/2026-06-05/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-05/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-05/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-06/index.html
+++ b/reports/2026-06-06/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-06/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-06/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-07/index.html
+++ b/reports/2026-06-07/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-07/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-07/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-08/index.html
+++ b/reports/2026-06-08/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-08/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-08/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-09/index.html
+++ b/reports/2026-06-09/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-09/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-09/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-10/index.html
+++ b/reports/2026-06-10/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-10/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-10/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-11/index.html
+++ b/reports/2026-06-11/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-11/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-11/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-12/index.html
+++ b/reports/2026-06-12/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-12/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-12/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-13/index.html
+++ b/reports/2026-06-13/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-13/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-13/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-14/index.html
+++ b/reports/2026-06-14/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-14/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-14/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-15/index.html
+++ b/reports/2026-06-15/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-15/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-15/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-16/index.html
+++ b/reports/2026-06-16/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-16/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-16/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-17/index.html
+++ b/reports/2026-06-17/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-17/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-17/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-18/index.html
+++ b/reports/2026-06-18/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-18/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-18/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-19/index.html
+++ b/reports/2026-06-19/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-19/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-19/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-20/index.html
+++ b/reports/2026-06-20/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-20/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-20/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-21/index.html
+++ b/reports/2026-06-21/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-21/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-21/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-22/index.html
+++ b/reports/2026-06-22/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-22/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-22/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-23/index.html
+++ b/reports/2026-06-23/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-23/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-23/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-24/index.html
+++ b/reports/2026-06-24/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-24/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-24/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-25/index.html
+++ b/reports/2026-06-25/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-25/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-25/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-26/index.html
+++ b/reports/2026-06-26/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-26/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-26/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-27/index.html
+++ b/reports/2026-06-27/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-27/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-27/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-28/index.html
+++ b/reports/2026-06-28/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-28/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-28/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-29/index.html
+++ b/reports/2026-06-29/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-29/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-29/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-06-30/index.html
+++ b/reports/2026-06-30/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-30/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-30/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-01/index.html
+++ b/reports/2026-07-01/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-01/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-01/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-02/index.html
+++ b/reports/2026-07-02/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-02/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-02/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-03/index.html
+++ b/reports/2026-07-03/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-03/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-03/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-04/index.html
+++ b/reports/2026-07-04/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-04/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-04/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-05/index.html
+++ b/reports/2026-07-05/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-05/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-05/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-06/index.html
+++ b/reports/2026-07-06/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-06/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-06/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-07/index.html
+++ b/reports/2026-07-07/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-07/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-07/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-08/index.html
+++ b/reports/2026-07-08/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-08/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-08/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-09/index.html
+++ b/reports/2026-07-09/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-09/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-09/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-10/index.html
+++ b/reports/2026-07-10/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-10/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-10/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-11/index.html
+++ b/reports/2026-07-11/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-11/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-11/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-12/index.html
+++ b/reports/2026-07-12/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-12/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-12/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-13/index.html
+++ b/reports/2026-07-13/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-13/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-13/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-14/index.html
+++ b/reports/2026-07-14/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-14/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-14/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-15/index.html
+++ b/reports/2026-07-15/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-15/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-15/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-16/index.html
+++ b/reports/2026-07-16/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-16/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-16/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-17/index.html
+++ b/reports/2026-07-17/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-17/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-17/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-18/index.html
+++ b/reports/2026-07-18/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-18/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-18/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-19/index.html
+++ b/reports/2026-07-19/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-19/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-19/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-20/index.html
+++ b/reports/2026-07-20/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-20/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-20/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-21/index.html
+++ b/reports/2026-07-21/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-21/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-21/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-22/index.html
+++ b/reports/2026-07-22/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-22/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-22/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-23/index.html
+++ b/reports/2026-07-23/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-23/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-23/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-24/index.html
+++ b/reports/2026-07-24/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-24/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-24/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-25/index.html
+++ b/reports/2026-07-25/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-25/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-25/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-26/index.html
+++ b/reports/2026-07-26/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-26/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-26/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-27/index.html
+++ b/reports/2026-07-27/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-27/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-27/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-28/index.html
+++ b/reports/2026-07-28/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-28/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-28/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-29/index.html
+++ b/reports/2026-07-29/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-29/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-29/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-30/index.html
+++ b/reports/2026-07-30/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-30/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-30/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-07-31/index.html
+++ b/reports/2026-07-31/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-31/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-31/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-08-01/index.html
+++ b/reports/2026-08-01/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-01/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-01/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-08-02/index.html
+++ b/reports/2026-08-02/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-02/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-02/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-08-03/index.html
+++ b/reports/2026-08-03/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-03/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-03/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-08-04/index.html
+++ b/reports/2026-08-04/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-04/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-04/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-08-05/index.html
+++ b/reports/2026-08-05/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-05/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-05/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/2026-08-06/index.html
+++ b/reports/2026-08-06/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-06/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-06/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,52 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/index.html
+++ b/reports/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <div class="archive-main">
@@ -855,52 +848,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-15/index.html
+++ b/reports/tekrarsiz/2026-06-15/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-15/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-15/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-16/index.html
+++ b/reports/tekrarsiz/2026-06-16/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-16/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-16/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-17/index.html
+++ b/reports/tekrarsiz/2026-06-17/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-17/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-17/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-18/index.html
+++ b/reports/tekrarsiz/2026-06-18/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-18/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-18/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-19/index.html
+++ b/reports/tekrarsiz/2026-06-19/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-19/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-19/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-20/index.html
+++ b/reports/tekrarsiz/2026-06-20/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-20/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-20/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-21/index.html
+++ b/reports/tekrarsiz/2026-06-21/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-21/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-21/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-22/index.html
+++ b/reports/tekrarsiz/2026-06-22/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-22/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-22/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-23/index.html
+++ b/reports/tekrarsiz/2026-06-23/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-23/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-23/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-24/index.html
+++ b/reports/tekrarsiz/2026-06-24/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-24/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-24/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-25/index.html
+++ b/reports/tekrarsiz/2026-06-25/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-25/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-25/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-26/index.html
+++ b/reports/tekrarsiz/2026-06-26/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-26/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-26/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-27/index.html
+++ b/reports/tekrarsiz/2026-06-27/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-27/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-27/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-28/index.html
+++ b/reports/tekrarsiz/2026-06-28/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-28/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-28/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-29/index.html
+++ b/reports/tekrarsiz/2026-06-29/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-29/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-29/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-06-30/index.html
+++ b/reports/tekrarsiz/2026-06-30/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-30/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-06-30/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-01/index.html
+++ b/reports/tekrarsiz/2026-07-01/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-01/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-01/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-02/index.html
+++ b/reports/tekrarsiz/2026-07-02/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-02/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-02/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-03/index.html
+++ b/reports/tekrarsiz/2026-07-03/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-03/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-03/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-04/index.html
+++ b/reports/tekrarsiz/2026-07-04/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-04/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-04/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-05/index.html
+++ b/reports/tekrarsiz/2026-07-05/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-05/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-05/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-06/index.html
+++ b/reports/tekrarsiz/2026-07-06/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-06/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-06/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-07/index.html
+++ b/reports/tekrarsiz/2026-07-07/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-07/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-07/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-08/index.html
+++ b/reports/tekrarsiz/2026-07-08/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-08/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-08/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-09/index.html
+++ b/reports/tekrarsiz/2026-07-09/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-09/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-09/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-10/index.html
+++ b/reports/tekrarsiz/2026-07-10/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-10/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-10/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-11/index.html
+++ b/reports/tekrarsiz/2026-07-11/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-11/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-11/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-12/index.html
+++ b/reports/tekrarsiz/2026-07-12/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-12/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-12/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-13/index.html
+++ b/reports/tekrarsiz/2026-07-13/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-13/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-13/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-14/index.html
+++ b/reports/tekrarsiz/2026-07-14/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-14/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-14/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-15/index.html
+++ b/reports/tekrarsiz/2026-07-15/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-15/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-15/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-16/index.html
+++ b/reports/tekrarsiz/2026-07-16/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-16/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-16/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-17/index.html
+++ b/reports/tekrarsiz/2026-07-17/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-17/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-17/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-18/index.html
+++ b/reports/tekrarsiz/2026-07-18/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-18/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-18/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-19/index.html
+++ b/reports/tekrarsiz/2026-07-19/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-19/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-19/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-20/index.html
+++ b/reports/tekrarsiz/2026-07-20/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-20/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-20/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-21/index.html
+++ b/reports/tekrarsiz/2026-07-21/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-21/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-21/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-22/index.html
+++ b/reports/tekrarsiz/2026-07-22/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-22/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-22/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-23/index.html
+++ b/reports/tekrarsiz/2026-07-23/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-23/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-23/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-24/index.html
+++ b/reports/tekrarsiz/2026-07-24/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-24/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-24/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-25/index.html
+++ b/reports/tekrarsiz/2026-07-25/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-25/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-25/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-26/index.html
+++ b/reports/tekrarsiz/2026-07-26/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-26/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-26/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-27/index.html
+++ b/reports/tekrarsiz/2026-07-27/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-27/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-27/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-28/index.html
+++ b/reports/tekrarsiz/2026-07-28/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-28/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-28/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-29/index.html
+++ b/reports/tekrarsiz/2026-07-29/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-29/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-29/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-30/index.html
+++ b/reports/tekrarsiz/2026-07-30/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-30/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-30/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-07-31/index.html
+++ b/reports/tekrarsiz/2026-07-31/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-31/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-07-31/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-08-01/index.html
+++ b/reports/tekrarsiz/2026-08-01/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-01/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-01/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-08-02/index.html
+++ b/reports/tekrarsiz/2026-08-02/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-02/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-02/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-08-03/index.html
+++ b/reports/tekrarsiz/2026-08-03/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-03/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-03/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-08-04/index.html
+++ b/reports/tekrarsiz/2026-08-04/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-04/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-04/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-08-05/index.html
+++ b/reports/tekrarsiz/2026-08-05/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-05/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-05/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,51 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/2026-08-06/index.html
+++ b/reports/tekrarsiz/2026-08-06/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-06/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/2026-08-06/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <article class="report-main">
@@ -55,52 +48,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>

--- a/reports/tekrarsiz/index.html
+++ b/reports/tekrarsiz/index.html
@@ -26,14 +26,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Ana içeriğe atla</a>
-<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
+<nav><div class="container nav-inner"><a class="logo-link" href="/" aria-label="TreScout anasayfa"><svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg><span>TreScout</span></a><div class="nav-actions"><a href="/discover/" class="btn btn-ghost">Keşif</a><a href="/dictionary/" class="btn btn-ghost">Sözlük</a><a href="/reports/" class="btn btn-ghost">Raporlar</a><a href="/compare/rss-vs-ai/" class="btn btn-ghost">Karşılaştır</a><a href="/en/reports/" class="btn btn-ghost" aria-label="İngilizceye geç">EN</a></div></div></nav>
 
   <main id="main">
     <div class="archive-main">
@@ -635,52 +628,45 @@
   </main>
 
   <footer>
-    <div class="container">
-      <div class="footer-grid">
-        <div class="footer-brand-block">
-          <div class="footer-logo">
-            <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true">
-        <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/>
-        <path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
-        <path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
-        <path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/>
-        <rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/>
-        <rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/>
-      </svg>
-            <span>TreScout</span>
-          </div>
-          <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand-block">
+        <div class="footer-logo">
+          <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden="true"><rect x="0" y="0" width="100" height="100" rx="22" fill="#1B4965"/><path d="M 20 56 A 30 30 0 0 1 80 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/><path d="M 30 56 A 20 20 0 0 1 70 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/><path d="M 40 56 A 10 10 0 0 1 60 56" fill="none" stroke="#5FA8D3" stroke-width="2.5" opacity="0.75" stroke-linecap="round"/><rect x="20" y="56" width="60" height="11" rx="2" fill="#F4D35E"/><rect x="44.5" y="56" width="11" height="28" rx="2" fill="#F4D35E"/></svg>
+          <span>TreScout</span>
         </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Ürün</div>
-          <ul>
-            <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
-            <li><a href="/discover/">Keşif</a></li>
-            <li><a href="/dictionary/">Sözlük</a></li>
-            <li><a href="/reports/">Raporlar</a></li>
-            <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
-            <li><a href="/#top">Erken Erişim</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">İletişim</div>
-          <ul>
-            <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
-            <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
-          </ul>
-        </div>
-        <div class="footer-col">
-          <div class="footer-col-title">Sosyal medya</div>
-          <ul>
-            <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
-          </ul>
-        </div>
+        <p class="footer-tagline">TreScout tarar, özetler, gönderir. Siz sadece okursunuz.</p>
       </div>
-      <div class="footer-bottom">
-        <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+      <div class="footer-col">
+        <div class="footer-col-title">Ürün</div>
+        <ul>
+          <li><a href="/#how-it-works">Nasıl Çalışır</a></li>
+          <li><a href="/discover/">Keşif</a></li>
+          <li><a href="/dictionary/">Sözlük</a></li>
+          <li><a href="/reports/">Raporlar</a></li>
+          <li><a href="/compare/rss-vs-ai/">Karşılaştır</a></li>
+          <li><a href="/#top">Erken Erişim</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">İletişim</div>
+        <ul>
+          <li><a href="mailto:hello@trescout.com">hello@trescout.com</a></li>
+          <li><a href="/privacy.html" target="_blank" rel="noopener">Aydınlatma Metni</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <div class="footer-col-title">Sosyal medya</div>
+        <ul>
+          <li><a href="https://x.com/GetTreScout" target="_blank" rel="noopener noreferrer">X</a></li>
+        </ul>
       </div>
     </div>
-  </footer>
+    <div class="footer-bottom">
+      <span>© 2026 TreScout · Tüm hakları saklıdır.</span>
+    </div>
+  </div>
+</footer>
 
   <!-- Vercel Analytics · cookieless, KVKK uyumlu -->
   <script defer src="/_vercel/insights/script.js"></script>


### PR DESCRIPTION
app#30'un tamamlayıcısı. Üreteç düzeltildi ama **geçmişte basılmış 128 sayfa** eski footer'la kalmıştı (`Karşılaştır` eksik).

`scripts/fix-all-headers-and-footers.js` ile hepsi kanonik sete çekildi · içerik değişmedi, yalnız footer bağlantı listesi.

## Doğrulama · dört guard yeşil

```
✅ CSP guard: 1919 sayfa
✅ Nav tutarlı: 1917 sayfa (TR + EN)
✅ Footer tutarlı: 1918 sayfa (TR + EN)
✅ Logo geometrisi tutarlı: 3838 marka işareti
```

Bundan sonra günlük çalışma sapmayı geri getirmez, çünkü üreteç de düzeltildi.

## AI Traceability

### Plan Agent
- Outputs used: guard çıktısı

### Skills Agent
- [ ] Kullanılmadı

### Türkçe İçerik
- Menü etiketi

### Manuel
- Mevcut normalize betiği kullanıldı, yeni betik yazılmadı