### PR TITLE
docs(claude-code): kullanım dışı betiğe uyarı başlığı

### DIFF
--- a/scripts/translate-report-json.js
+++ b/scripts/translate-report-json.js
@@ -1,3 +1,14 @@
+/**
+ * ⚠️ KULLANIM DIŞI · yayın hattında ÇAĞRILMIYOR.
+ *
+ * Yayın hattı (app/scripts/publish-report.ts) yalnız build-en.js ve
+ * build-reports-en.js çalıştırıyor. Bu betik eski bir yoldan kalma.
+ *
+ * Elle çalıştırmayın: İçinde 11 inline style= var, CSP guard'ını düşürür ve
+ * canlıda stiller uygulanmaz (site başlığı style-src 'self'). Yeniden
+ * kullanılacaksa önce stilleri sınıfa taşıyın (bkz. landing#57).
+ */
+
 const fs = require('fs');
 const path = require('path');
 


### PR DESCRIPTION
`scripts/translate-report-json.js` yayın hattında çağrılmıyor ama içinde **11 inline style=** var. Elle çalıştıran biri hem CSP guard'ını düşürür hem canlıda stilleri uygulanmayan sayfalar üretir (site başlığı `style-src 'self'`).

Silmedim · içinde çeviri eşleme mantığı var, ileride lazım olabilir. Bunun yerine dosya başına neden kullanılmaması gerektiği ve yeniden kullanılacaksa ne yapılması gerektiği yazıldı.

## AI Traceability
### Plan Agent
- Outputs used: landing#57 denetimi
### Skills Agent
- [ ] Kullanılmadı
### Türkçe İçerik
- Kod yorumu
### Manuel
- Silme yerine işaretleme kararı