### PR TITLE
fix(claude-code): eski başlıkları da denetle · karşılıksız yapay zekâ iddiası

### DIFF
--- a/assets/discover/catalog.json
+++ b/assets/discover/catalog.json
@@ -1860,7 +1860,8 @@
         "surum_tarihi": "2026-08-05"
       }
     ],
-    "tagline_en": "Published by GitHub, spec-kit is a tool required to start specification-driven development processes."
+    "tagline_en": "Published by GitHub, spec-kit is a tool required to start specification-driven development processes.",
+    "headline_locked": true
   },
   {
     "slug": "cosmos",
@@ -1983,7 +1984,8 @@
         "surum_tarihi": "2026-06-30"
       }
     ],
-    "tagline_en": "OpenClaw Windows node, system tray application, shared library and PowerToys command palette extension…"
+    "tagline_en": "OpenClaw Windows node, system tray application, shared library and PowerToys command palette extension…",
+    "headline_locked": true
   },
   {
     "slug": "last30days-skill",
@@ -4174,7 +4176,8 @@
         "surum_tarihi": "2026-07-08"
       }
     ],
-    "tagline_en": "Codebase-memory-mcp provides high-performance coding by transforming code bases into a persistent knowledge graph."
+    "tagline_en": "Codebase-memory-mcp provides high-performance coding by transforming code bases into a persistent knowledge graph.",
+    "headline_locked": true
   },
   {
     "slug": "timesfm",
@@ -5225,7 +5228,8 @@
         "onceki_yildiz": 113462
       }
     ],
-    "tagline_en": "Gstack is based on Garry Tan's Claude Code configuration and provides different roles such as CEO, designer, engineering manager."
+    "tagline_en": "Gstack is based on Garry Tan's Claude Code configuration and provides different roles such as CEO, designer, engineering manager.",
+    "headline_locked": true
   },
   {
     "slug": "hyperframes",
@@ -9984,7 +9988,8 @@
     "lite": false,
     "headline": "Otonom yapay zekâ ile derinlemesine araştırma",
     "last_review": "2026-08-06",
-    "tagline_en": "Developed by LangChain, open-deep-research is a multi-step search on the internet to answer complex questions."
+    "tagline_en": "Developed by LangChain, open-deep-research is a multi-step search on the internet to answer complex questions.",
+    "headline_locked": true
   },
   {
     "slug": "pi-web",

--- a/scripts/discover-sync.py
+++ b/scripts/discover-sync.py
@@ -374,7 +374,7 @@ def build_page(e, rich=None):
       '</article>\n</main>\n'+FOOTER+'\n'+('<script src="/assets/discover.js" defer></script>\n' if rich else '')+'<script src="/assets/subscribe.js" defer></script>\n'+VERCEL+'</body>\n</html>\n')
     return head+body
 
-AI_IZI=re.compile(r'(yapay zek|makine öğren|derin öğren|sinir ağ|büyük dil model|\bai\b|\bllm\b|\bgpt\b|\bml\b|model|ajan|agent|chatbot|sohbet bot|üretken|çıkarım|inference|transformer|embedding|vektör|neural|prompt)',re.I)
+AI_IZI=re.compile(r'(yapay zek|makine öğren|derin öğren|sinir ağ|büyük dil model|\bai\b|\bllm\b|\bgpt\b|\bml\b|model|ajan|agent|chatbot|sohbet bot|üretken|çıkarım|inference|transformer|embedding|vektör|neural|prompt|claude|copilot|kopilot|gemini|\bmcp\b)',re.I)
 def _ai_iddiasi(s): return bool(re.search(r'yapay zek',s or '',re.I))
 def _kaynakta_ai(n):
     blob=" ".join(str(n.get(k) or "") for k in ("title","tagline","summary"))+" "+" ".join(n.get("tags") or [])
@@ -464,8 +464,36 @@ def _set_page_headline(c, headline):
         html=re.sub(r'(<span class="disc-eyebrow">Keşif · GitHub)(</span>)', rf'\1 · {esc(c["title"])}\2', html, count=1)
     open(p,"w",encoding="utf-8").write(html)
 
+def audit_headlines(cat, key, limit):
+    """Eski başlıkları da vet_headline ölçütünden geçir · karşılıksız yapay zekâ iddiasını temizler.
+
+    vet_headline yalnız üretim anında çalışıyordu · guard'dan önce yazılmış başlıklar
+    hiç denetlenmedi (2026-08-06 denetimi: 397 kayıtta 7 karşılıksız iddia · Argo CD,
+    Insomnia gibi yapay zekâyla ilgisi olmayan araçlar). Kilitli başlık insan
+    doğrulamasıdır · dokunulmaz. Döner: değişen kayıt sayısı.
+    """
+    supheli=[c for c in cat if c.get("headline") and not c.get("headline_locked")
+             and _ai_iddiasi(c["headline"]) and not _kaynakta_ai(c)][:limit]
+    if not supheli: print("  · başlık denetimi: karşılıksız yapay zekâ iddiası yok"); return 0
+    print(f"  · başlık denetimi: {len(supheli)} karşılıksız iddia")
+    if DRY:
+        for c in supheli: print(f"    ~ {c['slug']}: {c['headline']}")
+        return 0
+    n=0
+    for c in supheli:
+        yeni=gemini_headline(c["title"], c.get("tagline",""), key,
+                             extra="UYARI: Bu araç yapay zekâ ile ilgili DEĞİL. Başlıkta yapay zekâdan söz etme.")
+        yeni=normalize_headline(yeni) if yeni else None
+        if not yeni or _ai_iddiasi(yeni):
+            print(f"    ! {c['slug']}: temiz başlık üretilemedi · elle bakın"); continue
+        print(f"    ✓ {c['slug']}: {c['headline']} → {yeni}")
+        c["headline"]=yeni; _set_page_headline(c, yeni); n+=1
+        time.sleep(1)  # rate limit
+    return n
+
+
 def headline_backfill(cat, key, limit):
-    """1) Mevcut başlıkları normalize et (Gemini'siz · marka). 2) Başlığı olmayanlara üret (limit)."""
+    """1) Normalize et (Gemini'siz · marka). 2) Eski başlıkları denetle. 3) Başlığı olmayanlara üret."""
     # 1. Mevcut başlıkları normalize et (ör. 'Yapay Zeka' → 'yapay zekâ')
     fixed=0
     for c in cat:
@@ -475,7 +503,11 @@ def headline_backfill(cat, key, limit):
                 c["headline"]=nb; fixed+=1
                 if not DRY: _set_page_headline(c, nb)
     if fixed: print(f"  · {fixed} mevcut başlık normalize edildi (marka)")
-    # 2. Başlığı olmayanlara üret
+    # 2. Guard'dan önce yazılmış başlıkları denetle
+    denetlenen=audit_headlines(cat, key, limit)
+    if denetlenen and not DRY:
+        json.dump(cat,open(CATALOG,"w",encoding="utf-8"),ensure_ascii=False,indent=2)
+    # 3. Başlığı olmayanlara üret
     todo=[c for c in cat if not c.get("headline")][:limit]
     print(f"--headlines · {len(todo)} girdiye başlık üretilecek")
     if DRY:
@@ -489,7 +521,7 @@ def headline_backfill(cat, key, limit):
         n+=1; print(f"  ✓ {c['slug']}: {b}")
         time.sleep(1)  # rate limit
     json.dump(cat,open(CATALOG,"w",encoding="utf-8"),ensure_ascii=False,indent=2)
-    print(f"✅ {n} yeni başlık · {fixed} normalize · catalog güncellendi")
+    print(f"✅ {n} yeni başlık · {denetlenen} denetimden geçirildi · {fixed} normalize · catalog güncellendi")
 
 def process_one(n, key):
     """Entry'i zenginleştir + sayfa & kart yaz. Döner: (rich|None, reason|None)."""


### PR DESCRIPTION
## Ne
`vet_headline` guard'ı (landing#64) yalnız **başlık üretilirken** çalışıyordu. Guard'dan önce yazılmış kayıtlar hiç denetimden geçmedi · 397 kayıtta **7 karşılıksız yapay zekâ iddiası** kaldı:

| slug | başlık | araç gerçekte |
|---|---|---|
| argo-cd | "Kubernetes için yapay zekâ destekli sürekli dağıtım" | bildirimsel CD |
| insomnia | "Kapsamlı yapay zekâ destekli API istemcisi" | API istemcisi |
| coding-interview-university | "…yapay zekâ desteğiyle hazırlanın" | mülakat kaynak listesi |
| clone-wars | "Popüler Platformları yapay zekâyla Kopyalayın" | açık kaynak klon derlemesi |
| nautilus-trader | "yapay zekâ alım satım motoru" | olay güdümlü alım satım motoru |
| no-mistakes | "yapay zekâ destekli güvenlik" | git push kancası |
| trek | "kişisel yapay zekâ seyahat planlayıcısı" | seyahat planlayıcı |

## Nasıl
- `audit_headlines()` · `--headlines` akışına denetim aşaması. Kilitli başlığa **dokunmaz**, temiz başlık üretilemezse eskisini bırakıp uyarır.
- `AI_IZI` kanıt taramasına `claude / copilot / gemini / mcp` eklendi. Gerçekten yapay zekâ aracı olduğu hâlde tanımında bu terimler geçmeyen kayıtlar yanlışlıkla eleniyordu.
- İnsan doğrulaması yapılmış 5 kayıt kilitlendi: `spec-kit`, `openclaw-windows-node`, `open-deep-research`, `gstack`, `codebase-memory-mcp` (Mustafa #36'da doğrulamıştı · kilit bunu kalıcı kılıyor).

Bu PR **mekanizmayı** getiriyor · 7 başlığın yeni metni Gemini ile iş akışında üretilip ayrı commit'le gelecek (anahtar yalnız Actions'ta).

Kapatır: #35

## AI Traceability
### Plan Agent
- Outputs used: Issue #35
- Tool: claude-code

### Skills Agent
- [ ] Bu PR'da Skills Agent kullanılmadı

### Türkçe İçerik
- [x] Kullanıcı-yüzü yeni metin **yok** · yeni başlıklar Gemini akışında üretilecek
- [x] Claude denetiminden geçti

### Manuel
- Hangi 7 aracın gerçekten yapay zekâ aracı olmadığı kararı · elle doğrulandı