### PR TITLE
fix(claude-code): stilsiz kalan iki öğe

### DIFF
--- a/assets/report-cover.css
+++ b/assets/report-cover.css
@@ -9,6 +9,8 @@
   .rep-chips { margin-top: 18px; display: flex; flex-wrap: wrap; gap: 8px; }
   .chip { font-size: 12px; color: var(--brand-light); background: rgba(95,168,211,.1); border: 1px solid rgba(95,168,211,.22); padding: 4px 10px; border-radius: 999px; white-space: nowrap; }
   .chip-total { color: var(--accent); background: rgba(244,211,94,.1); border-color: rgba(244,211,94,.25); }
+  /* İngilizce arşiv rozeti · gün sayfaları bu stil dosyasını yüklüyor (report-archive.css'te de var) */
+  .chip-en { background: rgba(95,168,211,.15); border-color: rgba(95,168,211,.3); color: var(--accent); }
   .rep-editorial { margin-top: 30px; font-size: 18px; line-height: 1.7; color: var(--ink); }
   .rep-actions { margin-top: 38px; display: flex; gap: 12px; flex-wrap: wrap; }
   .act { font-size: 15px; font-weight: 600; text-align: center; padding: 13px 26px; border-radius: 11px; transition: transform .12s, box-shadow .12s; }

--- a/en/dictionary/index.html
+++ b/en/dictionary/index.html
@@ -17,6 +17,7 @@
 <meta property="og:locale" content="en_US">
 <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="stylesheet" href="/assets/site.css">
+<link rel="stylesheet" href="/assets/discover.css">
 <link rel="stylesheet" href="/assets/dictionary.css">
 </head>
 <body>

--- a/scripts/build-en.js
+++ b/scripts/build-en.js
@@ -282,6 +282,7 @@ const dictIndexHtml = `<!DOCTYPE html>
 <meta property="og:locale" content="en_US">
 <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="stylesheet" href="/assets/site.css">
+<link rel="stylesheet" href="/assets/discover.css">
 <link rel="stylesheet" href="/assets/dictionary.css">
 </head>
 <body>


### PR DESCRIPTION
Tasarım denetiminin ilk parçası · iki gerçek görsel hata.

## 1. `/en/dictionary/` abonelik formu stilsiz

Sayfadaki CTA formu `disc-cta`, `cta-form`, `form-row`, `input` sınıflarını kullanıyor ama bunlar `discover.css`'te tanımlı ve sayfa o dosyayı yüklemiyordu. Canlıda ölçtüm:

```
.disc-cta  → padding: 0px, background: transparent, border: none
input      → tarayıcı varsayılanı (rgb(59,59,59), 2px inset)
```

Türkçe karşılığı (`/dictionary/`) `discover.css`'i yüklüyor, yani yalnız İngilizce tarafta eksikti. Sayfa ve üreteci (`build-en.js`) düzeltildi.

## 2. `.chip-en` · benim bıraktığım açık

landing#57'de inline stili sınıfa taşımıştım, ama **72 İngilizce gün sayfası** `report-archive.css` değil `report-cover.css` yüklüyor. Sınıf orada tanımlı değildi, yani rozet yine stilsizdi. İkinci dosyaya da eklendi.

Görsel olarak eskisinden kötü değildi (inline stil de CSP nedeniyle uygulanmıyordu), ama düzeltmenin yarısı boşta kalmıştı.

## Yöntem

Tek tek bakmak yerine tarayıcı yazdım: Her sayfanın kullandığı sınıfları çıkar, yüklediği CSS dosyalarındaki tanımlarla karşılaştır, başka bir CSS'te tanımlı olup burada yüklenmeyenleri işaretle. Site genelinde artık sıfır.

## AI Traceability

### Plan Agent
- Outputs used: canlı computed style ölçümü, sınıf/CSS eşleme taraması

### Skills Agent
- [ ] Kullanılmadı

### Türkçe İçerik
- Yok

### Manuel
- Tarama betiği ve düzeltmeler