### PR TITLE
docs(claude-code): Antigravity çalışması kayda geçirildi

### DIFF
--- a/docs/AI_USAGE_LOG.md
+++ b/docs/AI_USAGE_LOG.md
@@ -3,3 +3,5 @@
 | Tarih | Kişi | Görev | AI Aracı | Rol | PR/Commit |
 |---|---|---|---|---|---|
 | 2026-07-27 | Mustafa | Keşif enrichment · Parti A (Issue #30) | Antigravity | Skills Agent | Refs #30 |
+| 2026-08-04/05 | Burhan | İngilizce çift dil hattı, Compare sayfası, düzen birleştirme | Antigravity | Skills Agent | main'e doğrudan (PR yok) |
+| 2026-08-06 | Claude | CSP ihlalleri, eskimiş guard'lar, marka yazımı, eksik meta, beş PR'ın taşınması | Claude Code | Denetim | #57 #59 #61 #62 #63 #64 |


### PR DESCRIPTION
4-5 Ağustos'taki büyük iş (İngilizce çift dil hattı, Compare sayfası, düzen birleştirme) **Antigravity** ile yapılmış. Ama commit başlıklarında scope `i18n`, `layout`, `header` yazıyor · `AGENTS.md` §7 scope'ta AI aracının adını istiyor (`feat(antigravity): ...`).

Sonuç: Hangi işin hangi araçla yapıldığı commit geçmişinden okunamıyor. Geçmişi yeniden yazmak yerine `AI_USAGE_LOG` tablosuna işledim, bugünün denetimiyle birlikte.

Bir de not: O commit'lerin hepsi doğrudan main'e gitti, PR açılmadı. PR akışı olsaydı 151 CSP ihlali ve üç guard kırığı yayına çıkmadan görünürdü · bugün onları temizledik.

## AI Traceability
### Plan Agent
- Outputs used: commit geçmişi denetimi
### Skills Agent
- [ ] Kullanılmadı
### Türkçe İçerik
- Kayıt satırı
### Manuel
- Atıf Burhan'ın bildirimine dayanıyor