### PR TITLE
fix(claude-code): başlık cümle düzeni + katalog↔sayfa H1 sapması

### DIFF
--- a/.github/workflows/csp-inline-guard.yml
+++ b/.github/workflows/csp-inline-guard.yml
@@ -5,13 +5,14 @@ name: CSP Inline Guard
 # 2) Nav tutarlılığı: shared-component (nav) sayfa tipine göre kaymasın — 'link kayboluyor' bug'ı tekrarlamasın.
 # 3) Footer tutarlılığı: footer-grid'li tüm sayfalarda aynı "Ürün" linkleri (footer üreticiden üreticiye kaymasın).
 # 4) Logo geometrisi: marka işaretinin şekli (3 yay + T) her yerde aynı (boyut/aria/çerçeve bağlama göre serbest).
+# 5) Başlık tutarlılığı: keşif detay sayfasının H1'i katalogdaki headline ile aynı (alan bazlı taşımada sayfa geride kalmasın).
 
 on:
   pull_request:
-    paths: ['**.html']
+    paths: ['**.html', 'assets/discover/catalog.json']
   push:
     branches: [main]
-    paths: ['**.html']
+    paths: ['**.html', 'assets/discover/catalog.json']
   workflow_dispatch: {}
 
 permissions:
@@ -30,3 +31,5 @@ jobs:
         run: python3 scripts/check-footer-consistency.py
       - name: Logo geometri kontrolü
         run: python3 scripts/check-logo-consistency.py
+      - name: Başlık tutarlılık kontrolü (katalog ↔ sayfa H1)
+        run: python3 scripts/check-headline-consistency.py

--- a/assets/discover/catalog.json
+++ b/assets/discover/catalog.json
@@ -40,7 +40,7 @@
     ],
     "stars": 236779,
     "image": "/assets/discover/og/ecc.webp",
-    "headline": "yapay zekâ Ajanlarınıza Güç Katın",
+    "headline": "Yapay zekâ Ajanlarınıza Güç Katın",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -117,7 +117,7 @@
     ],
     "stars": 27085,
     "image": "/assets/discover/og/anthropic-cybersecurity-skills.webp",
-    "headline": "yapay zekâ için siber güvenlik becerileri",
+    "headline": "Yapay zekâ için siber güvenlik becerileri",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -144,7 +144,7 @@
     ],
     "stars": 14843,
     "image": "/assets/discover/og/stop-slop.webp",
-    "headline": "yapay zekâ metinlerini doğallaştırın",
+    "headline": "Yapay zekâ metinlerini doğallaştırın",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -168,7 +168,7 @@
     ],
     "stars": 69955,
     "image": "/assets/discover/og/taste-skill.webp",
-    "headline": "yapay zekâ Tasarımlarını Profesyonelleştirin",
+    "headline": "Yapay zekâ Tasarımlarını Profesyonelleştirin",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -323,7 +323,7 @@
       "Geliştirici aracı"
     ],
     "image": "/assets/discover/og/claude-mem.webp",
-    "headline": "yapay zekâ Ajanınıza Kalıcı Hafıza Kazandırın",
+    "headline": "Yapay zekâ Ajanınıza Kalıcı Hafıza Kazandırın",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -720,7 +720,7 @@
     ],
     "stars": 24046,
     "image": "/assets/discover/og/compound-engineering-plugin.webp",
-    "headline": "yapay zekâ Destekli Mühendislik Süreçleri",
+    "headline": "Yapay zekâ Destekli Mühendislik Süreçleri",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -1132,7 +1132,7 @@
     ],
     "stars": 16850,
     "image": "/assets/discover/og/hermes-webui.webp",
-    "headline": "yapay zekâ ajanlarınızı webden yönetin",
+    "headline": "Yapay zekâ ajanlarınızı webden yönetin",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -1184,7 +1184,7 @@
     ],
     "stars": 28742,
     "image": "/assets/discover/og/supermemory.webp",
-    "headline": "yapay zekâ için akıllı bellek",
+    "headline": "Yapay zekâ için akıllı bellek",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -1210,7 +1210,7 @@
     ],
     "stars": 1632,
     "image": "/assets/discover/og/babysitter.webp",
-    "headline": "yapay zekâ ajanlarınızı hatasız yönetin",
+    "headline": "Yapay zekâ ajanlarınızı hatasız yönetin",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -1236,7 +1236,7 @@
     ],
     "stars": 2911,
     "image": "/assets/discover/og/pi-subagents.webp",
-    "headline": "yapay zekâ ile asenkron görev yönetimi",
+    "headline": "Yapay zekâ ile asenkron görev yönetimi",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -1294,7 +1294,7 @@
     ],
     "stars": 53997,
     "lite": false,
-    "headline": "yapay zekâ tasarımlarınızı mükemmelleştirin",
+    "headline": "Yapay zekâ tasarımlarınızı mükemmelleştirin",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -1321,7 +1321,7 @@
     ],
     "stars": 95338,
     "lite": false,
-    "headline": "yapay zekâ ile akıllı borsa işlemleri",
+    "headline": "Yapay zekâ ile akıllı borsa işlemleri",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -1347,7 +1347,7 @@
     ],
     "stars": 114944,
     "lite": false,
-    "headline": "açık kaynaklı oyun geliştirme motoru",
+    "headline": "Açık kaynaklı oyun geliştirme motoru",
     "shot": {
       "src": "/assets/discover/godot.webp",
       "w": 1280,
@@ -1505,7 +1505,7 @@
     ],
     "stars": 7746,
     "lite": false,
-    "headline": "yapay zekâ çıktılarınızı analiz edin",
+    "headline": "Yapay zekâ çıktılarınızı analiz edin",
     "tagline_en": "Headroom contains log files, tool outputs, and contextual data pieces (RAG…) sent to large language models (LLM)."
   },
   {
@@ -1549,7 +1549,7 @@
     ],
     "stars": 8216,
     "lite": false,
-    "headline": "yapay zekâ ile akıllı veri getirme",
+    "headline": "Yapay zekâ ile akıllı veri getirme",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -1772,7 +1772,7 @@
     ],
     "stars": 29309,
     "lite": false,
-    "headline": "yapay zekâ ile kişisel alım satım",
+    "headline": "Yapay zekâ ile kişisel alım satım",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -1835,7 +1835,7 @@
     ],
     "stars": 125507,
     "lite": false,
-    "headline": "yapay zekâ ile şartname odaklı geliştirme",
+    "headline": "Yapay zekâ ile şartname odaklı geliştirme",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -2076,7 +2076,7 @@
     ],
     "stars": 64497,
     "lite": false,
-    "headline": "yapay zekâ ajanınıza internet yeteneği kazandırın",
+    "headline": "Yapay zekâ ajanınıza internet yeteneği kazandırın",
     "cmds": {
       "kurulum": [
         {
@@ -2149,7 +2149,7 @@
     ],
     "stars": 4881,
     "lite": false,
-    "headline": "yapay zekâ ile güncel verilere erişin",
+    "headline": "Yapay zekâ ile güncel verilere erişin",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -2174,7 +2174,7 @@
     ],
     "stars": 57977,
     "lite": false,
-    "headline": "yapay zekâ modellerine bellek kazandırın",
+    "headline": "Yapay zekâ modellerine bellek kazandırın",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -2201,7 +2201,7 @@
     ],
     "stars": 7625,
     "lite": false,
-    "headline": "yapay zekâ ajanları için TypeScript çatısı",
+    "headline": "Yapay zekâ ajanları için TypeScript çatısı",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -2338,7 +2338,7 @@
     ],
     "stars": 62979,
     "lite": false,
-    "headline": "yapay zekâ ile kariyerinizi yönetin",
+    "headline": "Yapay zekâ ile kariyerinizi yönetin",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -2453,7 +2453,7 @@
     ],
     "stars": 51860,
     "lite": false,
-    "headline": "yapay zekâ ile uzun ses kayıtlarını çözümleme",
+    "headline": "Yapay zekâ ile uzun ses kayıtlarını çözümleme",
     "cmds": {
       "kurulum": [
         {
@@ -2535,7 +2535,7 @@
     ],
     "stars": 24551,
     "lite": false,
-    "headline": "yapay zekâ ile gelir yönetimi",
+    "headline": "Yapay zekâ ile gelir yönetimi",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -2589,7 +2589,7 @@
     ],
     "stars": 122872,
     "lite": false,
-    "headline": "yapay zekâ modellerini bilgisayarınızda çalıştırın",
+    "headline": "Yapay zekâ modellerini bilgisayarınızda çalıştırın",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -2801,7 +2801,7 @@
     ],
     "stars": 15389,
     "lite": false,
-    "headline": "yapay zekâ ajanlarını Google ile güçlendirin",
+    "headline": "Yapay zekâ ajanlarını Google ile güçlendirin",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -2941,7 +2941,7 @@
     ],
     "stars": 139309,
     "lite": false,
-    "headline": "yapay zekâ araçlarının perde arkası",
+    "headline": "Yapay zekâ araçlarının perde arkası",
     "last_review": "2026-08-06",
     "tagline_en": "System prompts and language models used in popular artificial intelligence tools are used by developers…"
   },
@@ -3013,7 +3013,7 @@
     ],
     "stars": 81505,
     "lite": false,
-    "headline": "yapay zekâ ajanlarına mühendislik yeteneği kazandırın",
+    "headline": "Yapay zekâ ajanlarına mühendislik yeteneği kazandırın",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -3100,7 +3100,7 @@
     ],
     "stars": 1526,
     "lite": false,
-    "headline": "yapay zekâ ajanları için merkezi bellek",
+    "headline": "Yapay zekâ ajanları için merkezi bellek",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -3153,7 +3153,7 @@
     ],
     "stars": 14260,
     "lite": false,
-    "headline": "yapay zekâ yeteneklerini güvenli kılın",
+    "headline": "Yapay zekâ yeteneklerini güvenli kılın",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -3227,7 +3227,7 @@
     ],
     "stars": 138170,
     "lite": false,
-    "headline": "yapay zekâ ajanlarıyla dijital ajans kurun",
+    "headline": "Yapay zekâ ajanlarıyla dijital ajans kurun",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -3354,7 +3354,7 @@
     ],
     "stars": 1478,
     "lite": false,
-    "headline": "yapay zekâ modellerini otonom test edin",
+    "headline": "Yapay zekâ modellerini otonom test edin",
     "last_review": "2026-08-06",
     "tagline_en": "SIA autonomously monitors the performance of artificial intelligence models and agents on specific benchmark tasks."
   },
@@ -3495,7 +3495,7 @@
     ],
     "stars": 11038,
     "lite": false,
-    "headline": "yapay zekâ modellerinde KV önbelleği yönetimi",
+    "headline": "Yapay zekâ modellerinde KV önbelleği yönetimi",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -3566,7 +3566,7 @@
     ],
     "stars": 15888,
     "lite": false,
-    "headline": "yapay zekâ modellerini tek arayüzde yönetin",
+    "headline": "Yapay zekâ modellerini tek arayüzde yönetin",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -3894,7 +3894,7 @@
     ],
     "stars": 20962,
     "lite": false,
-    "headline": "yapay zekâ ajanları için bilgisayar kontrolü",
+    "headline": "Yapay zekâ ajanları için bilgisayar kontrolü",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -4120,7 +4120,7 @@
     ],
     "stars": 11957,
     "lite": false,
-    "headline": "anahtar tabanlı esnek ağ bağlantıları",
+    "headline": "Anahtar tabanlı esnek ağ bağlantıları",
     "cmds": {
       "kurulum": [
         {
@@ -4165,7 +4165,7 @@
     ],
     "stars": 37095,
     "lite": false,
-    "headline": "yapay zekâ kodlama ajanları için hızlı indeksleme",
+    "headline": "Yapay zekâ kodlama ajanları için hızlı indeksleme",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -4193,7 +4193,7 @@
     ],
     "stars": 27185,
     "lite": false,
-    "headline": "zaman serileri için yapay zekâ tahminleme",
+    "headline": "Zaman serileri için yapay zekâ tahminleme",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -4349,7 +4349,7 @@
     ],
     "stars": 38404,
     "lite": false,
-    "headline": "bilgisayarınızı yöneten yapay zekâ arayüzü",
+    "headline": "Bilgisayarınızı yöneten yapay zekâ arayüzü",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -4409,7 +4409,7 @@
     ],
     "stars": 44651,
     "lite": false,
-    "headline": "yapay zekâ ile profesyonel video üretimi",
+    "headline": "Yapay zekâ ile profesyonel video üretimi",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -4460,7 +4460,7 @@
     ],
     "stars": 55364,
     "lite": false,
-    "headline": "açık kaynaklı proje yönetim platformu",
+    "headline": "Açık kaynaklı proje yönetim platformu",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -4489,7 +4489,7 @@
     ],
     "stars": 6864,
     "lite": false,
-    "headline": "uzun vadeli görevler için yapay zekâ",
+    "headline": "Uzun vadeli görevler için yapay zekâ",
     "cmds": {
       "kurulum": [
         {
@@ -4649,7 +4649,7 @@
     ],
     "stars": 15631,
     "lite": false,
-    "headline": "yapay zekâ geliştirme için temel kaynaklar",
+    "headline": "Yapay zekâ geliştirme için temel kaynaklar",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -4674,7 +4674,7 @@
     ],
     "stars": 7550,
     "lite": false,
-    "headline": "yerel sistemde yapay zekâ ile video üretimi",
+    "headline": "Yerel sistemde yapay zekâ ile video üretimi",
     "cmds": {
       "kurulum": [
         {
@@ -4756,7 +4756,7 @@
     ],
     "stars": 13118,
     "lite": false,
-    "headline": "macOS için yapay zekâlı video düzenleyici",
+    "headline": "MacOS için yapay zekâlı video düzenleyici",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -4842,7 +4842,7 @@
     ],
     "stars": 4419,
     "lite": false,
-    "headline": "yapay zekâ ajanları için uygulama çerçevesi",
+    "headline": "Yapay zekâ ajanları için uygulama çerçevesi",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -4916,7 +4916,7 @@
     ],
     "stars": 48096,
     "lite": false,
-    "headline": "yerel ortamda çalışan yapay zekâ ses stüdyosu",
+    "headline": "Yerel ortamda çalışan yapay zekâ ses stüdyosu",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -5010,7 +5010,7 @@
     ],
     "stars": 59863,
     "lite": false,
-    "headline": "yapay zekâ ile otomatik borsa analizi",
+    "headline": "Yapay zekâ ile otomatik borsa analizi",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -5135,7 +5135,7 @@
     ],
     "stars": 29804,
     "lite": false,
-    "headline": "yapay zekâ ajanınıza kalıcı hafıza",
+    "headline": "Yapay zekâ ajanınıza kalıcı hafıza",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -5169,7 +5169,7 @@
     ],
     "stars": 61968,
     "lite": false,
-    "headline": "yapay zekâ modellerinin gizli talimatları",
+    "headline": "Yapay zekâ modellerinin gizli talimatları",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -5219,7 +5219,7 @@
     ],
     "stars": 125874,
     "lite": false,
-    "headline": "yapay zekâ ile yazılım geliştirme fabrikası",
+    "headline": "Yapay zekâ ile yazılım geliştirme fabrikası",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -5313,7 +5313,7 @@
     ],
     "stars": 30826,
     "lite": false,
-    "headline": "yapay zekâ ile web sitesi kopyalama",
+    "headline": "Yapay zekâ ile web sitesi kopyalama",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -5389,7 +5389,7 @@
     ],
     "stars": 6694,
     "lite": false,
-    "headline": "yapay zekâ ile özgeçmiş değerlendirme",
+    "headline": "Yapay zekâ ile özgeçmiş değerlendirme",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -5413,7 +5413,7 @@
     ],
     "stars": 178068,
     "lite": false,
-    "headline": "tek kodla çoklu platform uygulaması",
+    "headline": "Tek kodla çoklu platform uygulaması",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -5622,7 +5622,7 @@
     ],
     "stars": 14888,
     "lite": false,
-    "headline": "yapay zekâ ile değer yatırımı araştırması",
+    "headline": "Yapay zekâ ile değer yatırımı araştırması",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -5692,7 +5692,7 @@
     ],
     "stars": 2215,
     "lite": false,
-    "headline": "yapay zekâ ajanları için AWS araç seti",
+    "headline": "Yapay zekâ ajanları için AWS araç seti",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -5847,7 +5847,7 @@
     ],
     "stars": 63294,
     "lite": false,
-    "headline": "araçlar için açık kaynaklı yapay zekâ",
+    "headline": "Araçlar için açık kaynaklı yapay zekâ",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -6043,7 +6043,7 @@
     ],
     "stars": 193974,
     "lite": false,
-    "headline": "açık kaynaklı yapay zekâ kodlama ajanı",
+    "headline": "Açık kaynaklı yapay zekâ kodlama ajanı",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -6084,7 +6084,7 @@
     ],
     "stars": 63990,
     "lite": false,
-    "headline": "yapay zekâ projelerinde standart geliştirme",
+    "headline": "Yapay zekâ projelerinde standart geliştirme",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -6203,7 +6203,7 @@
     ],
     "stars": 9360,
     "lite": false,
-    "headline": "macOS için gizlilik odaklı sesli dikte",
+    "headline": "MacOS için gizlilik odaklı sesli dikte",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -6254,7 +6254,7 @@
     ],
     "stars": 49097,
     "lite": false,
-    "headline": "yapay zekâ ile otomatik güvenlik taraması",
+    "headline": "Yapay zekâ ile otomatik güvenlik taraması",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -6288,7 +6288,7 @@
     ],
     "stars": 19784,
     "lite": false,
-    "headline": "yapay zekâ ile otomatik video düzenleme",
+    "headline": "Yapay zekâ ile otomatik video düzenleme",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -6345,7 +6345,7 @@
     ],
     "stars": 2575,
     "lite": false,
-    "headline": "yapay zekâ ile otomatik sızma testi",
+    "headline": "Yapay zekâ ile otomatik sızma testi",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -6379,7 +6379,7 @@
     ],
     "stars": 3808,
     "lite": false,
-    "headline": "yapay zekâ ile çok yönlü karar verme",
+    "headline": "Yapay zekâ ile çok yönlü karar verme",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -6621,7 +6621,7 @@
     ],
     "stars": 11769,
     "lite": false,
-    "headline": "yapay zekâ uyumlu tasarım sistemi",
+    "headline": "Yapay zekâ uyumlu tasarım sistemi",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -6682,7 +6682,7 @@
     ],
     "stars": 692,
     "lite": false,
-    "headline": "yapay zekâ destekli japonca giriş sistemi",
+    "headline": "Yapay zekâ destekli japonca giriş sistemi",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -6711,7 +6711,7 @@
     ],
     "stars": 10828,
     "lite": false,
-    "headline": "yapay zekâ ajanları için güvenli çalışma ortamı",
+    "headline": "Yapay zekâ ajanları için güvenli çalışma ortamı",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -6740,7 +6740,7 @@
     ],
     "stars": 95589,
     "lite": false,
-    "headline": "yapay zekâ yanıtlarını kısaltarak tasarruf edin",
+    "headline": "Yapay zekâ yanıtlarını kısaltarak tasarruf edin",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -6774,7 +6774,7 @@
     ],
     "stars": 48381,
     "lite": false,
-    "headline": "yapay zekâ için tarayıcı hata ayıklama",
+    "headline": "Yapay zekâ için tarayıcı hata ayıklama",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -6829,7 +6829,7 @@
     ],
     "stars": 23755,
     "lite": false,
-    "headline": "yapay zekâ ajanlarına standart yetenekler kazandırın",
+    "headline": "Yapay zekâ ajanlarına standart yetenekler kazandırın",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -6944,7 +6944,7 @@
     ],
     "stars": 27689,
     "lite": false,
-    "headline": "yapay zekâ sistemleri için kapsamlı rehber",
+    "headline": "Yapay zekâ sistemleri için kapsamlı rehber",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -7146,7 +7146,7 @@
     ],
     "stars": 107399,
     "lite": false,
-    "headline": "açık kaynaklı Postgres geliştirme platformu",
+    "headline": "Açık kaynaklı Postgres geliştirme platformu",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -7306,7 +7306,7 @@
     ],
     "stars": 13091,
     "lite": false,
-    "headline": "yapay zekâ ile unity yönetimi",
+    "headline": "Yapay zekâ ile unity yönetimi",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -7342,7 +7342,7 @@
     ],
     "stars": 23654,
     "lite": false,
-    "headline": "yapay zekâ kodlama ajanlarına uzmanlık kazandırın",
+    "headline": "Yapay zekâ kodlama ajanlarına uzmanlık kazandırın",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -7421,7 +7421,7 @@
     ],
     "stars": 42728,
     "lite": false,
-    "headline": "yapay zekâ ajanınıza pazarlama becerileri kazandırın",
+    "headline": "Yapay zekâ ajanınıza pazarlama becerileri kazandırın",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -7448,7 +7448,7 @@
     ],
     "stars": 17403,
     "lite": false,
-    "headline": "yapay zekâ ajanları için çalışma alanı yönetimi",
+    "headline": "Yapay zekâ ajanları için çalışma alanı yönetimi",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -7475,7 +7475,7 @@
     ],
     "stars": 19597,
     "lite": false,
-    "headline": "yapay zekâ kullanım limitlerini izleyin",
+    "headline": "Yapay zekâ kullanım limitlerini izleyin",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -7509,7 +7509,7 @@
     ],
     "stars": 13424,
     "lite": false,
-    "headline": "yapay zekâ ile video analizi",
+    "headline": "Yapay zekâ ile video analizi",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -7635,7 +7635,7 @@
     ],
     "stars": 25967,
     "lite": false,
-    "headline": "yapay zekâ ile ofis dosyalarını yönetin",
+    "headline": "Yapay zekâ ile ofis dosyalarını yönetin",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -7696,7 +7696,7 @@
     ],
     "stars": 15363,
     "lite": false,
-    "headline": "yapay zekâ ajanları için katmanlı bellek",
+    "headline": "Yapay zekâ ajanları için katmanlı bellek",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -7831,7 +7831,7 @@
     ],
     "stars": 9072,
     "lite": false,
-    "headline": "yapay zekâ ile bilgisayarınızı yönetin",
+    "headline": "Yapay zekâ ile bilgisayarınızı yönetin",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -7920,7 +7920,7 @@
     ],
     "stars": 105953,
     "lite": false,
-    "headline": "yapay zekâ için hazır tasarım dokümanları",
+    "headline": "Yapay zekâ için hazır tasarım dokümanları",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -8215,7 +8215,7 @@
     ],
     "stars": 8177,
     "lite": false,
-    "headline": "üç boyutlu ağları optimize edin",
+    "headline": "Üç boyutlu ağları optimize edin",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -8282,7 +8282,7 @@
     ],
     "stars": 7892,
     "lite": false,
-    "headline": "yapay zekâ ajanları için tasarım yetenekleri",
+    "headline": "Yapay zekâ ajanları için tasarım yetenekleri",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -8469,7 +8469,7 @@
     ],
     "stars": 33999,
     "lite": false,
-    "headline": "yapay zekâ ile otomatik diyagram oluşturma",
+    "headline": "Yapay zekâ ile otomatik diyagram oluşturma",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -8581,7 +8581,7 @@
     ],
     "stars": 5642,
     "lite": false,
-    "headline": "yapay zekâ ajanları için komut koruması",
+    "headline": "Yapay zekâ ajanları için komut koruması",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -8745,7 +8745,7 @@
     ],
     "stars": 62684,
     "lite": false,
-    "headline": "yatırım stratejileri için yapay zekâ ajanları",
+    "headline": "Yatırım stratejileri için yapay zekâ ajanları",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -8797,7 +8797,7 @@
     ],
     "stars": 22106,
     "lite": false,
-    "headline": "yapay zekâ tasarımlarına özgünlük kazandırın",
+    "headline": "Yapay zekâ tasarımlarına özgünlük kazandırın",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -8978,7 +8978,7 @@
     ],
     "stars": 7220,
     "lite": false,
-    "headline": "yapay zekâ ve mühendislik için kapsamlı rehber",
+    "headline": "Yapay zekâ ve mühendislik için kapsamlı rehber",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -9005,7 +9005,7 @@
     ],
     "stars": 67509,
     "lite": false,
-    "headline": "bilgisayarınızda kod çalıştıran yapay zekâ",
+    "headline": "Bilgisayarınızda kod çalıştıran yapay zekâ",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -9032,7 +9032,7 @@
     ],
     "stars": 32640,
     "lite": false,
-    "headline": "yapay zekâ destekli kişiselleştirilmiş eğitim",
+    "headline": "Yapay zekâ destekli kişiselleştirilmiş eğitim",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -9166,7 +9166,7 @@
     ],
     "stars": 81117,
     "lite": false,
-    "headline": "yapay zekâ ajanları ile operasyon yönetimi",
+    "headline": "Yapay zekâ ajanları ile operasyon yönetimi",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -9238,7 +9238,7 @@
     ],
     "stars": 1632,
     "lite": false,
-    "headline": "yapay zekâ ajanları için uygulamalı atölye",
+    "headline": "Yapay zekâ ajanları için uygulamalı atölye",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -9286,7 +9286,7 @@
     ],
     "stars": 28041,
     "lite": false,
-    "headline": "yapay zekâ kod incelemesinde token tasarrufu",
+    "headline": "Yapay zekâ kod incelemesinde token tasarrufu",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -9364,7 +9364,7 @@
     ],
     "stars": 4069,
     "lite": false,
-    "headline": "yapay zekâ ajanınıza yerel web yetenekleri",
+    "headline": "Yapay zekâ ajanınıza yerel web yetenekleri",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -9418,7 +9418,7 @@
     ],
     "stars": 33116,
     "lite": false,
-    "headline": "yapay zekâ ajanları için rehber",
+    "headline": "Yapay zekâ ajanları için rehber",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -9448,7 +9448,7 @@
     ],
     "stars": 19145,
     "lite": false,
-    "headline": "yapay zekâ modelleri için heterojen hızlandırma",
+    "headline": "Yapay zekâ modelleri için heterojen hızlandırma",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -9571,7 +9571,7 @@
     ],
     "stars": 17046,
     "lite": false,
-    "headline": "yapay zekâ ile otomatik iş zekâsı",
+    "headline": "Yapay zekâ ile otomatik iş zekâsı",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -9631,7 +9631,7 @@
     ],
     "stars": 27084,
     "lite": false,
-    "headline": "yapay zekâ için hızlı araç entegrasyonu",
+    "headline": "Yapay zekâ için hızlı araç entegrasyonu",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -9737,7 +9737,7 @@
     ],
     "stars": 1673,
     "lite": false,
-    "headline": "yerel sistemlerde hızlı konuşma dönüştürme",
+    "headline": "Yerel sistemlerde hızlı konuşma dönüştürme",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -9791,7 +9791,7 @@
     ],
     "stars": 17370,
     "lite": false,
-    "headline": "yapay zekâ yanıtlarını odaklı hale getirin",
+    "headline": "Yapay zekâ yanıtlarını odaklı hale getirin",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -9823,7 +9823,7 @@
     ],
     "stars": 12478,
     "lite": false,
-    "headline": "yapay zekâ ile otomatik tasarım",
+    "headline": "Yapay zekâ ile otomatik tasarım",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -9868,7 +9868,7 @@
     ],
     "stars": 31111,
     "lite": false,
-    "headline": "donanımınıza uygun yapay zekâ modellerini bulun",
+    "headline": "Donanımınıza uygun yapay zekâ modellerini bulun",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -10058,7 +10058,7 @@
     ],
     "stars": 15477,
     "lite": false,
-    "headline": "yapay zekâ çıktılarını yapılandırın",
+    "headline": "Yapay zekâ çıktılarını yapılandırın",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -10084,7 +10084,7 @@
     ],
     "stars": 5328,
     "lite": false,
-    "headline": "yazılım mimarinizi canlı diyagramlarla görselleştirin",
+    "headline": "Yazılım mimarinizi canlı diyagramlarla görselleştirin",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -10224,7 +10224,7 @@
     ],
     "stars": 8875,
     "lite": false,
-    "headline": "yapay zekâ ajanları için eş zamanlı tarayıcı",
+    "headline": "Yapay zekâ ajanları için eş zamanlı tarayıcı",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -10258,7 +10258,7 @@
     ],
     "stars": 19239,
     "lite": false,
-    "headline": "yapay zekâ destekli hassas kod inceleme",
+    "headline": "Yapay zekâ destekli hassas kod inceleme",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -10380,7 +10380,7 @@
     ],
     "stars": 27657,
     "lite": false,
-    "headline": "yapay zekâ destekli veritabanı yönetimi",
+    "headline": "Yapay zekâ destekli veritabanı yönetimi",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -10676,7 +10676,7 @@
     ],
     "stars": 20706,
     "lite": false,
-    "headline": "web tabanlı 3 boyutlu mimari düzenleyici",
+    "headline": "Web tabanlı 3 boyutlu mimari düzenleyici",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -10702,7 +10702,7 @@
     ],
     "stars": 1684,
     "lite": false,
-    "headline": "yerel borsa verisi ve analiz motoru",
+    "headline": "Yerel borsa verisi ve analiz motoru",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -10856,7 +10856,7 @@
     ],
     "stars": 14677,
     "lite": false,
-    "headline": "kurumsal varlık ve lisans yönetimi",
+    "headline": "Kurumsal varlık ve lisans yönetimi",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -10913,7 +10913,7 @@
     ],
     "stars": 21196,
     "lite": false,
-    "headline": "yapay zekâ iş akışlarını paylaşın",
+    "headline": "Yapay zekâ iş akışlarını paylaşın",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {
@@ -11147,7 +11147,7 @@
     ],
     "stars": 5281,
     "lite": false,
-    "headline": "donanım analizi için çok protokollü araç",
+    "headline": "Donanım analizi için çok protokollü araç",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -11301,7 +11301,7 @@
     ],
     "stars": 6780,
     "lite": false,
-    "headline": "yapay zekâ ajanınıza yerel yetenekler kazandırın",
+    "headline": "Yapay zekâ ajanınıza yerel yetenekler kazandırın",
     "last_review": "2026-08-06",
     "tagline_en": "NomaDamas/k-skill is a platform designed to provide AI agents with local skills in a cultural context."
   },
@@ -11456,7 +11456,7 @@
     ],
     "stars": 44150,
     "lite": false,
-    "headline": "yapay zekâ ajanlarına ücretsiz erişim",
+    "headline": "Yapay zekâ ajanlarına ücretsiz erişim",
     "last_review": "2026-08-06",
     "tagline_en": "Terminals, applications for artificial intelligence models such as free-claude-code, Claude Code and Codex developed by Alishahryar1…"
   },
@@ -11662,7 +11662,7 @@
     ],
     "stars": 3677,
     "lite": false,
-    "headline": "yapay zekâ ajanlarına bilgisayar kontrolü",
+    "headline": "Yapay zekâ ajanlarına bilgisayar kontrolü",
     "needs_enrichment": true,
     "enrich_reason": "komutsuz",
     "last_review": "2026-08-06",
@@ -11682,7 +11682,7 @@
     ],
     "stars": 2399,
     "lite": false,
-    "headline": "yapay zekâ ajanları için kalıcı hafıza",
+    "headline": "Yapay zekâ ajanları için kalıcı hafıza",
     "last_review": "2026-08-06",
     "guncellemeler": [
       {

--- a/discover/agency-agents/index.html
+++ b/discover/agency-agents/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agency Agents</span><span class="disc-momentum">🚀 +1.599 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanlarıyla dijital ajans kurun</h1>
+<h1 class="disc-title">Yapay zekâ ajanlarıyla dijital ajans kurun</h1>
 <p class="disc-lead">Agency-agents projesi, farklı uzmanlık alanlarına sahip yapay zekâ ajanlarını bir araya getirerek dijital bir ajans yapısı oluşturuyor. Yazılım geliştirme, içerik üretimi ve veri doğrulama gibi süreçleri özelleşmiş karakterler ve iş akışları üzerinden yönetmeyi sağlıyor.</p>
 <ul class="disc-meta"><li>★ 138.170</li><li>Shell</li><li>GitHub Trending · 2026-06-12</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 111.887 → 138.170.</li></ul></section>

--- a/discover/agent-native/index.html
+++ b/discover/agent-native/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agent Native</span><span class="disc-momentum">🚀 +147 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanları için uygulama çerçevesi</h1>
+<h1 class="disc-title">Yapay zekâ ajanları için uygulama çerçevesi</h1>
 <p class="disc-lead">BuilderIO tarafından geliştirilen agent-native, yapay zekâ ajanları için yerel uygulamalar (agent-native applications) oluşturmaya odaklanan bir TypeScript çerçevesidir (framework). Geliştiricilerin ajan tabanlı iş akışlarını doğrudan uygulama mimarisine entegre etmelerini sağlar.</p>
 <ul class="disc-meta"><li>★ 4.419</li><li>TypeScript</li><li>GitHub Trending · 2026-06-20</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 4.397 → 4.419, son sürüm @agent-native/skills@0.2.490 (6 Ağustos 2026).</li><li><strong>4 Ağustos 2026:</strong> Yıldız 4.381 → 4.397, son sürüm @agent-native/core@0.136.4 (4 Ağustos 2026).</li><li><strong>3 Ağustos 2026:</strong> Yıldız 4.374 → 4.381, son sürüm @agent-native/core@0.134.0 (3 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 1.138 → 4.374, son sürüm @agent-native/skills@0.2.457 (2 Ağustos 2026).</li></ul></section>

--- a/discover/agent-skills/index.html
+++ b/discover/agent-skills/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agent Skills</span><span class="disc-momentum">🚀 +443 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanlarına mühendislik yeteneği kazandırın</h1>
+<h1 class="disc-title">Yapay zekâ ajanlarına mühendislik yeteneği kazandırın</h1>
 <p class="disc-lead">Yapay zekâ kodlama ajanları için geliştirilen bu kütüphane, üretim seviyesinde mühendislik yetenekleri (engineering skills) sunuyor. Yazılım geliştirme süreçlerini otomatize eden ajanların teknik kapasitesini artırmak için standartlaştırılmış araçlar sağlıyor.</p>
 <ul class="disc-meta"><li>★ 81.505</li><li>Shell</li><li>GitHub Trending · 2026-06-10</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>4 Ağustos 2026:</strong> Yıldız 81.328 → 81.505, son sürüm 0.6.6 (4 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 50.041 → 81.328, son sürüm 0.6.5 (26 Temmuz 2026).</li></ul></section>

--- a/discover/agent-toolkit-for-aws/index.html
+++ b/discover/agent-toolkit-for-aws/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agent Toolkit for Aws</span><span class="disc-momentum">🚀 +47 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanları için AWS araç seti</h1>
+<h1 class="disc-title">Yapay zekâ ajanları için AWS araç seti</h1>
 <p class="disc-lead">AWS, yapay zekâ ajanlarının bulut altyapısıyla etkileşimini kolaylaştırmak için Model Bağlantı Protokolü (Model Context Protocol) sunucuları, yetenekler (skills) ve eklentiler içeren bir araç seti yayımladı. Bu geliştirme, ajanların AWS servisleri üzerinde doğrudan işlem yapabilmesini sağlayan standartlaştırılmış bir yapı sunuyor.</p>
 <ul class="disc-meta"><li>★ 2.215</li><li>Python</li><li>GitHub Trending · 2026-06-26</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>4 Ağustos 2026:</strong> Yıldız 1.209 → 2.215.</li></ul></section>

--- a/discover/agentskills/index.html
+++ b/discover/agentskills/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agentskills</span><span class="disc-momentum">🚀 +86 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanlarına standart yetenekler kazandırın</h1>
+<h1 class="disc-title">Yapay zekâ ajanlarına standart yetenekler kazandırın</h1>
 <p class="disc-lead">Agent Skills, yapay zekâ ajanlarının görevlerini yerine getirirken kullandığı yetenekleri (skills) standartlaştıran bir teknik şartname ve dokümantasyon projesidir. Python tabanlı bu yapı, farklı ajan sistemleri arasında yetenek paylaşımını ve birlikte çalışabilirliği (interoperability) kolaylaştırmayı amaçlar.</p>
 <ul class="disc-meta"><li>★ 23.755</li><li>Python</li><li>GitHub Trending · 2026-07-03</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 21.721 → 23.755.</li></ul></section>

--- a/discover/ai-agent-book/index.html
+++ b/discover/ai-agent-book/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Agent Book</span><span class="disc-momentum">🚀 +1.734 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanları için rehber</h1>
+<h1 class="disc-title">Yapay zekâ ajanları için rehber</h1>
 <p class="disc-lead">Yapay zekâ ajanları (AI agents) üzerine hazırlanan bu açık kaynaklı kitap, tasarım prensipleri ve mühendislik uygulamalarını kapsamlı bir şekilde ele alıyor. İçeriğinde teorik bilgilerin yanı sıra bölümlere ayrılmış uygulama kodları ve derlenmiş PDF dosyaları yer alıyor.</p>
 <ul class="disc-meta"><li>★ 33.116</li><li>Python</li><li>GitHub Trending · 2026-07-20</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 29.814 → 33.116.</li><li><strong>2 Ağustos 2026:</strong> Yıldız 7.362 → 29.814.</li></ul></section>

--- a/discover/ai-berkshire/index.html
+++ b/discover/ai-berkshire/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Berkshire</span><span class="disc-momentum">🚀 +309 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile değer yatırımı araştırması</h1>
+<h1 class="disc-title">Yapay zekâ ile değer yatırımı araştırması</h1>
 <p class="disc-lead">AI-berkshire, Claude Code altyapısını kullanarak Warren Buffett ve Charlie Munger gibi yatırımcıların metodolojilerini uygulayan bir değer yatırımı araştırma çerçevesidir (research framework). Sistem, çoklu yapay zekâ ajanı (multi-agent) yapısıyla finansal verileri analiz ederek karşıt görüşlü incelemeler yürütmektedir.</p>
 <ul class="disc-meta"><li>★ 14.888</li><li>Python</li><li>GitHub Trending · 2026-06-26</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 2.500 → 14.888, son sürüm v1.0.0 (7 Nisan 2026).</li></ul></section>

--- a/discover/ai-hedge-fund/index.html
+++ b/discover/ai-hedge-fund/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Hedge Fund</span><span class="disc-momentum">🚀 +115 bugün</span></div>
-<h1 class="disc-title">yatırım stratejileri için yapay zekâ ajanları</h1>
+<h1 class="disc-title">Yatırım stratejileri için yapay zekâ ajanları</h1>
 <p class="disc-lead">Yapay zekâ destekli yatırım fonu (AI hedge fund), finansal piyasa analizi ve varlık yönetimi süreçlerini otomatize etmek için otonom ajanlar kullanıyor. Python tabanlı bu proje, piyasa verilerini işleyerek yatırım stratejileri geliştiren bir yapay zekâ ekibi (AI team) modeli sunuyor.</p>
 <ul class="disc-meta"><li>★ 62.684</li><li>Python</li><li>GitHub Trending · 2026-07-13</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 62.606 → 62.684, son sürüm v2.1.0 (4 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 61.500 → 62.606, son sürüm v2.0.2 (30 Temmuz 2026).</li></ul></section>

--- a/discover/ai-website-cloner-template/index.html
+++ b/discover/ai-website-cloner-template/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Website Cloner Template</span><span class="disc-momentum">🚀 +100 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile web sitesi kopyalama</h1>
+<h1 class="disc-title">Yapay zekâ ile web sitesi kopyalama</h1>
 <p class="disc-lead">JCodesMore tarafından geliştirilen yapay zekâ web sitesi kopyalayıcı (AI website cloner), TypeScript tabanlı kodlama ajanlarını kullanarak tek komutla mevcut web sitelerinin kopyalanmasını sağlıyor. Bu araç, web tasarımı ve geliştirme süreçlerini otomatize etmek için yapay zekâ destekli kod oluşturma (AI-powered code generation) yönteminden yararlanıyor.</p>
 <ul class="disc-meta"><li>★ 30.826</li><li>TypeScript</li><li>GitHub Trending · 2026-06-23</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 18.039 → 30.826, son sürüm v0.3.1 (30 Mart 2026).</li></ul></section>

--- a/discover/aisuite/index.html
+++ b/discover/aisuite/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Aisuite</span><span class="disc-momentum">🚀 +127 bugün</span></div>
-<h1 class="disc-title">yapay zekâ modellerini tek arayüzde yönetin</h1>
+<h1 class="disc-title">Yapay zekâ modellerini tek arayüzde yönetin</h1>
 <p class="disc-lead">Andrew Ng tarafından geliştirilen aisuite, farklı üretken yapay zekâ (generative AI) sağlayıcılarını tek bir arayüz üzerinden yönetmeyi sağlayan bir Python kütüphanesidir. Geliştiricilerin çeşitli model servisleri arasında kod değişikliği yapmadan geçiş yapmasına olanak tanır.</p>
 <ul class="disc-meta"><li>★ 15.888</li><li>Python</li><li>GitHub Trending · 2026-06-14</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 14.220 → 15.888, son sürüm v0.1.3 (20 Temmuz 2026).</li></ul></section>

--- a/discover/aitoearn/index.html
+++ b/discover/aitoearn/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AiToEarn</span><span class="disc-momentum">🚀 +183 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile gelir yönetimi</h1>
+<h1 class="disc-title">Yapay zekâ ile gelir yönetimi</h1>
 <p class="disc-lead">AiToEarn, kullanıcıların yapay zekâ destekli otomasyonlar aracılığıyla gelir elde etme süreçlerini yönetmelerini sağlayan bir TypeScript tabanlı platformdur. Proje, otonom görev yürütme ve yapay zekâ tabanlı kazanç modellerini (AI-driven earning models) bir araya getirerek geliştiricilere açık bir altyapı sunuyor.</p>
 <ul class="disc-meta"><li>★ 24.551</li><li>TypeScript</li><li>GitHub Trending · 2026-06-08</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 19.145 → 24.551, son sürüm v2.5.0 (24 Haziran 2026).</li></ul></section>

--- a/discover/amnezia-client/index.html
+++ b/discover/amnezia-client/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Amnezia Client</span><span class="disc-momentum">🚀 +35 bugün</span></div>
-<h1 class="disc-title">Kendi sunucunuzda kişisel yapay zekâ destekli VPN</h1>
+<h1 class="disc-title">Kendi sunucunuzda kişisel VPN istemcisi</h1>
 <p class="disc-lead">Amnezia VPN istemcisi, kullanıcıların kendi sunucuları üzerinden sansürsüz internet erişimi sağlamasına olanak tanıyan açık kaynaklı bir ağ aracıdır. C++ diliyle geliştirilen bu yazılım, masaüstü ve mobil platformlarda kişisel gizliliği koruyan özelleştirilebilir tünelleme protokolleri sunar.</p>
 <ul class="disc-meta"><li>★ 14.262</li><li>C++</li><li>GitHub Trending · 2026-07-27</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 13.457 → 14.262, son sürüm 5.0.0.5 (26 Temmuz 2026).</li></ul></section>

--- a/discover/anthropic-cybersecurity-skills/index.html
+++ b/discover/anthropic-cybersecurity-skills/index.html
@@ -59,7 +59,7 @@
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
       <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Anthropic Cybersecurity Skills</span><span class="disc-momentum">🚀 Bir günde +871 yıldız</span></div>
-      <h1 class="disc-title">yapay zekâ için siber güvenlik becerileri</h1>
+      <h1 class="disc-title">Yapay zekâ için siber güvenlik becerileri</h1>
       <p class="disc-lead">Yapay zekâ ajanları için geliştirilmiş <strong>754 hazır siber güvenlik becerisi</strong>; 26 farklı güvenlik alanını kapsar ve MITRE ATT&CK, NIST CSF, MITRE ATLAS gibi 5 temel çerçeveyle eşlenir. Claude Code, GitHub Copilot, Codex, Cursor ve Gemini CLI gibi 20'den fazla platformda çalışır. <strong>(İsmine rağmen Anthropic'in resmi projesi değildir, bağımsız bir topluluk çalışmasıdır.)</strong></p>
       <ul class="disc-meta"><li>★ 27.085</li><li>Python</li><li>Apache-2.0</li><li>GitHub Trending · 26 May 2026</li></ul>
             <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>1 Ağustos 2026:</strong> Yıldız 9.924 → 27.085, son sürüm v1.3.0 (22 Haziran 2026).</li></ul></section>

--- a/discover/aspnetcore/index.html
+++ b/discover/aspnetcore/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Aspnetcore</span></div>
-<h1 class="disc-title">Modern web uygulamaları için yapay zekâ destekli çerçeve</h1>
+<h1 class="disc-title">Kurumsal web uygulamaları için platform</h1>
 <p class="disc-lead">ASP.NET Core, Windows, macOS ve Linux üzerinde modern bulut tabanlı web uygulamaları geliştirmek için kullanılan platformlar arası bir .NET çerçevesidir (framework). C# diliyle geliştirilen bu yapı, yüksek performanslı ve ölçeklenebilir web hizmetleri oluşturmaya olanak tanır.</p>
 <ul class="disc-meta"><li>★ 38.339</li><li>GitHub Trending · 2026-06-19</li></ul>
       <aside class="disc-note"><p><strong>TreScout notu:</strong> Microsoft&#x27;un web uygulaması geliştirme altyapısı. Windows&#x27;a bağlı olduğu algısı eskidir, Linux&#x27;ta da sorunsuz çalışır. Kurumsal işlerde güçlüdür: Kullanıcı girişi, veri tabanı erişimi ve izleme için hazır parçalar kutudan çıkar. C# dilini bilmiyorsanız öğrenme maliyeti yüksektir, küçük bir iş için ağır kalır.</p></aside>

--- a/discover/awesome-artificial-intelligence/index.html
+++ b/discover/awesome-artificial-intelligence/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Artificial Intelligence</span><span class="disc-momentum">🚀 +40 bugün</span></div>
-<h1 class="disc-title">yapay zekâ geliştirme için temel kaynaklar</h1>
+<h1 class="disc-title">Yapay zekâ geliştirme için temel kaynaklar</h1>
 <p class="disc-lead">Awesome-artificial-intelligence, yapay zekâ (artificial intelligence) alanındaki eğitimleri, kitapları, video dersleri ve akademik makaleleri bir araya getiren kapsamlı bir kaynak listesidir. Bu derleme, öğrenme sürecindeki kullanıcılar için disipline dayalı yapılandırılmış bir içerik havuzu sunar.</p>
 <ul class="disc-meta"><li>★ 15.631</li><li>GitHub Trending · 2026-06-19</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 14.532 → 15.631.</li></ul></section>

--- a/discover/babysitter/index.html
+++ b/discover/babysitter/index.html
@@ -59,7 +59,7 @@
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
       <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Babysitter</span><span class="disc-momentum">🚀 Bir günde +58 yıldız</span></div>
-      <h1 class="disc-title">yapay zekâ ajanlarınızı hatasız yönetin</h1>
+      <h1 class="disc-title">Yapay zekâ ajanlarınızı hatasız yönetin</h1>
       <p class="disc-lead"><strong>Babysitter</strong>, yapay zekâ ajanlarından oluşan iş gücünün karmaşık görevleri <strong>hatasız ve halüsinasyonsuz</strong> bir şekilde yürütebilmesi için deterministik bir denetim mekanizması sunar.</p>
       <ul class="disc-meta"><li>★ 1.632</li><li>JavaScript</li><li>MIT</li><li>GitHub Trending · 1 Haziran 2026</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 1.101 → 1.632, son sürüm v0.0.188 (26 Haziran 2026).</li></ul></section>

--- a/discover/buzz/index.html
+++ b/discover/buzz/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Buzz</span><span class="disc-momentum">🚀 +2.162 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanlarıyla ortak çalışma alanı</h1>
+<h1 class="disc-title">Merkeziyetsiz kovan zihni iletişim platformu</h1>
 <p class="disc-lead">Block tarafından Rust diliyle geliştirilen Buzz, merkeziyetsiz bir kovan zihni iletişim platformu (hive mind communication platform) olarak tasarlanmıştır. Dağıtık ağ yapısı üzerinden kolektif veri paylaşımını ve eş zamanlı etkileşimi destekleyen bir altyapı sunar.</p>
 <ul class="disc-meta"><li>★ 23.428</li><li>Rust</li><li>GitHub Trending · 2026-07-24</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 22.004 → 23.428, son sürüm desktop-v0.5.5 (5 Ağustos 2026).</li><li><strong>4 Ağustos 2026:</strong> Yıldız 20.906 → 22.004, son sürüm desktop-v0.5.4 (3 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 7.593 → 20.906, son sürüm desktop-v0.5.3 (31 Temmuz 2026).</li></ul></section>

--- a/discover/career-ops/index.html
+++ b/discover/career-ops/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Career Ops</span><span class="disc-momentum">🚀 +193 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile kariyerinizi yönetin</h1>
+<h1 class="disc-title">Yapay zekâ ile kariyerinizi yönetin</h1>
 <p class="disc-lead">Claude Code altyapısını kullanan career-ops, yapay zekâ destekli iş arama süreçlerini 14 farklı yetenek moduyla otomatikleştiriyor. Sistem, Go tabanlı bir kontrol paneli üzerinden toplu işlem yönetimi ve özgeçmiş oluşturma gibi işlevleri tek bir merkezde topluyor.</p>
 <ul class="disc-meta"><li>★ 62.979</li><li>JavaScript</li><li>GitHub Trending · 2026-06-07</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 62.526 → 62.979, son sürüm career-ops-v1.25.0 (4 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 49.580 → 62.526, son sürüm career-ops-v1.24.0 (30 Temmuz 2026).</li></ul></section>

--- a/discover/chat2db/index.html
+++ b/discover/chat2db/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Chat2DB</span><span class="disc-momentum">🚀 +82 bugün</span></div>
-<h1 class="disc-title">yapay zekâ destekli veritabanı yönetimi</h1>
+<h1 class="disc-title">Yapay zekâ destekli veritabanı yönetimi</h1>
 <p class="disc-lead">Chat2DB, yapay zekâ destekli bir veritabanı yönetim aracı ve SQL istemcisi (SQL client) olarak öne çıkıyor. Java ile geliştirilen bu platform, MySQL, PostgreSQL ve Oracle gibi çok sayıda veritabanı sistemini tek bir grafik kullanıcı arayüzü (GUI) üzerinden yönetme imkânı sağlıyor.</p>
 <ul class="disc-meta"><li>★ 27.657</li><li>Java</li><li>GitHub Trending · 2026-07-25</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 27.604 → 27.657, son sürüm v5.3.3 (6 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 26.409 → 27.604, son sürüm v5.3.2 (28 Temmuz 2026).</li></ul></section>

--- a/discover/chinatextbook/index.html
+++ b/discover/chinatextbook/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · ChinaTextbook</span><span class="disc-momentum">🚀 +350 bugün</span></div>
-<h1 class="disc-title">Çin eğitim müfredatına yapay zekâ ile erişin</h1>
+<h1 class="disc-title">Çin eğitim müfredatı ve ders kitapları</h1>
 <p class="disc-lead">ChinaTextbook deposu, ilkokuldan üniversite seviyesine kadar Çin eğitim müfredatında kullanılan ders kitaplarının taşınabilir belge formatındaki (PDF) dijital arşivini sunuyor. Bu kaynak, geniş kapsamlı akademik materyallere merkezi bir erişim noktası sağlıyor.</p>
 <ul class="disc-meta"><li>★ 76.412</li><li>Roff</li><li>GitHub Trending · 2026-06-08</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>3 Ağustos 2026:</strong> Yıldız 72.765 → 76.412.</li></ul></section>

--- a/discover/chrome-devtools-mcp/index.html
+++ b/discover/chrome-devtools-mcp/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Chrome Devtools MCP</span><span class="disc-momentum">🚀 +104 bugün</span></div>
-<h1 class="disc-title">yapay zekâ için tarayıcı hata ayıklama</h1>
+<h1 class="disc-title">Yapay zekâ için tarayıcı hata ayıklama</h1>
 <p class="disc-lead">Chrome Geliştirici Araçları (Chrome DevTools) için geliştirilen bu sunucu, kodlama yapan yapay zekâ ajanlarının (coding agents) tarayıcı tabanlı hata ayıklama süreçlerini yönetmesini sağlıyor. Model Bağlam Protokolü (Model Context Protocol) üzerinden çalışan bu araç, ajanların web uygulamalarını doğrudan incelemesine ve hata giderme işlemlerini otomatize etmesine olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 48.381</li><li>TypeScript</li><li>GitHub Trending · 2026-07-03</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 45.204 → 48.381, son sürüm chrome-devtools-mcp-v1.6.0 (14 Temmuz 2026).</li></ul></section>

--- a/discover/claude-mem/index.html
+++ b/discover/claude-mem/index.html
@@ -59,7 +59,7 @@
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
       <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · claude-mem</span><span class="disc-momentum">🚀 Bir günde +319 yıldız</span></div>
-      <h1 class="disc-title">yapay zekâ Ajanınıza Kalıcı Hafıza Kazandırın</h1>
+      <h1 class="disc-title">Yapay zekâ Ajanınıza Kalıcı Hafıza Kazandırın</h1>
       <p class="disc-lead"><strong>claude-mem</strong>, AI ajanlarınızın <strong>oturumlar arası hatırlama</strong> yapabilmesini sağlar. Bir oturumda gerçekleşen her şeyi yakalar, AI ile anlamlı özetlere dönüştürür ve sonraki oturumda ilgili bağlamı geri sunar. Claude Code, Codex, Gemini, Copilot ve OpenCode ile uyumludur.</p>
       <figure class="disc-shot"><img src="/assets/discover/claude-mem.webp" width="640" height="360" loading="lazy" decoding="async" alt="claude-mem arayüzünden bir görünüm"><figcaption>Görsel: claude-mem (proje deposundan)</figcaption></figure>
       <ul class="disc-meta"><li>★ 89.464</li><li>TypeScript</li><li>Apache-2.0</li><li>GitHub Trending · 26 May 2026</li></ul>

--- a/discover/claude-video/index.html
+++ b/discover/claude-video/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Video</span><span class="disc-momentum">🚀 +427 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile video analizi</h1>
+<h1 class="disc-title">Yapay zekâ ile video analizi</h1>
 <p class="disc-lead">Claude-video, Claude modeline video içeriğini analiz etme yeteneği kazandıran bir Python aracıdır. Yazılım, videoları indirip karelere ayırarak ve metne dönüştürerek (transcription) görsel veriyi yapay zekâ modelinin işleyebileceği formata getirir.</p>
 <ul class="disc-meta"><li>★ 13.424</li><li>Python</li><li>GitHub Trending · 2026-07-07</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 4.554 → 13.424, son sürüm v0.2.0 (1 Temmuz 2026).</li></ul></section>

--- a/discover/clypra/index.html
+++ b/discover/clypra/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Clypra</span><span class="disc-momentum">🚀 +85 bugün</span></div>
-<h1 class="disc-title">açık kaynak profesyonel yapay zekâ video düzenleyici</h1>
+<h1 class="disc-title">Açık kaynaklı masaüstü video düzenleyici</h1>
 <p class="disc-lead">Clypra, Tauri, React ve TypeScript kullanılarak geliştirilen açık kaynak kodlu bir video düzenleyici (video editor) uygulamasıdır. Yazılım, ücretli video düzenleme araçlarında bulunan gelişmiş özellikleri ücretsiz bir alternatif olarak sunmayı hedefler.</p>
 <ul class="disc-meta"><li>★ 2.965</li><li>TypeScript</li><li>GitHub Trending · 2026-07-15</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 2.952 → 2.965, son sürüm v1.2.2 (6 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 2.729 → 2.952, son sürüm v1.2.1 (30 Temmuz 2026).</li></ul></section>

--- a/discover/code-review-graph/index.html
+++ b/discover/code-review-graph/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Code Review Graph</span><span class="disc-momentum">🚀 +74 bugün</span></div>
-<h1 class="disc-title">yapay zekâ kod incelemesinde token tasarrufu</h1>
+<h1 class="disc-title">Yapay zekâ kod incelemesinde token tasarrufu</h1>
 <p class="disc-lead">Code-review-graph, kod tabanını analiz ederek yapay zekâ araçları için yerel odaklı bir kod zekası haritası (code intelligence graph) oluşturuyor. Bu yapı, büyük projelerde bağlam azaltma (context reduction) yöntemlerini kullanarak yapay zekâ destekli kod inceleme süreçlerini daha verimli hale getiriyor.</p>
 <ul class="disc-meta"><li>★ 28.041</li><li>Python</li><li>GitHub Trending · 2026-07-18</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 19.852 → 28.041, son sürüm v2.3.7 (18 Temmuz 2026).</li></ul></section>

--- a/discover/compound-engineering-plugin/index.html
+++ b/discover/compound-engineering-plugin/index.html
@@ -59,7 +59,7 @@
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
       <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Compound Engineering</span><span class="disc-momentum">🚀 Bir günde +184 yıldız</span></div>
-      <h1 class="disc-title">yapay zekâ Destekli Mühendislik Süreçleri</h1>
+      <h1 class="disc-title">Yapay zekâ Destekli Mühendislik Süreçleri</h1>
       <p class="disc-lead"><strong>Compound Engineering</strong>; Claude Code, Codex ve Cursor için geliştirilmiş resmi bir eklentidir. Temel felsefesi nettir: <strong>her mühendislik işi bir sonrakini zorlaştırmamalı, aksine kolaylaştırmalıdır.</strong> Bu amaçla, geliştirme sürecini iyileştiren yapay zekâ becerileri ve ajanları sunar.</p>
       <ul class="disc-meta"><li>★ 24.046</li><li>TypeScript</li><li>MIT</li><li>GitHub Trending · 29 May 2026</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 24.041 → 24.046, son sürüm compound-engineering-v3.21.4 (6 Ağustos 2026).</li><li><strong>6 Ağustos 2026:</strong> Yıldız 23.748 → 24.041, son sürüm compound-engineering-v3.21.3 (5 Ağustos 2026).</li><li><strong>4 Ağustos 2026:</strong> Yıldız 23.700 → 23.748, son sürüm compound-engineering-v3.21.1 (4 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 17.931 → 23.700, son sürüm compound-engineering-v3.21.0 (31 Temmuz 2026).</li></ul></section>

--- a/discover/council-of-high-intelligence/index.html
+++ b/discover/council-of-high-intelligence/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Council of High Intelligence</span><span class="disc-momentum">🚀 +331 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile çok yönlü karar verme</h1>
+<h1 class="disc-title">Yapay zekâ ile çok yönlü karar verme</h1>
 <p class="disc-lead">Council of High Intelligence, farklı büyük dil modellerini (large language models) kullanarak çeşitli uzman kişilikler üzerinden yapılandırılmış karar verme süreçleri yürütüyor. Sistem, karmaşık problemleri çok turlu tartışmalarla analiz ederek farklı yapay zekâ modellerinin bakış açılarını birleştiriyor.</p>
 <ul class="disc-meta"><li>★ 3.808</li><li>Shell</li><li>GitHub Trending · 2026-06-30</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 2.176 → 3.808, son sürüm v1.2.0 (4 Temmuz 2026).</li></ul></section>

--- a/discover/cs249r-book/index.html
+++ b/discover/cs249r-book/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cs249r Book</span><span class="disc-momentum">🚀 +68 bugün</span></div>
-<h1 class="disc-title">yapay zekâ sistemleri için kapsamlı rehber</h1>
+<h1 class="disc-title">Yapay zekâ sistemleri için kapsamlı rehber</h1>
 <p class="disc-lead">Harvard Üniversitesi tarafından paylaşılan bu kaynak, makine öğrenmesi sistemleri (machine learning systems) üzerine kapsamlı bir teknik rehber sunuyor. Donanım ve yazılım katmanlarını birleştiren bu çalışma, ölçeklenebilir yapay zekâ altyapılarının tasarım süreçlerini ele alıyor.</p>
 <ul class="disc-meta"><li>★ 27.689</li><li>Python</li><li>GitHub Trending · 2026-07-03</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 25.784 → 27.689, son sürüm tinytorch-v0.1.13 (24 Haziran 2026).</li></ul></section>

--- a/discover/cubesandbox/index.html
+++ b/discover/cubesandbox/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · CubeSandbox</span><span class="disc-momentum">🚀 +79 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanları için güvenli çalışma ortamı</h1>
+<h1 class="disc-title">Yapay zekâ ajanları için güvenli çalışma ortamı</h1>
 <p class="disc-lead">TencentCloud tarafından Rust diliyle geliştirilen CubeSandbox, yapay zekâ ajanları (AI agents) için anlık, eş zamanlı ve güvenli bir çalışma ortamı (sandbox) sunuyor. Hafif yapısıyla dikkat çeken bu araç, ajan tabanlı sistemlerin yalıtılmış bir alanda çalışmasını sağlıyor.</p>
 <ul class="disc-meta"><li>★ 10.828</li><li>Rust</li><li>GitHub Trending · 2026-07-02</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 6.927 → 10.828, son sürüm v0.6.0 (24 Temmuz 2026).</li></ul></section>

--- a/discover/daily-stock-analysis/index.html
+++ b/discover/daily-stock-analysis/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Daily Stock Analysis</span><span class="disc-momentum">🚀 +568 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile otomatik borsa analizi</h1>
+<h1 class="disc-title">Yapay zekâ ile otomatik borsa analizi</h1>
 <p class="disc-lead">Büyük dil modelleri (large language models) ile desteklenen bu sistem, çok kaynaklı piyasa verilerini ve gerçek zamanlı haberleri analiz ederek yatırım kararları için görselleştirilmiş paneller sunuyor. Otomatik bildirimler ve ücretsiz zamanlanmış çalışma desteğiyle farklı borsalar için analiz süreçlerini standartlaştırıyor.</p>
 <ul class="disc-meta"><li>★ 59.863</li><li>Python</li><li>GitHub Trending · 2026-06-22</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 45.304 → 59.863, son sürüm v3.29.0 (2 Ağustos 2026).</li></ul></section>

--- a/discover/desktopcommandermcp/index.html
+++ b/discover/desktopcommandermcp/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · DesktopCommanderMCP</span><span class="disc-momentum">🚀 +28 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile bilgisayarınızı yönetin</h1>
+<h1 class="disc-title">Yapay zekâ ile bilgisayarınızı yönetin</h1>
 <p class="disc-lead">DesktopCommanderMCP, Claude için geliştirilen ve yapay zekâ modeline uçbirim denetimi (terminal control), dosya sistemi araması ve fark tabanlı dosya düzenleme (diff file editing) yetenekleri kazandıran bir Model Bağlantı Protokolü (Model Context Protocol) sunucusudur. TypeScript ile yazılan bu araç, yapay zekânın yerel dosya sistemleri üzerinde doğrudan işlem yapabilmesini sağlar.</p>
 <ul class="disc-meta"><li>★ 9.072</li><li>TypeScript</li><li>GitHub Trending · 2026-07-09</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 6.436 → 9.072, son sürüm v0.2.44 (9 Temmuz 2026).</li></ul></section>

--- a/discover/ecc/index.html
+++ b/discover/ecc/index.html
@@ -59,7 +59,7 @@
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
       <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · ECC</span><span class="disc-momentum">🚀 Bir günde +1.912 yıldız</span></div>
-      <h1 class="disc-title">yapay zekâ Ajanlarınıza Güç Katın</h1>
+      <h1 class="disc-title">Yapay zekâ Ajanlarınıza Güç Katın</h1>
       <p class="disc-lead">ECC; Claude Code, Codex, Cursor ve OpenCode gibi yapay zekâ kodlama araçlarına <strong>beceriler, içgüdüler, hafıza optimizasyonu ve güvenlik taraması</strong> kazandıran kapsamlı bir sistemdir. Tekil konfigürasyon dosyaları yerine, ajanın daha tutarlı, güvenli ve önce-araştır mantığıyla çalışmasını sağlayan hazır bir katman sunar.</p>
       <figure class="disc-shot"><img src="/assets/discover/ecc.webp" width="1440" height="810" loading="lazy" decoding="async" alt="ECC arayüzünden bir görünüm"><figcaption>Görsel: ECC (proje deposundan)</figcaption></figure>
       <ul class="disc-meta"><li>★ 236.779</li><li>JavaScript</li><li>MIT</li><li>GitHub Trending · 26 May 2026</li></ul>

--- a/discover/editor/index.html
+++ b/discover/editor/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Editor</span><span class="disc-momentum">🚀 +341 bugün</span></div>
-<h1 class="disc-title">web tabanlı 3 boyutlu mimari düzenleyici</h1>
+<h1 class="disc-title">Web tabanlı 3 boyutlu mimari düzenleyici</h1>
 <p class="disc-lead">TypeScript tabanlı pascalorg/editor, kullanıcıların tarayıcı üzerinden üç boyutlu mimari projeler oluşturmasına ve bu projeleri paylaşmasına olanak tanıyor. Yazılım, mimari tasarım süreçlerini web tabanlı bir arayüzle erişilebilir kılmayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 20.706</li><li>TypeScript</li><li>GitHub Trending · 2026-07-29</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 18.985 → 20.706, son sürüm v0.9.1 (10 Haziran 2026).</li></ul></section>

--- a/discover/ego-lite/index.html
+++ b/discover/ego-lite/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ego Lite</span><span class="disc-momentum">🚀 +247 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanları için eş zamanlı tarayıcı</h1>
+<h1 class="disc-title">Yapay zekâ ajanları için eş zamanlı tarayıcı</h1>
 <p class="disc-lead">Ego-lite, kullanıcılar ve yapay zekâ ajanları (AI agents) için eş zamanlı çalışma imkânı sunan bir tarayıcıdır. JavaScript tabanlı bu araç, insan ve makine etkileşimini aynı tarayıcı ortamında paralel şekilde yürütmeyi hedefler.</p>
 <ul class="disc-meta"><li>★ 8.875</li><li>JavaScript</li><li>GitHub Trending · 2026-07-24</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 7.602 → 8.875, son sürüm v1.2.5 (17 Temmuz 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 1.896 → 7.602, son sürüm v1.2.5 (17 Temmuz 2026).</li></ul></section>

--- a/discover/esp32-bit-pirate/index.html
+++ b/discover/esp32-bit-pirate/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · ESP32-Bit-Pirate</span><span class="disc-momentum">🚀 +83 bugün</span></div>
-<h1 class="disc-title">donanım analizi için çok protokollü araç</h1>
+<h1 class="disc-title">Donanım analizi için çok protokollü araç</h1>
 <p class="disc-lead">ESP32-Bit-Pirate, web tabanlı bir komut satırı arayüzü (CLI) üzerinden çok sayıda haberleşme protokolünü destekleyen bir donanım hackleme aracıdır. C++ diliyle geliştirilen bu sistem, farklı protokolleri tek bir platform üzerinden yöneterek donanım analizi süreçlerini kolaylaştırır.</p>
 <ul class="disc-meta"><li>★ 5.281</li><li>C++</li><li>GitHub Trending · 2026-08-01</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 5.115 → 5.281, son sürüm v1.6 (5 Haziran 2026).</li></ul></section>

--- a/discover/espectre/index.html
+++ b/discover/espectre/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Espectre</span><span class="disc-momentum">🚀 +134 bugün</span></div>
-<h1 class="disc-title">Wi-Fi ile yapay zekâ destekli hareket algılama</h1>
+<h1 class="disc-title">Wi-Fi sinyalleri ile hareket algılama</h1>
 <p class="disc-lead">ESPectre, Wi-Fi kanal durum bilgisi (CSI) analizi üzerinden hareket algılama gerçekleştiren bir sistemdir. Ev otomasyon platformu Ev Asistanı (Home Assistant) ile entegre çalışarak kablosuz ağ sinyallerini izleme yeteneği sunar.</p>
 <ul class="disc-meta"><li>★ 8.905</li><li>Python</li><li>GitHub Trending · 2026-06-10</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 8.362 → 8.905, son sürüm 2.8.0 (21 Mayıs 2026).</li></ul></section>

--- a/discover/faceswap/index.html
+++ b/discover/faceswap/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Faceswap</span><span class="disc-momentum">🚀 +166 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile yüz değiştirme</h1>
+<h1 class="disc-title">Görüntülerde Yüz Değiştirme Rehberi</h1>
 <p class="disc-lead">Python tabanlı Faceswap, derin sahte (deepfake) teknolojisini kullanarak görüntülerdeki yüzleri değiştirmeye olanak tanıyan açık kaynaklı bir yazılımdır. Kullanıcıların video ve görseller üzerinde yüz dönüştürme (face swapping) işlemleri gerçekleştirmesine imkân sağlar.</p>
 <ul class="disc-meta"><li>★ 57.204</li><li>Python</li><li>GitHub Trending · 2026-07-30</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 56.487 → 57.204, son sürüm v3.0.0 (21 Aralık 2025).</li></ul></section>

--- a/discover/fanqiang/index.html
+++ b/discover/fanqiang/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Fanqiang</span><span class="disc-momentum">🚀 +161 bugün</span></div>
-<h1 class="disc-title">İnternet sansürünü yapay zekâ ile aşın</h1>
+<h1 class="disc-title">Kotlin ile internet sansürünü aşın</h1>
 <p class="disc-lead">Fanqiang projesi, internet sansürünü aşmak için geliştirilen ve Kotlin diliyle yazılmış bir ağ geçidi (gateway) aracıdır. Kullanıcılara kısıtlı ağ kaynaklarına erişim sağlamak amacıyla tasarlanmış açık kaynaklı bir yazılımdır.</p>
 <ul class="disc-meta"><li>★ 49.405</li><li>Kotlin</li><li>GitHub Trending · 2026-06-12</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 47.142 → 49.405, son sürüm FQNews-v1.3.8 (18 Ağustos 2024).</li></ul></section>

--- a/discover/fastmcp/index.html
+++ b/discover/fastmcp/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Fastmcp</span><span class="disc-momentum">🚀 +96 bugün</span></div>
-<h1 class="disc-title">yapay zekâ için hızlı araç entegrasyonu</h1>
+<h1 class="disc-title">Yapay zekâ için hızlı araç entegrasyonu</h1>
 <p class="disc-lead">FastMCP, Model Bağlam Protokolü (Model Context Protocol - MCP) sunucuları ve istemcileri geliştirmeyi kolaylaştıran Python tabanlı bir çerçevedir (framework). Geliştiricilerin yapay zekâ modelleri ile yerel araçlar arasında hızlı entegrasyon kurmasını sağlar.</p>
 <ul class="disc-meta"><li>★ 27.084</li><li>Python</li><li>GitHub Trending · 2026-07-21</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 27.020 → 27.084, son sürüm v3.4.6 (5 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 26.621 → 27.020, son sürüm v3.4.5 (27 Temmuz 2026).</li></ul></section>

--- a/discover/flowsint/index.html
+++ b/discover/flowsint/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Flowsint</span></div>
-<h1 class="disc-title">yapay zekâ ile siber tehditleri görselleştirin</h1>
+<h1 class="disc-title">Çizge tabanlı siber tehdit görselleştirme</h1>
 <p class="disc-lead">Flowsint, siber güvenlik analistleri ve araştırmacılar için görsel, esnek ve genişletilebilir çizge tabanlı inceleme (graph-based investigation) platformu sunuyor. TypeScript ile geliştirilen bu araç, karmaşık veri setlerinin görselleştirilerek analiz edilmesini kolaylaştırıyor.</p>
 <ul class="disc-meta"><li>★ 7.528</li><li>GitHub Trending · 2026-06-03</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 4.693 → 7.528, son sürüm v1.2.11 (1 Temmuz 2026).</li></ul></section>

--- a/discover/flue/index.html
+++ b/discover/flue/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Flue</span><span class="disc-momentum">🚀 +126 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanları için TypeScript çatısı</h1>
+<h1 class="disc-title">Yapay zekâ ajanları için TypeScript çatısı</h1>
 <p class="disc-lead">Astro ekibi tarafından geliştirilen Flue, TypeScript tabanlı bir kum havuzu ajan çatısı (sandbox agent framework) olarak öne çıkıyor. Bu yapı, geliştiricilerin güvenli ve izole edilmiş ortamlarda yapay zekâ ajanları oluşturmasına olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 7.625</li><li>TypeScript</li><li>GitHub Trending · 2026-06-06</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 4.594 → 7.625.</li></ul></section>

--- a/discover/fluidvoice/index.html
+++ b/discover/fluidvoice/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · FluidVoice</span><span class="disc-momentum">🚀 +365 bugün</span></div>
-<h1 class="disc-title">macOS için gizlilik odaklı sesli dikte</h1>
+<h1 class="disc-title">MacOS için gizlilik odaklı sesli dikte</h1>
 <p class="disc-lead">FluidVoice, macOS işletim sistemi üzerinde tamamen çevrim dışı çalışan hızlı bir sesli dikte (voice to text) uygulamasıdır. Swift diliyle geliştirilen bu araç, verileri yerel olarak işleyerek gizlilik odaklı bir ses dönüştürme deneyimi sunar.</p>
 <ul class="disc-meta"><li>★ 9.360</li><li>Swift</li><li>GitHub Trending · 2026-06-29</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 9.248 → 9.360, son sürüm v1.6.7 (5 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 3.995 → 9.248, son sürüm v1.6.6 (31 Temmuz 2026).</li></ul></section>

--- a/discover/flutter/index.html
+++ b/discover/flutter/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Flutter</span><span class="disc-momentum">🚀 +73 bugün</span></div>
-<h1 class="disc-title">tek kodla çoklu platform uygulaması</h1>
+<h1 class="disc-title">Tek kodla çoklu platform uygulaması</h1>
 <p class="disc-lead">Google tarafından geliştirilen Flutter, tek bir kod tabanı kullanarak mobil, web ve masaüstü platformları için hızlı bir şekilde kullanıcı arayüzü (user interface) oluşturulmasına olanak tanıyor. Dart programlama dilini temel alan bu açık kaynaklı çerçeve (framework), yüksek performanslı ve görsel açıdan zengin uygulamalar geliştirmek için yaygın olarak tercih ediliyor.</p>
 <ul class="disc-meta"><li>★ 178.068</li><li>Dart</li><li>GitHub Trending · 2026-06-25</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 177.494 → 178.068, son sürüm 3.19.0-0.1.pre (11 Ocak 2024).</li></ul></section>

--- a/discover/free-stockdb/index.html
+++ b/discover/free-stockdb/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Free Stockdb</span><span class="disc-momentum">🚀 +50 bugün</span></div>
-<h1 class="disc-title">yerel borsa verisi ve analiz motoru</h1>
+<h1 class="disc-title">Yerel borsa verisi ve analiz motoru</h1>
 <p class="disc-lead">Free-stockdb, A hisse senetleri ve borsa yatırım fonları (ETF) için günlük ve dakikalık verileri yöneten yerel bir nicel analiz motorudur. Sistem, verilerin artımlı senkronizasyonu, yerel önbellekleme, fiyat düzeltme, geriye dönük test (backtesting) ve teknik gösterge hesaplamaları gibi işlevleri bir arada sunar.</p>
 <ul class="disc-meta"><li>★ 1.684</li><li>HTML</li><li>GitHub Trending · 2026-07-29</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 1.492 → 1.684, son sürüm 测试版本0.2.1 (19 Temmuz 2026).</li></ul></section>

--- a/discover/gastown/index.html
+++ b/discover/gastown/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Gastown</span><span class="disc-momentum">🚀 +51 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanları için çalışma alanı yönetimi</h1>
+<h1 class="disc-title">Yapay zekâ ajanları için çalışma alanı yönetimi</h1>
 <p class="disc-lead">Gas Town, çoklu ajan çalışma alanı yöneticisi (multi-agent workspace manager) olarak farklı yapay zekâ ajanlarının bir arada çalışmasını sağlayan bir altyapı sunuyor. Go diliyle geliştirilen bu araç, karmaşık iş akışlarında ajanlar arası koordinasyonu ve kaynak yönetimini merkezileştiriyor.</p>
 <ul class="disc-meta"><li>★ 17.403</li><li>Go</li><li>GitHub Trending · 2026-07-06</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 16.488 → 17.403, son sürüm v1.2.1 (6 Haziran 2026).</li></ul></section>

--- a/discover/glm-5/index.html
+++ b/discover/glm-5/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · GLM 5</span></div>
-<h1 class="disc-title">uzun vadeli görevler için yapay zekâ</h1>
+<h1 class="disc-title">Uzun vadeli görevler için yapay zekâ</h1>
 <p class="disc-lead">GLM-5, yazılım geliştirme süreçlerini sezgisel kodlamadan (vibe coding) yapılandırılmış ajan tabanlı mühendisliğe (agentic engineering) taşımayı amaçlayan bir çerçeve sunuyor. Bu sistem, karmaşık görevleri otonom bir şekilde yönetebilen yapay zekâ ajanları (AI agents) aracılığıyla yazılım geliştirme iş akışlarını standartlaştırıyor.</p>
 <ul class="disc-meta"><li>★ 6.864</li><li>GitHub Trending · 2026-06-19</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 4.301 → 6.864.</li></ul></section>

--- a/discover/godot/index.html
+++ b/discover/godot/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Godot</span></div>
-<h1 class="disc-title">açık kaynaklı oyun geliştirme motoru</h1>
+<h1 class="disc-title">Açık kaynaklı oyun geliştirme motoru</h1>
 <p class="disc-lead">Godot Motoru (Godot Engine), iki ve üç boyutlu oyun geliştirme süreçleri için kullanılan açık kaynaklı bir oyun motorudur. C++ diliyle geliştirilen bu platform, geliştiricilere farklı işletim sistemlerinde çalışabilen oyunlar üretme imkânı tanır.</p>
 <ul class="disc-meta"><li>★ 114.944</li><li>GitHub Trending · 2026-06-02</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 111.819 → 114.944, son sürüm 4.7.1-stable (14 Temmuz 2026).</li></ul></section>

--- a/discover/gstack/index.html
+++ b/discover/gstack/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Gstack</span><span class="disc-momentum">🚀 +573 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile yazılım geliştirme fabrikası</h1>
+<h1 class="disc-title">Yapay zekâ ile yazılım geliştirme fabrikası</h1>
 <p class="disc-lead">Gstack, Garry Tan&#x27;ın Claude Code yapılandırmasını temel alan ve CEO, tasarımcı, mühendislik yöneticisi gibi farklı roller üstlenen 23 özelleşmiş araçtan oluşan bir sistemdir. Bu TypeScript tabanlı yapı, yazılım geliştirme süreçlerini otomatize etmek için tanımlanmış iş akışları (workflows) sunar.</p>
 <ul class="disc-meta"><li>★ 125.874</li><li>TypeScript</li><li>GitHub Trending · 2026-06-23</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 113.462 → 125.874.</li></ul></section>

--- a/discover/hallmark/index.html
+++ b/discover/hallmark/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hallmark</span><span class="disc-momentum">🚀 +155 bugün</span></div>
-<h1 class="disc-title">yapay zekâ tasarımlarına özgünlük kazandırın</h1>
+<h1 class="disc-title">Yapay zekâ tasarımlarına özgünlük kazandırın</h1>
 <p class="disc-lead">Hallmark, yapay zekâ tarafından üretilen standart içeriklerin (AI slop) tasarım üzerindeki etkisini azaltmak amacıyla geliştirilen bir stil dosyasıdır. Claude Code, Cursor ve Codex gibi araçlarda kullanılan arayüzlerin özgün ve insani bir estetik kazanmasını sağlar.</p>
 <ul class="disc-meta"><li>★ 22.106</li><li>CSS</li><li>GitHub Trending · 2026-07-13</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 20.791 → 22.106.</li><li><strong>2 Ağustos 2026:</strong> Yıldız 4.508 → 20.791.</li></ul></section>

--- a/discover/headroom/index.html
+++ b/discover/headroom/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Headroom</span></div>
-<h1 class="disc-title">yapay zekâ çıktılarınızı analiz edin</h1>
+<h1 class="disc-title">Yapay zekâ çıktılarınızı analiz edin</h1>
 <p class="disc-lead">Headroom, büyük dil modellerine (LLM) gönderilen günlük dosyalarını, araç çıktılarını ve bağlamsal veri parçalarını (RAG chunks) sıkıştırarak jeton (token) kullanımını %60 ile %95 oranında azaltıyor. Python tabanlı bu araç, kütüphane, vekil sunucu (proxy) ve Model Bağlam Protokolü (MCP) sunucusu olarak farklı entegrasyon seçenekleri sunuyor.</p>
 <ul class="disc-meta"><li>★ 7.746</li><li>GitHub Trending · 2026-06-03</li></ul>
       <section class="disc-sec"><h2>Ne kazandırır?</h2><ul class="disc-wins"><li>Jeton kullanımını %60 ile %95 oranında azaltır.</li><li>Verileri yerel olarak sıkıştırarak gizliliği korur.</li><li>Orijinal verileri kaybetmeden geri çağrılabilir sıkıştırma sağlar.</li></ul></section>

--- a/discover/hermes-webui/index.html
+++ b/discover/hermes-webui/index.html
@@ -59,7 +59,7 @@
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
       <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hermes WebUI</span><span class="disc-momentum">🚀 Bir günde +357 yıldız</span></div>
-      <h1 class="disc-title">yapay zekâ ajanlarınızı webden yönetin</h1>
+      <h1 class="disc-title">Yapay zekâ ajanlarınızı webden yönetin</h1>
       <p class="disc-lead"><strong>Hermes WebUI</strong>, Hermes AI ajanlarını <strong>web tarayıcısı veya mobil cihazlar</strong> üzerinden yönetmenizi sağlayan bir arayüzdür. Ajan etkileşimlerini tek bir merkezden takip edip kontrol etmenize olanak tanır.</p>
       <figure class="disc-shot"><img src="/assets/discover/hermes-webui.webp" width="1440" height="1028" loading="lazy" decoding="async" alt="Hermes WebUI arayüzünden bir görünüm"><figcaption>Görsel: Hermes WebUI (proje deposundan)</figcaption></figure>
       <ul class="disc-meta"><li>★ 16.850</li><li>Python</li><li>MIT</li><li>GitHub Trending · 1 Haziran 2026</li></ul>

--- a/discover/hivemind/index.html
+++ b/discover/hivemind/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hivemind</span><span class="disc-momentum">🚀 +64 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanları için merkezi bellek</h1>
+<h1 class="disc-title">Yapay zekâ ajanları için merkezi bellek</h1>
 <p class="disc-lead">Activeloop tarafından geliştirilen Hivemind, tüm yapay zekâ ajanları için merkezi bir bellek ve koordinasyon katmanı (centralized memory layer) sunuyor. TypeScript tabanlı bu yapı, farklı ajanların verileri paylaşmasını ve ortak bir zekâ havuzu üzerinden iletişim kurmasını sağlıyor.</p>
 <ul class="disc-meta"><li>★ 1.526</li><li>TypeScript</li><li>GitHub Trending · 2026-06-11</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 985 → 1.526, son sürüm v0.7.145 (30 Temmuz 2026).</li></ul></section>

--- a/discover/impeccable/index.html
+++ b/discover/impeccable/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Impeccable</span></div>
-<h1 class="disc-title">yapay zekâ tasarımlarınızı mükemmelleştirin</h1>
+<h1 class="disc-title">Yapay zekâ tasarımlarınızı mükemmelleştirin</h1>
 <p class="disc-lead">Impeccable, yapay zekâ modellerinin tasarım çıktılarını iyileştirmek için geliştirilmiş bir tasarım dili (design language) kütüphanesidir. Yazılım, üretken yapay zekâ (generative AI) araçlarının görsel tutarlılığını ve estetik kalitesini artırmak amacıyla standartlaştırılmış kurallar sunar.</p>
 <ul class="disc-meta"><li>★ 53.997</li><li>GitHub Trending · 2026-06-02</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 33.104 → 53.997, son sürüm ext-v1.3.1 (30 Temmuz 2026).</li></ul></section>

--- a/discover/instatic/index.html
+++ b/discover/instatic/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Instatic</span><span class="disc-momentum">🚀 +351 bugün</span></div>
-<h1 class="disc-title">Kendi sunucunuzda modern yapay zekâ destekli CMS</h1>
+<h1 class="disc-title">Kendi sunucunuzda modern görsel CMS</h1>
 <p class="disc-lead">Instatic, TypeScript tabanlı, kendi kendine barındırılan (self-hosted) modern bir görsel içerik yönetim sistemi (CMS) olarak sunuluyor. Kullanıcıların hızlı kurulum süreciyle içerik yönetimi arayüzünü kendi sunucularında çalıştırmasına olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 7.250</li><li>TypeScript</li><li>GitHub Trending · 2026-07-01</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 1.681 → 7.250, son sürüm v0.0.14 (28 Temmuz 2026).</li></ul></section>

--- a/discover/iroh/index.html
+++ b/discover/iroh/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Iroh</span></div>
-<h1 class="disc-title">anahtar tabanlı esnek ağ bağlantıları</h1>
+<h1 class="disc-title">Anahtar tabanlı esnek ağ bağlantıları</h1>
 <p class="disc-lead">Iroh, IP adresleri yerine anahtar tabanlı (key-based) adresleme kullanarak ağ bağlantılarını daha esnek hale getiren modüler bir ağ yığınıdır (networking stack). Rust diliyle geliştirilen bu araç, ağ kesintilerine karşı dayanıklı ve doğrudan veri aktarımı sağlayan bir altyapı sunar.</p>
 <ul class="disc-meta"><li>★ 11.957</li><li>GitHub Trending · 2026-06-17</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 9.418 → 11.957, son sürüm v1.0.3 (20 Temmuz 2026).</li></ul></section>

--- a/discover/k-skill/index.html
+++ b/discover/k-skill/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · K Skill</span><span class="disc-momentum">🚀 +53 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanınıza yerel yetenekler kazandırın</h1>
+<h1 class="disc-title">Yapay zekâ ajanınıza yerel yetenekler kazandırın</h1>
 <p class="disc-lead">NomaDamas/k-skill, yapay zekâ ajanlarına (AI agents) kültürel bağlamda yerel yetenekler kazandırmak için tasarlanmış bir kütüphane. Ajanların kullanıcılarla daha doğal ve kültürel kodlara uygun etkileşim kurmasını sağlayan özelleştirilmiş beceri setleri (skill sets) sunuyor.</p>
 <ul class="disc-meta"><li>★ 6.780</li><li>JavaScript</li><li>GitHub Trending · 2026-08-02</li></ul>
       <section class="disc-sec"><h2>Ne kazandırır?</h2><ul class="disc-wins"><li>Yapay zekâ ajanlarının Türkiye&#x27;ye özgü yerel hizmetleri kullanmasını sağlar</li><li>Ulaşım, kamu verileri ve günlük işlerde otomatik sorgulama yapar</li><li>Ekstra bir istemci yazılımına ihtiyaç duymadan doğrudan entegre olur</li></ul></section>

--- a/discover/karukan/index.html
+++ b/discover/karukan/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Karukan</span><span class="disc-momentum">🚀 +42 bugün</span></div>
-<h1 class="disc-title">yapay zekâ destekli japonca giriş sistemi</h1>
+<h1 class="disc-title">Yapay zekâ destekli japonca giriş sistemi</h1>
 <p class="disc-lead">Rust diliyle geliştirilen Karukan, Linux ve macOS işletim sistemleri için sinirsel kana-kanji dönüştürme motoru (neural kana-kanji conversion engine) kullanan bir Japonca giriş yöntemi sistemidir (Japanese Input Method System). Yazılım, geleneksel yöntemlerin ötesine geçerek metin dönüştürme süreçlerinde yapay zekâ tabanlı bir yaklaşım sunar.</p>
 <ul class="disc-meta"><li>★ 692</li><li>Rust</li><li>GitHub Trending · 2026-07-02</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 615 → 692, son sürüm v0.1.0 (23 Şubat 2026).</li></ul></section>

--- a/discover/ktransformers/index.html
+++ b/discover/ktransformers/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ktransformers</span><span class="disc-momentum">🚀 +360 bugün</span></div>
-<h1 class="disc-title">yapay zekâ modelleri için heterojen hızlandırma</h1>
+<h1 class="disc-title">Yapay zekâ modelleri için heterojen hızlandırma</h1>
 <p class="disc-lead">Ktransformers, büyük dil modellerinin (large language models) çıkarım ve ince ayar (fine-tuning) süreçlerinde heterojen donanım optimizasyonlarını destekleyen esnek bir çerçeve sunuyor. Bu yapı, farklı donanım kaynaklarını verimli kullanarak model performansını artırmayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 19.145</li><li>Python</li><li>GitHub Trending · 2026-07-20</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 18.491 → 19.145, son sürüm v0.6.4 (23 Temmuz 2026).</li></ul></section>

--- a/discover/likec4/index.html
+++ b/discover/likec4/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Likec4</span><span class="disc-momentum">🚀 +80 bugün</span></div>
-<h1 class="disc-title">yazılım mimarinizi canlı diyagramlarla görselleştirin</h1>
+<h1 class="disc-title">Yazılım mimarinizi canlı diyagramlarla görselleştirin</h1>
 <p class="disc-lead">Likec4, yazılım mimarisini doğrudan kaynak kod üzerinden görselleştiren ve canlı diyagramlar oluşturulmasını sağlayan bir araçtır. Kod tabanıyla eş zamanlı güncellenen mimari şemalar (diagrams) aracılığıyla teknik dokümantasyonun sürekliliğini hedefler.</p>
 <ul class="disc-meta"><li>★ 5.328</li><li>TypeScript</li><li>GitHub Trending · 2026-07-23</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 4.419 → 5.328, son sürüm v1.59.2 (22 Temmuz 2026).</li></ul></section>

--- a/discover/llama-cpp/index.html
+++ b/discover/llama-cpp/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Llama.cpp</span><span class="disc-momentum">🚀 +158 bugün</span></div>
-<h1 class="disc-title">yapay zekâ modellerini bilgisayarınızda çalıştırın</h1>
+<h1 class="disc-title">Yapay zekâ modellerini bilgisayarınızda çalıştırın</h1>
 <p class="disc-lead">Llama.cpp, büyük dil modellerinin (large language models) standart donanımlar üzerinde verimli bir şekilde çalıştırılmasını sağlayan C ve C++ tabanlı bir çıkarım (inference) kütüphanesidir. Yazılım, düşük bellek kullanımı ve yüksek performans odaklı yapısıyla yerel cihazlarda yapay zekâ modellerinin çalıştırılmasını kolaylaştırır.</p>
 <ul class="disc-meta"><li>★ 122.872</li><li>C++</li><li>GitHub Trending · 2026-06-08</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 122.866 → 122.872, son sürüm b10293 (6 Ağustos 2026).</li><li><strong>6 Ağustos 2026:</strong> Yıldız 122.857 → 122.866, son sürüm b10291 (6 Ağustos 2026).</li><li><strong>6 Ağustos 2026:</strong> Yıldız 122.639 → 122.857, son sürüm b10290 (6 Ağustos 2026).</li><li><strong>4 Ağustos 2026:</strong> Yıldız 122.629 → 122.639, son sürüm b10256 (4 Ağustos 2026).</li></ul></section>

--- a/discover/llmfit/index.html
+++ b/discover/llmfit/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Llmfit</span><span class="disc-momentum">🚀 +129 bugün</span></div>
-<h1 class="disc-title">donanımınıza uygun yapay zekâ modellerini bulun</h1>
+<h1 class="disc-title">Donanımınıza uygun yapay zekâ modellerini bulun</h1>
 <p class="disc-lead">Rust diliyle geliştirilen llmfit, yüzlerce büyük dil modelini (large language model) ve sağlayıcıyı tarayarak donanımınızla uyumlu olanları tek bir komutla tespit etmenizi sağlıyor. Araç, yerel sistem kaynaklarına en uygun modelleri bulma sürecini otomatikleştiriyor.</p>
 <ul class="disc-meta"><li>★ 31.111</li><li>Rust</li><li>GitHub Trending · 2026-07-22</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>4 Ağustos 2026:</strong> Yıldız 31.076 → 31.111, son sürüm v1.1.8 (4 Ağustos 2026).</li><li><strong>3 Ağustos 2026:</strong> Yıldız 31.060 → 31.076, son sürüm v1.1.7 (3 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 30.309 → 31.060, son sürüm v1.1.6 (21 Temmuz 2026).</li></ul></section>

--- a/discover/lmcache/index.html
+++ b/discover/lmcache/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · LMCache</span><span class="disc-momentum">🚀 +28 bugün</span></div>
-<h1 class="disc-title">yapay zekâ modellerinde KV önbelleği yönetimi</h1>
+<h1 class="disc-title">Yapay zekâ modellerinde KV önbelleği yönetimi</h1>
 <p class="disc-lead">LMCache, büyük dil modelleri (large language models) için anahtar-değer önbelleği (KV cache) yönetimini optimize ederek çıkarım hızını artıran bir katman sunuyor. Bellek kullanımını verimli hale getiren bu sistem, aynı bağlamı kullanan sorgularda hesaplama yükünü azaltmayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 11.038</li><li>Python</li><li>GitHub Trending · 2026-06-13</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 10.985 → 11.038, son sürüm v0.5.3 (5 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 8.698 → 10.985, son sürüm operator-v0.5.1 (23 Temmuz 2026).</li></ul></section>

--- a/discover/lobehub/index.html
+++ b/discover/lobehub/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Lobehub</span><span class="disc-momentum">🚀 +71 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanları ile operasyon yönetimi</h1>
+<h1 class="disc-title">Yapay zekâ ajanları ile operasyon yönetimi</h1>
 <p class="disc-lead">LobeHub, yapay zekâ ajanlarını işe alma, zamanlama ve raporlama süreçleriyle yöneterek 7 gün 24 saat çalışan bir yapay zekâ ekibi operasyonu (AI team operations) oluşturmayı sağlıyor. Platform, farklı ajanları tek bir merkezden organize ederek iş akışlarını otomatize eden bir yönetici arayüzü sunuyor.</p>
 <ul class="disc-meta"><li>★ 81.117</li><li>TypeScript</li><li>GitHub Trending · 2026-07-17</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 80.291 → 81.117, son sürüm v2.2.13 (1 Ağustos 2026).</li></ul></section>

--- a/discover/ltx-2/index.html
+++ b/discover/ltx-2/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · LTX 2</span></div>
-<h1 class="disc-title">yerel sistemde yapay zekâ ile video üretimi</h1>
+<h1 class="disc-title">Yerel sistemde yapay zekâ ile video üretimi</h1>
 <p class="disc-lead">Lightricks tarafından geliştirilen LTX-2, ses ve video üreten yapay zekâ modelleri için Python çıkarım (inference) ve düşük dereceli uyarlama (low-rank adaptation, LoRA) eğitim paketi sunuyor. Bu araç seti, kullanıcıların LTX-2 modellerini kendi verileriyle eğitmesine ve model çıktılarını yerel sistemlerde çalıştırmasına olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 7.550</li><li>GitHub Trending · 2026-06-19</li></ul>
       <section class="disc-sec"><h2>Ne kazandırır?</h2><ul class="disc-wins"><li>Ses ve video senkronizasyonu sağlar</li><li>Kendi verilerinizle LoRA eğitimi yapabilirsiniz</li><li>Yerel sistemde yüksek kaliteli video üretimi</li></ul></section>

--- a/discover/marketingskills/index.html
+++ b/discover/marketingskills/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Marketingskills</span><span class="disc-momentum">🚀 +145 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanınıza pazarlama becerileri kazandırın</h1>
+<h1 class="disc-title">Yapay zekâ ajanınıza pazarlama becerileri kazandırın</h1>
 <p class="disc-lead">Claude Code ve yapay zekâ ajanları için geliştirilen marketingskills kütüphanesi, dönüşüm oranı optimizasyonu (CRO), metin yazarlığı, arama motoru optimizasyonu (SEO), analitik ve büyüme mühendisliği gibi alanlarda özelleşmiş yetenekler sunuyor. Bu araç seti, yapay zekâ modellerinin pazarlama odaklı görevleri daha profesyonel ve veriye dayalı şekilde yürütmesini sağlıyor.</p>
 <ul class="disc-meta"><li>★ 42.728</li><li>JavaScript</li><li>GitHub Trending · 2026-07-06</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 36.679 → 42.728, son sürüm v2.10.0 (27 Temmuz 2026).</li></ul></section>

--- a/discover/masterdnsvpn/index.html
+++ b/discover/masterdnsvpn/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MasterDnsVPN</span><span class="disc-momentum">🚀 +354 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile sansürleri aşın</h1>
+<h1 class="disc-title">DNS tünelleme ile sansür engellerini aşın</h1>
 <p class="disc-lead">MasterDnsVPN, sansür engellerini aşmak için geliştirilen ve düşük yükle çalışan bir alan adı sistemi tünelleme (DNS tunneling) sanal özel ağ (VPN) çözümüdür. Go diliyle yazılan araç, veri iletiminde yüksek paket kaybı kararlılığı ve çözümleyici yük dengeleme (resolver load balancing) özellikleri sunar.</p>
 <ul class="disc-meta"><li>★ 6.870</li><li>Go</li><li>GitHub Trending · 2026-06-11</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 5.411 → 6.870, son sürüm v2026.06.13.234407-7de2476 (13 Haziran 2026).</li></ul></section>

--- a/discover/mempalace/index.html
+++ b/discover/mempalace/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Mempalace</span><span class="disc-momentum">🚀 +227 bugün</span></div>
-<h1 class="disc-title">yapay zekâ modellerine bellek kazandırın</h1>
+<h1 class="disc-title">Yapay zekâ modellerine bellek kazandırın</h1>
 <p class="disc-lead">MemPalace, yapay zekâ modelleri için açık kaynaklı bir bellek sistemi (memory system) sunuyor. Sistem, geniş dil modellerinin (large language models) bağlamsal hafıza performansını ölçümlemek ve geliştirmek amacıyla optimize edilmiş araçlar içeriyor.</p>
 <ul class="disc-meta"><li>★ 57.977</li><li>Python</li><li>GitHub Trending · 2026-06-06</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 53.981 → 57.977, son sürüm v3.6.0 (17 Temmuz 2026).</li></ul></section>

--- a/discover/meshoptimizer/index.html
+++ b/discover/meshoptimizer/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Meshoptimizer</span><span class="disc-momentum">🚀 +91 bugün</span></div>
-<h1 class="disc-title">üç boyutlu ağları optimize edin</h1>
+<h1 class="disc-title">Üç boyutlu ağları optimize edin</h1>
 <p class="disc-lead">Meshoptimizer kütüphanesi, üç boyutlu ağ (mesh) verilerini optimize ederek dosya boyutlarını küçültüyor ve işleme (rendering) performansını artırıyor. C++ diliyle geliştirilen bu araç, grafik uygulamalarında bellek kullanımını iyileştirmek için geometrik verileri düzenliyor.</p>
 <ul class="disc-meta"><li>★ 8.177</li><li>C++</li><li>GitHub Trending · 2026-07-11</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 8.045 → 8.177, son sürüm v1.2 (30 Haziran 2026).</li></ul></section>

--- a/discover/mirofish/index.html
+++ b/discover/mirofish/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MiroFish</span><span class="disc-momentum">🚀 +320 bugün</span></div>
-<h1 class="disc-title">Veri Tahmininde Evrensel yapay zekâ</h1>
+<h1 class="disc-title">Veri tahmininde sürü zekâsı motoru</h1>
 <p class="disc-lead">MiroFish, çeşitli veri türlerini tahmin etmek amacıyla geliştirilen basit ve evrensel bir sürü zekâsı motoru (swarm intelligence engine) sunuyor. Python tabanlı bu araç, karmaşık sistemlerdeki örüntüleri tanımlamak için kolektif hesaplama yöntemlerinden yararlanıyor.</p>
 <ul class="disc-meta"><li>★ 69.813</li><li>Python</li><li>GitHub Trending · 2026-06-06</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 64.830 → 69.813, son sürüm v0.1.2 (7 Mart 2026).</li></ul></section>

--- a/discover/mxc/index.html
+++ b/discover/mxc/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MXC</span><span class="disc-momentum">🚀 +64 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile güvenli sistem yalıtımı</h1>
+<h1 class="disc-title">Rust ile politika tabanlı katmanlı sistem yalıtımı</h1>
 <p class="disc-lead">Microsoft tarafından geliştirilen MXC, Rust diliyle yazılmış politika tabanlı, katmanlı bir yalıtım ve kapsayıcılık (isolation and containment) çözümüdür. Sistem kaynaklarını güvenli bir şekilde sınırlandırmak ve uygulama güvenliğini artırmak amacıyla tasarlanmıştır.</p>
 <ul class="disc-meta"><li>★ 641</li><li>Rust</li><li>GitHub Trending · 2026-06-07</li></ul>
       <section class="disc-sec"><h2>Ne kazandırır?</h2><ul class="disc-wins"><li>Güvenilmeyen kodları yalıtılmış ortamlarda güvenle çalıştırır.</li><li>JSON tabanlı politikalarla dosya, ağ ve arayüz erişimini denetler.</li><li>Windows, Linux ve macOS üzerinde çoklu yalıtım arka uçları sunar.</li></ul></section>

--- a/discover/next-ai-draw-io/index.html
+++ b/discover/next-ai-draw-io/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Next AI Draw IO</span><span class="disc-momentum">🚀 +81 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile otomatik diyagram oluşturma</h1>
+<h1 class="disc-title">Yapay zekâ ile otomatik diyagram oluşturma</h1>
 <p class="disc-lead">Next.js tabanlı bu uygulama, diyagram oluşturma aracı draw.io ile üretken yapay zekâ (generative AI) yeteneklerini birleştiriyor. Kullanıcılar, doğal dil komutları aracılığıyla görsel şemalar oluşturabiliyor ve mevcut diyagramlarını yapay zekâ desteğiyle düzenleyebiliyor.</p>
 <ul class="disc-meta"><li>★ 33.999</li><li>TypeScript</li><li>GitHub Trending · 2026-07-12</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 33.359 → 33.999, son sürüm v0.4.16 (21 Mayıs 2026).</li></ul></section>

--- a/discover/nginx/index.html
+++ b/discover/nginx/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Nginx</span><span class="disc-momentum">🚀 +20 bugün</span></div>
-<h1 class="disc-title">Web Sunucunuzu yapay zekâyla Hızlandırın</h1>
+<h1 class="disc-title">Yüksek performanslı web sunucusu ve ters vekil</h1>
 <p class="disc-lead">NGINX açık kaynak kod deposu, yüksek performanslı bir web sunucusu ve ters vekil sunucu (reverse proxy) olarak C diliyle geliştirilmeye devam ediyor. Yazılım, ağ trafiğini yönetmek ve içerik dağıtımını optimize etmek amacıyla geniş ölçekli altyapılarda standart bir çözüm sunuyor.</p>
 <ul class="disc-meta"><li>★ 31.312</li><li>C</li><li>GitHub Trending · 2026-06-07</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 30.727 → 31.312, son sürüm release-1.31.3 (15 Temmuz 2026).</li></ul></section>

--- a/discover/odoo/index.html
+++ b/discover/odoo/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Odoo</span></div>
-<h1 class="disc-title">İş süreçlerinizi yapay zekâ ile yönetin</h1>
+<h1 class="disc-title">Açık kaynaklı kurumsal kaynak planlama</h1>
 <p class="disc-lead">Odoo, işletmelerin tüm operasyonel süreçlerini tek bir çatı altında yönetmelerini sağlayan açık kaynaklı bir kurumsal kaynak planlama (enterprise resource planning) platformudur. Python diliyle geliştirilen bu sistem, satıştan muhasebeye kadar geniş bir yelpazede modüler iş uygulamaları sunar.</p>
 <ul class="disc-meta"><li>★ 52.082</li><li>GitHub Trending · 2026-06-04</li></ul>
       <section class="disc-sec"><h2>Ne kazandırır?</h2><ul class="disc-wins"><li>Satış, muhasebe ve depo gibi iş süreçlerini tek merkezden yönetir.</li><li>Birbiriyle uyumlu modüler iş uygulamaları sunar.</li><li>İhtiyaca göre özelleştirilebilir açık kaynaklı bir altyapı sağlar.</li></ul></section>

--- a/discover/officecli/index.html
+++ b/discover/officecli/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OfficeCLI</span><span class="disc-momentum">🚀 +893 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile ofis dosyalarını yönetin</h1>
+<h1 class="disc-title">Yapay zekâ ile ofis dosyalarını yönetin</h1>
 <p class="disc-lead">OfficeCLI, yapay zekâ ajanlarının Word, Excel ve PowerPoint dosyalarını doğrudan okumasına, düzenlemesine ve otomatize etmesine olanak tanıyan açık kaynaklı bir ofis paketi sunuyor. C# ile geliştirilen bu araç, herhangi bir ofis yazılımı kurulumuna ihtiyaç duymadan tek bir ikili dosya (binary) üzerinden işlem yapılmasına imkân veriyor.</p>
 <ul class="disc-meta"><li>★ 25.967</li><li>C#</li><li>GitHub Trending · 2026-07-08</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 24.245 → 25.967, son sürüm v1.0.143 (28 Temmuz 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 10.491 → 24.245, son sürüm v1.0.143 (28 Temmuz 2026).</li></ul></section>

--- a/discover/open-seo/index.html
+++ b/discover/open-seo/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Open Seo</span><span class="disc-momentum">🚀 +57 bugün</span></div>
-<h1 class="disc-title">SEO verilerini yapay zekâ ile yönetin</h1>
+<h1 class="disc-title">Açık kaynaklı SEO veri ve analiz platformu</h1>
 <p class="disc-lead">Open SEO, Semrush ve Ahrefs gibi ücretli araçlara açık kaynaklı bir alternatif sunuyor. Arama motoru optimizasyonu (SEO) verilerini analiz etmek için geliştirilen bu yazılım, TypeScript tabanlı altyapısıyla süreçleri şeffaflaştırmayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 10.091</li><li>TypeScript</li><li>GitHub Trending · 2026-06-26</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 2.736 → 10.091, son sürüm v0.1.3 (30 Temmuz 2026).</li></ul></section>

--- a/discover/opencode/index.html
+++ b/discover/opencode/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Opencode</span><span class="disc-momentum">🚀 +392 bugün</span></div>
-<h1 class="disc-title">açık kaynaklı yapay zekâ kodlama ajanı</h1>
+<h1 class="disc-title">Açık kaynaklı yapay zekâ kodlama ajanı</h1>
 <p class="disc-lead">OpenCode, yazılım geliştirme süreçlerini otomatikleştirmek için tasarlanmış açık kaynaklı bir kodlama ajanıdır (coding agent). TypeScript diliyle geliştirilen bu araç, yazılım projelerinde otonom görev yürütme yetenekleri sunar.</p>
 <ul class="disc-meta"><li>★ 193.974</li><li>TypeScript</li><li>GitHub Trending · 2026-06-28</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 193.021 → 193.974, son sürüm v1.18.14 (5 Ağustos 2026).</li><li><strong>4 Ağustos 2026:</strong> Yıldız 192.342 → 193.021, son sürüm v1.18.12 (4 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 179.948 → 192.342, son sürüm v1.18.11 (1 Ağustos 2026).</li></ul></section>

--- a/discover/opencv/index.html
+++ b/discover/opencv/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Opencv</span></div>
-<h1 class="disc-title">Görüntü işleme için açık kaynak kütüphane</h1>
+<h1 class="disc-title">Görüntü işlemenin açık kaynak standardı</h1>
 <p class="disc-lead">Açık kaynak kodlu bilgisayarlı görü kütüphanesi (computer vision library) olan OpenCV, görüntü işleme ve makine öğrenmesi (machine learning) uygulamaları için geniş kapsamlı araçlar sunuyor. C++ diliyle geliştirilen bu kütüphane, gerçek zamanlı görsel veri analizi süreçlerinde standart bir altyapı görevi görüyor.</p>
 <ul class="disc-meta"><li>★ 90.258</li><li>GitHub Trending · 2026-06-08</li></ul>
       <aside class="disc-note"><p><strong>TreScout notu:</strong> Yapay zekâ modeli eğitmek için değil, görüntünün kendisiyle uğraşmak için: Kırpma, renk düzeltme, kenar bulma, kameradan görüntü okuma. Model eğitmek gerektiğinde bu iş için ayrı kütüphaneler kullanılır, bu onların yerine geçmez. Kurulumu tek komut, video biçimleri için ek paket isteyebilir.</p></aside>

--- a/discover/openinterpreter/index.html
+++ b/discover/openinterpreter/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openinterpreter</span><span class="disc-momentum">🚀 +299 bugün</span></div>
-<h1 class="disc-title">bilgisayarınızda kod çalıştıran yapay zekâ</h1>
+<h1 class="disc-title">Bilgisayarınızda kod çalıştıran yapay zekâ</h1>
 <p class="disc-lead">Open Interpreter, yerel bilgisayar ortamında kod çalıştırarak yazılım geliştirme süreçlerini otomatize eden bir kodlama ajanı (coding agent) sunuyor. Düşük maliyetli dil modelleriyle uyumlu çalışacak şekilde tasarlanan bu araç, karmaşık görevleri doğrudan terminal üzerinden yürütmeyi sağlıyor.</p>
 <ul class="disc-meta"><li>★ 67.509</li><li>Rust</li><li>GitHub Trending · 2026-07-16</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 65.626 → 67.509, son sürüm rust-v0.0.34 (18 Temmuz 2026).</li></ul></section>

--- a/discover/openpilot/index.html
+++ b/discover/openpilot/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openpilot</span><span class="disc-momentum">🚀 +80 bugün</span></div>
-<h1 class="disc-title">araçlar için açık kaynaklı yapay zekâ</h1>
+<h1 class="disc-title">Araçlar için açık kaynaklı yapay zekâ</h1>
 <p class="disc-lead">Comma AI tarafından geliştirilen openpilot, robotik sistemler için tasarlanmış açık kaynaklı bir işletim sistemidir. Yazılım, 300&#x27;den fazla araç modelinde sürücü destek sistemini (driver assistance system) yükselterek otonom sürüş yetenekleri kazandırıyor.</p>
 <ul class="disc-meta"><li>★ 63.294</li><li>Python</li><li>GitHub Trending · 2026-06-27</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 61.864 → 63.294, son sürüm v0.11.1 (5 Haziran 2026).</li></ul></section>

--- a/discover/openspec/index.html
+++ b/discover/openspec/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OpenSpec</span><span class="disc-momentum">🚀 +177 bugün</span></div>
-<h1 class="disc-title">yapay zekâ projelerinde standart geliştirme</h1>
+<h1 class="disc-title">Yapay zekâ projelerinde standart geliştirme</h1>
 <p class="disc-lead">OpenSpec, yapay zekâ kod asistanları için şartname odaklı geliştirme (spec-driven development) süreçlerini destekleyen bir TypeScript kütüphanesidir. Yazılım geliştirme aşamalarında teknik gereksinimlerin standartlaştırılmasını ve kod üretim süreçlerinin daha kontrollü ilerlemesini sağlar.</p>
 <ul class="disc-meta"><li>★ 63.990</li><li>TypeScript</li><li>GitHub Trending · 2026-06-28</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 63.477 → 63.990, son sürüm v1.8.0 (5 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 57.272 → 63.477, son sürüm v1.7.0 (29 Temmuz 2026).</li></ul></section>

--- a/discover/openwork/index.html
+++ b/discover/openwork/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openwork</span><span class="disc-momentum">🚀 +97 bugün</span></div>
-<h1 class="disc-title">yapay zekâ iş akışlarını paylaşın</h1>
+<h1 class="disc-title">Yapay zekâ iş akışlarını paylaşın</h1>
 <p class="disc-lead">Openwork, Claude Cowork platformuna açık kaynaklı bir alternatif olarak geliştirilen ve opencode altyapısını kullanan bir yazılım projesidir. TypeScript diliyle yazılan bu araç, yazılım geliştirme süreçlerini otomatize etmeyi hedefleyen yapay zekâ destekli bir çalışma ortamı sunar.</p>
 <ul class="disc-meta"><li>★ 21.196</li><li>TypeScript</li><li>GitHub Trending · 2026-07-30</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 21.152 → 21.196, son sürüm v0.18.17 (6 Ağustos 2026).</li><li><strong>6 Ağustos 2026:</strong> Yıldız 20.740 → 21.152, son sürüm v0.18.16 (5 Ağustos 2026).</li><li><strong>4 Ağustos 2026:</strong> Yıldız 20.174 → 20.740, son sürüm v0.18.13 (3 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 18.143 → 20.174, son sürüm v0.18.12 (30 Temmuz 2026).</li></ul></section>

--- a/discover/outlines/index.html
+++ b/discover/outlines/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Outlines</span><span class="disc-momentum">🚀 +65 bugün</span></div>
-<h1 class="disc-title">yapay zekâ çıktılarını yapılandırın</h1>
+<h1 class="disc-title">Yapay zekâ çıktılarını yapılandırın</h1>
 <p class="disc-lead">Outlines kütüphanesi, büyük dil modellerinden gelen yanıtları önceden tanımlanmış şemalara göre yapılandırılmış çıktılar (structured outputs) halinde sunulmasını sağlıyor. Geliştiriciler, Python tabanlı bu araçla model çıktılarını düzenli ifadeler (regular expressions) veya bağlamsız dil bilgisi (context-free grammars) kurallarıyla kısıtlayarak veri bütünlüğünü koruyor.</p>
 <ul class="disc-meta"><li>★ 15.477</li><li>Python</li><li>GitHub Trending · 2026-07-22</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 14.917 → 15.477, son sürüm 1.3.2 (20 Temmuz 2026).</li></ul></section>

--- a/discover/palmier-pro/index.html
+++ b/discover/palmier-pro/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Palmier Pro</span><span class="disc-momentum">🚀 +756 bugün</span></div>
-<h1 class="disc-title">macOS için yapay zekâlı video düzenleyici</h1>
+<h1 class="disc-title">MacOS için yapay zekâlı video düzenleyici</h1>
 <p class="disc-lead">Palmier Pro, macOS işletim sistemi üzerinde çalışan ve yapay zekâ destekli düzenleme araçları sunan bir video düzenleyici (video editor) olarak geliştirildi. Swift diliyle yazılan bu uygulama, yapay zekâ tabanlı iş akışlarını yerel sistem performansı ile birleştirmeyi amaçlıyor.</p>
 <ul class="disc-meta"><li>★ 13.118</li><li>Swift</li><li>GitHub Trending · 2026-06-20</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 13.010 → 13.118, son sürüm v0.7.2 (6 Ağustos 2026).</li><li><strong>3 Ağustos 2026:</strong> Yıldız 12.988 → 13.010, son sürüm v0.7.1 (3 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 2.134 → 12.988, son sürüm v0.6.16 (30 Temmuz 2026).</li></ul></section>

--- a/discover/pg-durable/index.html
+++ b/discover/pg-durable/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pg Durable</span><span class="disc-momentum">🚀 +316 bugün</span></div>
-<h1 class="disc-title">PostgreSQL ile yapay zekâ süreçlerini yönetin</h1>
+<h1 class="disc-title">PostgreSQL üzerinde dayanıklı süreç yönetimi</h1>
 <p class="disc-lead">Microsoft tarafından geliştirilen pg_durable, PostgreSQL üzerinde dayanıklı yürütme (durable execution) süreçlerini yönetmek için tasarlanmış bir kütüphanedir. Rust diliyle yazılan araç, karmaşık iş akışlarını veritabanı içerisinde hata toleranslı ve kalıcı bir şekilde çalıştırmayı sağlar.</p>
 <ul class="disc-meta"><li>★ 2.716</li><li>Rust</li><li>GitHub Trending · 2026-06-08</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 1.580 → 2.716, son sürüm v0.2.5 (30 Temmuz 2026).</li></ul></section>

--- a/discover/pi-subagents/index.html
+++ b/discover/pi-subagents/index.html
@@ -59,7 +59,7 @@
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
       <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pi Subagents</span><span class="disc-momentum">🚀 Bir günde +69 yıldız</span></div>
-      <h1 class="disc-title">yapay zekâ ile asenkron görev yönetimi</h1>
+      <h1 class="disc-title">Yapay zekâ ile asenkron görev yönetimi</h1>
       <p class="disc-lead"><strong>pi-subagents</strong>, Pi platformu üzerinde <strong>asenkron alt-ajan delegasyonu</strong> süreçlerini yönetmek için geliştirilmiş bir TypeScript kütüphanesidir. Karmaşık iş yüklerini alt-ajanlara dağıtmayı kolaylaştırır.</p>
       <ul class="disc-meta"><li>★ 2.911</li><li>TypeScript</li><li>Lisans: yok</li><li>GitHub Trending · 1 Haziran 2026</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 2.831 → 2.911, son sürüm v0.41.0 (5 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 1.951 → 2.831, son sürüm v0.40.0 (1 Ağustos 2026).</li></ul></section>

--- a/discover/plane/index.html
+++ b/discover/plane/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Plane</span><span class="disc-momentum">🚀 +89 bugün</span></div>
-<h1 class="disc-title">açık kaynaklı proje yönetim platformu</h1>
+<h1 class="disc-title">Açık kaynaklı proje yönetim platformu</h1>
 <p class="disc-lead">Plane, görev yönetimi, sprint planlama ve dokümantasyon süreçlerini bir araya getiren açık kaynaklı bir proje yönetim platformudur. Jira ve Linear gibi kurumsal araçlara alternatif olarak geliştirilen bu platform, ekiplerin iş akışlarını merkezi bir arayüz üzerinden düzenlemesine olanak tanır.</p>
 <ul class="disc-meta"><li>★ 55.364</li><li>TypeScript</li><li>GitHub Trending · 2026-06-18</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 51.506 → 55.364, son sürüm v1.4.0 (31 Temmuz 2026).</li></ul></section>

--- a/discover/plugins/index.html
+++ b/discover/plugins/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Plugins</span><span class="disc-momentum">🚀 +49 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile güncel verilere erişin</h1>
+<h1 class="disc-title">Yapay zekâ ile güncel verilere erişin</h1>
 <p class="disc-lead">OpenAI eklentileri (plugins), dil modellerinin güncel verilere erişmesini ve üçüncü taraf uygulamalarla etkileşime girmesini sağlıyor. Bu yapı, yapay zekânın dış araçları kullanarak karmaşık görevleri yerine getirmesine olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 4.881</li><li>JavaScript</li><li>GitHub Trending · 2026-06-06</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 1.596 → 4.881.</li></ul></section>

--- a/discover/powertoys/index.html
+++ b/discover/powertoys/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · PowerToys</span></div>
-<h1 class="disc-title">Windows deneyimini özelleştiren yardımcı araçlar</h1>
+<h1 class="disc-title">Windows&#x27;u kendinize göre ayarlayın</h1>
 <p class="disc-lead">Microsoft PowerToys, Windows işletim sisteminde verimliliği ve kişiselleştirmeyi artırmak amacıyla geliştirilen bir yardımcı yazılım koleksiyonudur. Kullanıcılara sistem üzerinde gelişmiş özelleştirme araçları ve iş akışı optimizasyonları sunar.</p>
 <ul class="disc-meta"><li>★ 137.392</li><li>GitHub Trending · 2026-06-13</li></ul>
       <aside class="disc-note"><p><strong>TreScout notu:</strong> Tek bir program değil, Windows&#x27;a eklenen küçük araçlar paketi. Çoğu kişi ikisi için kuruyor: Pencereleri ekrana ızgara düzeninde yerleştiren araç ve klavyeden hızlı arama. Şirket bilgisayarında kurulum yönetici izni isteyebilir.</p></aside>

--- a/discover/production-agentic-rag-course/index.html
+++ b/discover/production-agentic-rag-course/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Production Agentic RAG Course</span></div>
-<h1 class="disc-title">yapay zekâ ile akıllı veri getirme</h1>
+<h1 class="disc-title">Yapay zekâ ile akıllı veri getirme</h1>
 <p class="disc-lead">Production-agentic-rag-course, karmaşık veri kaynaklarından bilgi getirme süreçlerini otomatize eden ajan tabanlı getirme destekli üretim (agentic RAG) sistemlerinin geliştirilmesine yönelik uygulamalı bir eğitim sunuyor. Python dilini temel alan bu kaynak, ölçeklenebilir ve üretim seviyesinde yapay zekâ uygulamaları oluşturmak için gerekli teknik mimariyi öğretiyor.</p>
 <ul class="disc-meta"><li>★ 8.216</li><li>GitHub Trending · 2026-06-03</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 6.536 → 8.216, son sürüm week7.0 (26 Kasım 2025).</li></ul></section>

--- a/discover/server/index.html
+++ b/discover/server/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Server</span></div>
-<h1 class="disc-title">Dijital müzik kütüphanenizi tek merkezden yönetin</h1>
+<h1 class="disc-title">Açık kaynaklı dijital müzik sunucusu</h1>
 <p class="disc-lead">Music Assistant, farklı dijital yayın servislerini ve bağlı hoparlörleri tek bir arayüzde birleştiren açık kaynaklı bir medya kütüphanesi yöneticisidir. Python tabanlı bu sunucu yazılımı, sürekli çalışan cihazlar üzerinde merkezi bir müzik yönetim sistemi oluşturulmasını sağlar.</p>
 <ul class="disc-meta"><li>★ 2.913</li><li>GitHub Trending · 2026-06-13</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 1.857 → 2.913, son sürüm 2.9.10 (30 Temmuz 2026).</li></ul></section>

--- a/discover/sia/index.html
+++ b/discover/sia/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · SIA</span><span class="disc-momentum">🚀 +199 bugün</span></div>
-<h1 class="disc-title">yapay zekâ modellerini otonom test edin</h1>
+<h1 class="disc-title">Yapay zekâ modellerini otonom test edin</h1>
 <p class="disc-lead">SIA, yapay zekâ modellerinin ve ajanların belirli kıyaslama görevlerindeki (benchmark tasks) performanslarını otonom şekilde artırmak için geliştirilen bir öz-iyileştiren yapay zekâ (self-improving AI) çerçevesidir. Python tabanlı bu sistem, yapay zekâ sistemlerinin kendi çıktılarını analiz ederek süreçlerini optimize etmesini sağlar.</p>
 <ul class="disc-meta"><li>★ 1.478</li><li>Python</li><li>GitHub Trending · 2026-06-12</li></ul>
       <section class="disc-sec"><h2>Ne kazandırır?</h2><ul class="disc-wins"><li>Yapay zekâ modellerinin görev performansını otonom şekilde artırır.</li><li>Meta, hedef ve geri bildirim ajanları arasında döngüsel iyileştirme sağlar.</li><li>Benchmark görevlerinde yüksek doğruluk ve işlem hızı verimliliği sunar.</li></ul></section>

--- a/discover/skills/index.html
+++ b/discover/skills/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Skills</span><span class="disc-momentum">🚀 +461 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanlarını Google ile güçlendirin</h1>
+<h1 class="disc-title">Yapay zekâ ajanlarını Google ile güçlendirin</h1>
 <p class="disc-lead">Google tarafından geliştirilen yetenekler (skills) kütüphanesi, yapay zekâ ajanlarının Google ürünleri ve teknolojileriyle etkileşim kurmasını sağlayan Python tabanlı araçlar sunuyor. Bu kaynak, ajanların belirli görevleri yerine getirmesi için gerekli işlevselliği standartlaştırılmış bir yapıda sağlıyor.</p>
 <ul class="disc-meta"><li>★ 15.389</li><li>Python</li><li>GitHub Trending · 2026-06-09</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 12.675 → 15.389.</li></ul></section>

--- a/discover/skillspector/index.html
+++ b/discover/skillspector/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · SkillSpector</span><span class="disc-momentum">🚀 +319 bugün</span></div>
-<h1 class="disc-title">yapay zekâ yeteneklerini güvenli kılın</h1>
+<h1 class="disc-title">Yapay zekâ yeteneklerini güvenli kılın</h1>
 <p class="disc-lead">NVIDIA tarafından geliştirilen SkillSpector, yapay zekâ ajanlarına ait yetenek paketlerindeki (skills) güvenlik açıklarını ve kötü niyetli kalıpları tespit eden bir tarama aracıdır. Python tabanlı bu yazılım, ajan tabanlı sistemlerin geliştirilme sürecinde karşılaşılan güvenlik risklerini analiz etmeyi hedefler.</p>
 <ul class="disc-meta"><li>★ 14.260</li><li>Python</li><li>GitHub Trending · 2026-06-12</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 14.066 → 14.260, son sürüm v2.5.3 (5 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 2.967 → 14.066, son sürüm v2.5.1 (31 Temmuz 2026).</li></ul></section>

--- a/discover/snipe-it/index.html
+++ b/discover/snipe-it/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Snipe It</span><span class="disc-momentum">🚀 +164 bugün</span></div>
-<h1 class="disc-title">kurumsal varlık ve lisans yönetimi</h1>
+<h1 class="disc-title">Kurumsal varlık ve lisans yönetimi</h1>
 <p class="disc-lead">Snipe-IT, bilişim teknolojileri varlıklarını ve yazılım lisanslarını takip etmeye yarayan açık kaynaklı bir yönetim sistemidir. PHP diliyle geliştirilen bu platform, kurumların envanter kayıtlarını ve kullanım döngülerini dijital ortamda düzenlemesine olanak tanır.</p>
 <ul class="disc-meta"><li>★ 14.677</li><li>PHP</li><li>GitHub Trending · 2026-07-30</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 14.536 → 14.677, son sürüm v8.6.3 (15 Haziran 2026).</li></ul></section>

--- a/discover/spec-kit/index.html
+++ b/discover/spec-kit/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Spec Kit</span><span class="disc-momentum">🚀 +321 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile şartname odaklı geliştirme</h1>
+<h1 class="disc-title">Yapay zekâ ile şartname odaklı geliştirme</h1>
 <p class="disc-lead">GitHub tarafından yayınlanan spec-kit, şartname odaklı geliştirme (spec-driven development) süreçlerini başlatmak için gerekli araçları sunuyor. Python tabanlı bu kütüphane, yazılım geliştirme aşamasında tanımlanan teknik şartnamelerin kod süreçlerine entegrasyonunu kolaylaştırıyor.</p>
 <ul class="disc-meta"><li>★ 125.507</li><li>Python</li><li>GitHub Trending · 2026-06-05</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 125.212 → 125.507, son sürüm v0.16.0 (5 Ağustos 2026).</li><li><strong>4 Ağustos 2026:</strong> Yıldız 125.003 → 125.212, son sürüm v0.15.2 (3 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 108.801 → 125.003, son sürüm v0.15.1 (31 Temmuz 2026).</li></ul></section>

--- a/discover/stitch-skills/index.html
+++ b/discover/stitch-skills/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Stitch Skills</span><span class="disc-momentum">🚀 +117 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanları için tasarım yetenekleri</h1>
+<h1 class="disc-title">Yapay zekâ ajanları için tasarım yetenekleri</h1>
 <p class="disc-lead">Google Labs tarafından geliştirilen Stitch Skills, Stitch MCP sunucusuyla uyumlu çalışmak üzere tasarlanmış bir ajan yetenekleri (agent skills) kütüphanesidir. Açık standartları takip eden bu kütüphane, Gemini CLI ve Cursor gibi kodlama ajanları (coding agents) için iş akışlarını standartlaştırmayı amaçlar.</p>
 <ul class="disc-meta"><li>★ 7.892</li><li>TypeScript</li><li>GitHub Trending · 2026-07-11</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 6.814 → 7.892, son sürüm v1.0 (18 Mayıs 2026).</li></ul></section>

--- a/discover/stop-slop/index.html
+++ b/discover/stop-slop/index.html
@@ -59,7 +59,7 @@
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
       <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Stop Slop</span><span class="disc-momentum">🚀 Bir günde +547 yıldız</span></div>
-      <h1 class="disc-title">yapay zekâ metinlerini doğallaştırın</h1>
+      <h1 class="disc-title">Yapay zekâ metinlerini doğallaştırın</h1>
       <p class="disc-lead">Yapay zekâ ile üretilen metinler genellikle tahmin edilebilir ifadeler, ritimler ve yapılar içerir. <strong>Stop Slop</strong>, Claude veya herhangi bir LLM'e bu kalıpları yakalayıp temizlemeyi öğreten bir beceri dosyasıdır. Bu sayede metinleriniz çok daha doğal ve insani bir tona kavuşur.</p>
       <figure class="disc-shot"><img src="/assets/discover/stop-slop.webp" width="1440" height="810" loading="lazy" decoding="async" alt="Stop Slop arayüzünden bir görünüm"><figcaption>Görsel: stop-slop (proje deposundan)</figcaption></figure>
       <ul class="disc-meta"><li>★ 14.843</li><li>Claude Skill</li><li>MIT</li><li>GitHub Trending · 26 May 2026</li></ul>

--- a/discover/strix/index.html
+++ b/discover/strix/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Strix</span><span class="disc-momentum">🚀 +122 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile otomatik güvenlik taraması</h1>
+<h1 class="disc-title">Yapay zekâ ile otomatik güvenlik taraması</h1>
 <p class="disc-lead">Strix, uygulamalardaki güvenlik açıklarını tespit etmek ve gidermek için tasarlanmış açık kaynaklı bir yapay zekâ tabanlı güvenlik aracıdır (AI security tool). Python diliyle geliştirilen bu sistem, yazılım geliştirme süreçlerinde zafiyet tarama ve düzeltme işlemlerini otomatize eder.</p>
 <ul class="disc-meta"><li>★ 49.097</li><li>Python</li><li>GitHub Trending · 2026-06-29</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 46.599 → 49.097, son sürüm v1.4.1 (27 Temmuz 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 27.035 → 46.599, son sürüm v1.4.1 (27 Temmuz 2026).</li></ul></section>

--- a/discover/supabase/index.html
+++ b/discover/supabase/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Supabase</span><span class="disc-momentum">🚀 +169 bugün</span></div>
-<h1 class="disc-title">açık kaynaklı Postgres geliştirme platformu</h1>
+<h1 class="disc-title">Açık kaynaklı Postgres geliştirme platformu</h1>
 <p class="disc-lead">Supabase, web, mobil ve yapay zekâ uygulamaları geliştirmek için Postgres veritabanı (Postgres database) altyapısı sunan bir geliştirme platformudur. Açık kaynaklı yapısıyla uygulama geliştirme süreçlerini hızlandırmak için gerekli olan veritabanı yönetimi ve arka uç (backend) hizmetlerini bir arada sağlar.</p>
 <ul class="disc-meta"><li>★ 107.399</li><li>TypeScript</li><li>GitHub Trending · 2026-07-04</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 105.582 → 107.399, son sürüm v1.26.07 (9 Temmuz 2026).</li></ul></section>

--- a/discover/supermemory/index.html
+++ b/discover/supermemory/index.html
@@ -59,7 +59,7 @@
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
       <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Supermemory</span><span class="disc-momentum">🚀 Bir günde +264 yıldız</span></div>
-      <h1 class="disc-title">yapay zekâ için akıllı bellek</h1>
+      <h1 class="disc-title">Yapay zekâ için akıllı bellek</h1>
       <p class="disc-lead"><strong>Supermemory</strong>, yapay zekâ çağı için tasarlanmış, yüksek <strong>ölçeklenebilir bir bellek motoru</strong> ve API sunar. Uygulamalarınıza kalıcı ve sorgulanabilir bir hafıza katmanı eklemenizi sağlar.</p>
       <figure class="disc-shot"><img src="/assets/discover/supermemory.webp" width="1440" height="954" loading="lazy" decoding="async" alt="Supermemory arayüzünden bir görünüm"><figcaption>Görsel: supermemory (proje deposundan)</figcaption></figure>
       <ul class="disc-meta"><li>★ 28.742</li><li>TypeScript</li><li>MIT</li><li>GitHub Trending · 1 Haziran 2026</li></ul>

--- a/discover/supervision/index.html
+++ b/discover/supervision/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Supervision</span><span class="disc-momentum">🚀 +1.288 bugün</span></div>
-<h1 class="disc-title">Bilgisayarlı görü projelerinizi yapay zekâ ile hızlandırın</h1>
+<h1 class="disc-title">Bilgisayarlı görü projeleri için araçlar</h1>
 <p class="disc-lead">Roboflow tarafından geliştirilen Supervision, bilgisayarlı görü (computer vision) projeleri için yeniden kullanılabilir yardımcı araçlar ve fonksiyonlar sunuyor. Python tabanlı bu kütüphane, nesne tespiti ve takibi gibi süreçlerdeki standart işlemleri kolaylaştırarak geliştirme iş akışlarını hızlandırıyor.</p>
 <ul class="disc-meta"><li>★ 49.033</li><li>Python</li><li>GitHub Trending · 2026-06-09</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 48.545 → 49.033, son sürüm 0.30.0 (4 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 42.546 → 48.545, son sürüm 0.29.1 (23 Haziran 2026).</li></ul></section>

--- a/discover/svelte/index.html
+++ b/discover/svelte/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Svelte</span></div>
-<h1 class="disc-title">Web uygulamaları için derleyici yaklaşımı</h1>
+<h1 class="disc-title">Derleme zamanında çalışan arayüz çerçevesi</h1>
 <p class="disc-lead">Svelte, geleneksel çerçevelerin aksine tarayıcıda çalışma zamanı (runtime) yükünü azaltan bir derleme zamanı (compile-time) yaklaşımı kullanıyor. Bu JavaScript kütüphanesi, uygulama kodunu küçük ve hızlı çalışan saf JavaScript modüllerine dönüştürerek web geliştirme süreçlerini basitleştiriyor.</p>
 <ul class="disc-meta"><li>★ 87.724</li><li>GitHub Trending · 2026-06-07</li></ul>
       <aside class="disc-note"><p><strong>TreScout notu:</strong> Web arayüzü yazarken kullanılan çerçevelerden biri. İşin çoğunu siz kodu yazarken hallettiği için ziyaretçinin tarayıcısına daha az kod iner, sayfa hızlı açılır. Bedeli topluluk büyüklüğü: En yaygın seçenek olan React&#x27;e göre hazır parça, örnek ve iş ilanı azdır.</p></aside>

--- a/discover/swc/index.html
+++ b/discover/swc/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · SWC</span></div>
-<h1 class="disc-title">Web projeleri için hızlı derleyici</h1>
+<h1 class="disc-title">Web projelerinizi Rust hızında derleyin</h1>
 <p class="disc-lead">Rust diliyle geliştirilen SWC, web projeleri için hızlı bir derleme (compilation) ve paketleme (bundling) platformu sunuyor. JavaScript ve TypeScript dosyalarını yüksek performansla işleyerek modern web geliştirme süreçlerini hızlandırıyor.</p>
 <ul class="disc-meta"><li>★ 34.160</li><li>GitHub Trending · 2026-06-14</li></ul>
       <aside class="disc-note"><p><strong>TreScout notu:</strong> Yazdığınız modern JavaScript kodunu tarayıcıların anladığı biçime çevirir, aynı işi yapan eski araçlara göre çok daha hızlıdır. Hata denetimi yapmaz, yalnızca çevirir. Bazı popüler çerçeveler bunu zaten içeride kullanıyor, farkında olmadan kullanıyor olabilirsiniz.</p></aside>

--- a/discover/system-prompts-and-models-of-ai-tools/index.html
+++ b/discover/system-prompts-and-models-of-ai-tools/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · System Prompts and Models of AI Tools</span><span class="disc-momentum">🚀 +79 bugün</span></div>
-<h1 class="disc-title">yapay zekâ araçlarının perde arkası</h1>
+<h1 class="disc-title">Yapay zekâ araçlarının perde arkası</h1>
 <p class="disc-lead">Popüler yapay zekâ araçlarının sistem yönergeleri (system prompts) ve kullanılan dil modelleri (AI models), geliştiricilerin incelemesi için tek bir kaynakta toplanıyor. Bu arşiv, güncel kodlama asistanlarının ve üretken yapay zekâ (generative AI) platformlarının arka planındaki yapılandırma stratejilerini şeffaf bir şekilde ortaya koyuyor.</p>
 <ul class="disc-meta"><li>★ 139.309</li><li>GitHub Trending · 2026-06-10</li></ul>
       <section class="disc-sec"><h2>Ne kazandırır?</h2><ul class="disc-wins"><li>Popüler yapay zekâ araçlarının sistem yönergelerine erişim sağlar.</li><li>Kullanılan dil modellerinin yapılandırma stratejilerini şeffaflaştırır.</li><li>Yapay zekâ sistemlerinin arka planındaki teknik detayları inceleme imkânı sunar.</li></ul></section>

--- a/discover/system-prompts-leaks/index.html
+++ b/discover/system-prompts-leaks/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · System Prompts Leaks</span><span class="disc-momentum">🚀 +282 bugün</span></div>
-<h1 class="disc-title">yapay zekâ modellerinin gizli talimatları</h1>
+<h1 class="disc-title">Yapay zekâ modellerinin gizli talimatları</h1>
 <p class="disc-lead">GitHub üzerinde paylaşılan system_prompts_leaks deposu, Anthropic, OpenAI, Google ve xAI gibi büyük teknoloji şirketlerinin yapay zekâ modellerine ait sistem istemlerini (system prompts) bir araya getiriyor. Bu derleme, popüler dil modellerinin arka planda çalışan yapılandırma talimatlarını ve kısıtlamalarını incelemek isteyen geliştiriciler için merkezi bir kaynak sunuyor.</p>
 <ul class="disc-meta"><li>★ 61.968</li><li>JavaScript</li><li>GitHub Trending · 2026-06-22</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 44.809 → 61.968.</li></ul></section>

--- a/discover/taste-skill/index.html
+++ b/discover/taste-skill/index.html
@@ -59,7 +59,7 @@
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
       <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Taste Skill</span><span class="disc-momentum">🚀 Bir günde +1.440 yıldız</span></div>
-      <h1 class="disc-title">yapay zekâ Tasarımlarını Profesyonelleştirin</h1>
+      <h1 class="disc-title">Yapay zekâ Tasarımlarını Profesyonelleştirin</h1>
       <p class="disc-lead">Yapay zekâ ajanları arayüz üretirken çoğu zaman şablon odaklı sonuçlar verir. <strong>Taste Skill</strong>, ajanlara daha etkili <strong>yerleşim, tipografi, hareket ve boşluk</strong> kullanımı öğreten taşınabilir bir beceri setidir. Bu sayede yapay zekâ ile oluşturulan arayüzler çok daha özgün ve profesyonel görünür.</p>
       <figure class="disc-shot"><img src="/assets/discover/taste-skill.webp" width="1440" height="950" loading="lazy" decoding="async" alt="Taste Skill arayüzünden bir görünüm"><figcaption>Görsel: taste-skill (proje deposundan)</figcaption></figure>
       <ul class="disc-meta"><li>★ 69.955</li><li>Shell</li><li>MIT</li><li>GitHub Trending · 26 May 2026</li></ul>

--- a/discover/tencentdb-agent-memory/index.html
+++ b/discover/tencentdb-agent-memory/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · TencentDB-Agent-Memory</span><span class="disc-momentum">🚀 +318 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ajanları için katmanlı bellek</h1>
+<h1 class="disc-title">Yapay zekâ ajanları için katmanlı bellek</h1>
 <p class="disc-lead">TencentDB Agent Memory, yapay zekâ ajanları için dört aşamalı bir süreçle tamamen yerel uzun süreli bellek (long-term memory) çözümü sunuyor. Dış kaynaklı uygulama programlama arayüzlerine (API) ihtiyaç duymadan veri saklama ve geri çağırma işlemlerini gerçekleştiriyor.</p>
 <ul class="disc-meta"><li>★ 15.363</li><li>TypeScript</li><li>GitHub Trending · 2026-07-09</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 12.420 → 15.363, son sürüm v2.0.0 (3 Ağustos 2026).</li><li><strong>4 Ağustos 2026:</strong> Yıldız 10.727 → 12.420, son sürüm v2.0.0 (3 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 7.846 → 10.727, son sürüm v1.0.1 (14 Temmuz 2026).</li></ul></section>

--- a/discover/timesfm/index.html
+++ b/discover/timesfm/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Timesfm</span><span class="disc-momentum">🚀 +606 bugün</span></div>
-<h1 class="disc-title">zaman serileri için yapay zekâ tahminleme</h1>
+<h1 class="disc-title">Zaman serileri için yapay zekâ tahminleme</h1>
 <p class="disc-lead">Google Research tarafından geliştirilen Zaman Serisi Temel Modeli (Time Series Foundation Model), zaman serisi tahminleme işlemleri için önceden eğitilmiş bir yapı sunuyor. Model, farklı veri setleri üzerinde genel tahminleme yetenekleri sağlamak amacıyla tasarlanmıştır.</p>
 <ul class="disc-meta"><li>★ 27.185</li><li>Python</li><li>GitHub Trending · 2026-06-18</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 22.167 → 27.185, son sürüm v2.0.2 (2 Temmuz 2026).</li></ul></section>

--- a/discover/tolaria/index.html
+++ b/discover/tolaria/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Tolaria</span><span class="disc-momentum">🚀 +245 bugün</span></div>
-<h1 class="disc-title">Markdown notlarınızı yapay zekâ ile düzenleyin</h1>
+<h1 class="disc-title">Markdown bilgi tabanı masaüstü uygulaması</h1>
 <p class="disc-lead">Tolaria, Markdown tabanlı bilgi tabanlarını yönetmek için geliştirilen bir masaüstü uygulamasıdır. TypeScript ile yazılan bu araç, kişisel dokümantasyon ve not sistemlerini düzenli bir yapıda tutmayı kolaylaştırır.</p>
 <ul class="disc-meta"><li>★ 19.219</li><li>TypeScript</li><li>GitHub Trending · 2026-06-08</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 13.116 → 19.219, son sürüm v2027-07-31 (31 Temmuz 2026).</li></ul></section>

--- a/discover/tradingagents/index.html
+++ b/discover/tradingagents/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · TradingAgents</span></div>
-<h1 class="disc-title">yapay zekâ ile akıllı borsa işlemleri</h1>
+<h1 class="disc-title">Yapay zekâ ile akıllı borsa işlemleri</h1>
 <p class="disc-lead">TradingAgents, finansal piyasalarda işlem yapmak amacıyla geliştirilen çoklu ajanlı büyük dil modeli (multi-agent LLM) tabanlı bir çerçevedir. Python ile yazılan bu sistem, otonom ticaret ajanlarının finansal verileri analiz ederek strateji oluşturmasını ve karar verme süreçlerini yönetmesini sağlar.</p>
 <ul class="disc-meta"><li>★ 95.338</li><li>GitHub Trending · 2026-06-02</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 82.054 → 95.338, son sürüm v0.3.1 (5 Temmuz 2026).</li></ul></section>

--- a/discover/transcribe-cpp/index.html
+++ b/discover/transcribe-cpp/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Transcribe.cpp</span><span class="disc-momentum">🚀 +395 bugün</span></div>
-<h1 class="disc-title">yerel sistemlerde hızlı konuşma dönüştürme</h1>
+<h1 class="disc-title">Yerel sistemlerde hızlı konuşma dönüştürme</h1>
 <p class="disc-lead">Transcribe.cpp, 16&#x27;dan fazla model ailesini destekleyen ve C++ diliyle geliştirilen bir konuşmayı metne dönüştürme (speech-to-text) çıkarım (inference) kütüphanesidir. Ggml altyapısını kullanan bu araç, farklı ses işleme modellerinin yerel sistemlerde verimli bir şekilde çalıştırılmasını sağlar.</p>
 <ul class="disc-meta"><li>★ 1.673</li><li>C++</li><li>GitHub Trending · 2026-07-21</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 1.357 → 1.673, son sürüm v0.1.3 (12 Temmuz 2026).</li></ul></section>

--- a/discover/trivy/index.html
+++ b/discover/trivy/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Trivy</span><span class="disc-momentum">🚀 +24 bugün</span></div>
-<h1 class="disc-title">Konteyner ve Bulut Güvenliğinizi yapay zekâ ile Koruyun</h1>
+<h1 class="disc-title">Konteyner ve bulut güvenlik tarayıcısı</h1>
 <p class="disc-lead">Trivy, konteynerler, Kubernetes kümeleri ve bulut altyapılarındaki güvenlik açıklarını, hatalı yapılandırmaları ve gizli anahtarları (secrets) tespit eden kapsamlı bir güvenlik tarama aracıdır. Yazılım malzeme listesi (SBOM) oluşturma yeteneğiyle geliştirme süreçlerinde güvenlik denetimlerini otomatize eder.</p>
 <ul class="disc-meta"><li>★ 35.511</li><li>Go</li><li>GitHub Trending · 2026-06-04</li></ul>
       <section class="disc-sec"><h2>Ne kazandırır?</h2><ul class="disc-wins"><li>Konteyner imajlarında güvenlik açıklarını tespit eder.</li><li>Yazılım bağımlılıklarını ve hatalı yapılandırmaları denetler.</li><li>Gizli anahtarları ve hassas bilgileri tarayarak sızıntıları önler.</li></ul></section>

--- a/discover/turbovec/index.html
+++ b/discover/turbovec/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Turbovec</span><span class="disc-momentum">🚀 +1.554 bugün</span></div>
-<h1 class="disc-title">Yüksek performanslı yapay zekâ vektör dizini</h1>
+<h1 class="disc-title">Rust ile yüksek performanslı vektör dizini</h1>
 <p class="disc-lead">TurboQuant altyapısı üzerine inşa edilen turbovec, Rust diliyle geliştirilmiş yüksek performanslı bir vektör dizini (vector index) aracıdır. Python bağlamaları (bindings) sayesinde geliştiricilerin vektör tabanlı arama işlemlerini hızlı ve verimli bir şekilde gerçekleştirmesine olanak tanır.</p>
 <ul class="disc-meta"><li>★ 14.575</li><li>Python</li><li>GitHub Trending · 2026-06-08</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 7.703 → 14.575.</li></ul></section>

--- a/discover/ui-tars-desktop/index.html
+++ b/discover/ui-tars-desktop/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · UI-TARS-desktop</span><span class="disc-momentum">🚀 +150 bugün</span></div>
-<h1 class="disc-title">bilgisayarınızı yöneten yapay zekâ arayüzü</h1>
+<h1 class="disc-title">Bilgisayarınızı yöneten yapay zekâ arayüzü</h1>
 <p class="disc-lead">ByteDance tarafından geliştirilen UI-TARS, çok modlu yapay zekâ modellerini (multimodal AI models) masaüstü arayüzleriyle entegre eden açık kaynaklı bir ajan altyapısıdır. Bu sistem, görsel verileri işleyerek bilgisayar üzerindeki görevleri otonom şekilde gerçekleştiren ajanların (AI agents) oluşturulmasını sağlar.</p>
 <ul class="disc-meta"><li>★ 38.404</li><li>TypeScript</li><li>GitHub Trending · 2026-06-18</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 36.779 → 38.404, son sürüm v0.3.0 (4 Kasım 2025).</li></ul></section>

--- a/discover/unity-mcp/index.html
+++ b/discover/unity-mcp/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Unity MCP</span><span class="disc-momentum">🚀 +69 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile unity yönetimi</h1>
+<h1 class="disc-title">Yapay zekâ ile unity yönetimi</h1>
 <p class="disc-lead">Unity MCP, büyük dil modelleri (large language models) ile Unity düzenleyicisi arasında bir köprü kurarak varlık yönetimi, sahne kontrolü ve kod düzenleme süreçlerinin otomatize edilmesini sağlıyor. Model Sunucu Protokolü (Model Context Protocol) aracılığıyla çalışan bu araç, yapay zekâ asistanlarının oyun geliştirme iş akışlarına doğrudan müdahale etmesine imkân tanıyor.</p>
 <ul class="disc-meta"><li>★ 13.091</li><li>C#</li><li>GitHub Trending · 2026-07-05</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>3 Ağustos 2026:</strong> Yıldız 13.064 → 13.091, son sürüm v10.1.2 (2 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 11.702 → 13.064, son sürüm v10.1.0 (13 Temmuz 2026).</li></ul></section>

--- a/discover/vibe-trading/index.html
+++ b/discover/vibe-trading/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Vibe-Trading</span><span class="disc-momentum">🚀 +197 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile kişisel alım satım</h1>
+<h1 class="disc-title">Yapay zekâ ile kişisel alım satım</h1>
 <p class="disc-lead">Vibe-Trading, finansal piyasalarda işlem yapmak amacıyla geliştirilmiş kişisel bir alım satım ajanı (trading agent) sunuyor. Proje, Python tabanlı yapısıyla kullanıcıların otomatik ticaret stratejilerini yönetmelerine olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 29.309</li><li>Python</li><li>GitHub Trending · 2026-06-04</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 10.343 → 29.309, son sürüm v0.1.12 (22 Temmuz 2026).</li></ul></section>

--- a/discover/vibevoice/index.html
+++ b/discover/vibevoice/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · VibeVoice</span></div>
-<h1 class="disc-title">yapay zekâ ile uzun ses kayıtlarını çözümleme</h1>
+<h1 class="disc-title">Yapay zekâ ile uzun ses kayıtlarını çözümleme</h1>
 <p class="disc-lead">Microsoft tarafından yayınlanan VibeVoice, açık kaynaklı bir sesli yapay zekâ (voice AI) çerçevesi olarak geliştirildi. Sistem, Python tabanlı yapısıyla kullanıcıların kendi ses modellerini eğitmelerine ve uygulamalarına entegre etmelerine olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 51.860</li><li>GitHub Trending · 2026-06-07</li></ul>
       <aside class="disc-note"><p><strong>TreScout notu:</strong> Depo yayımlandıktan sonra değişti: Sesi yazıya çeviren kısım duruyor, yazıyı sese çeviren kısım geri çekildi. Uzun kayıtları tek seferde işleyebilmesi ayırt edici yanı. Hızlı değişen bir proje, işinize katmadan önce deponun bugünkü hâline bakın.</p></aside>

--- a/discover/video-use/index.html
+++ b/discover/video-use/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Video Use</span><span class="disc-momentum">🚀 +196 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile otomatik video düzenleme</h1>
+<h1 class="disc-title">Yapay zekâ ile otomatik video düzenleme</h1>
 <p class="disc-lead">Video-use kütüphanesi, kodlama ajanlarının (coding agents) video düzenleme süreçlerini otomatize etmesine olanak tanıyor. Python tabanlı bu araç, görsel düzenleme görevlerini yazılım komutları aracılığıyla yerine getirerek iş akışlarını hızlandırıyor.</p>
 <ul class="disc-meta"><li>★ 19.784</li><li>Python</li><li>GitHub Trending · 2026-06-29</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 18.290 → 19.784.</li><li><strong>2 Ağustos 2026:</strong> Yıldız 11.471 → 18.290.</li></ul></section>

--- a/discover/voice-pro/index.html
+++ b/discover/voice-pro/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Voice Pro</span><span class="disc-momentum">🚀 +58 bugün</span></div>
-<h1 class="disc-title">Hepsi bir arada yapay zekâ ses aracı</h1>
+<h1 class="disc-title">Metinden konuşmaya ve ses kopyalama</h1>
 <p class="disc-lead">Voice-pro, metinden konuşmaya dönüştürme (TTS) ve sıfır örnekli ses kopyalama (zero-shot voice cloning) araçlarını bir araya getiren açık kaynaklı bir arayüzdür. Kullanıcılar, web tabanlı arayüzü üzerinden ses ayrıştırma, çok dilli çeviri ve YouTube içeriklerini işleme gibi işlemleri tek bir platformda gerçekleştirebilir.</p>
 <ul class="disc-meta"><li>★ 11.965</li><li>Python</li><li>GitHub Trending · 2026-08-02</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 11.859 → 11.965, son sürüm v4.0.0 (13 Temmuz 2026).</li></ul></section>

--- a/discover/voicebox/index.html
+++ b/discover/voicebox/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Voicebox</span><span class="disc-momentum">🚀 +145 bugün</span></div>
-<h1 class="disc-title">yerel ortamda çalışan yapay zekâ ses stüdyosu</h1>
+<h1 class="disc-title">Yerel ortamda çalışan yapay zekâ ses stüdyosu</h1>
 <p class="disc-lead">Voicebox, kullanıcıların ses kopyalama (voice cloning), dikte ve içerik oluşturma işlemlerini gerçekleştirmesine olanak tanıyan açık kaynaklı bir yapay zekâ ses stüdyosudur. TypeScript diliyle geliştirilen bu platform, ses işleme süreçlerini yerel ortamda yönetmek için kapsamlı araçlar sunar.</p>
 <ul class="disc-meta"><li>★ 48.096</li><li>TypeScript</li><li>GitHub Trending · 2026-06-21</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 31.156 → 48.096, son sürüm v0.5.0 (25 Nisan 2026).</li></ul></section>

--- a/discover/vulnclaw/index.html
+++ b/discover/vulnclaw/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · VulnClaw</span><span class="disc-momentum">🚀 +129 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile otomatik sızma testi</h1>
+<h1 class="disc-title">Yapay zekâ ile otomatik sızma testi</h1>
 <p class="disc-lead">VulnClaw, yapay zekâ ajanları (AI agents) ve model bağlam protokolü (Model Context Protocol) araç zincirini kullanarak sızma testi süreçlerini otomatize ediyor. Araç, doğal dil komutlarını işleyerek bilgi toplama, zafiyet tarama, istismar ve raporlama adımlarını uçtan uca gerçekleştiriyor.</p>
 <ul class="disc-meta"><li>★ 2.575</li><li>Python</li><li>GitHub Trending · 2026-06-30</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 2.425 → 2.575, son sürüm v0.3.7 (4 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 1.313 → 2.425, son sürüm v0.3.6 (25 Temmuz 2026).</li></ul></section>

--- a/discover/win11debloat/index.html
+++ b/discover/win11debloat/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Win11Debloat</span></div>
-<h1 class="disc-title">Windows sisteminizi yapay zekâdan arındırın</h1>
+<h1 class="disc-title">Windows Sistemini Gereksizlerden Arındırın</h1>
 <p class="disc-lead">Win11Debloat, Windows 10 ve 11 işletim sistemlerinde önceden yüklenmiş uygulamaları kaldırmayı ve telemetri verilerini devre dışı bırakmayı sağlayan bir PowerShell betiğidir. Kullanıcıların sistemlerini özelleştirmelerine ve gereksiz bileşenlerden arındırarak sistem hafifletme (debloat) işlemi yapmalarına olanak tanır.</p>
 <ul class="disc-meta"><li>★ 54.506</li><li>GitHub Trending · 2026-06-16</li></ul>
       <aside class="disc-note"><p><strong>TreScout notu:</strong> Windows&#x27;la birlikte gelen istemediğiniz uygulamaları kaldırır, arka planda veri toplayan ayarları kapatır. Çalıştırmadan önce ne yaptığını okuyun: Kaldırılan bazı parçaları geri getirmek kolay değildir. Kişisel bilgisayarda pratik, şirket cihazında ya da başkasıyla paylaştığınız bilgisayarda kullanmayın.</p></aside>

--- a/discover/wrenai/index.html
+++ b/discover/wrenai/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · WrenAI</span><span class="disc-momentum">🚀 +121 bugün</span></div>
-<h1 class="disc-title">yapay zekâ ile otomatik iş zekâsı</h1>
+<h1 class="disc-title">Yapay zekâ ile otomatik iş zekâsı</h1>
 <p class="disc-lead">Canner tarafından geliştirilen WrenAI, doğal dili veritabanı sorgularına (text-to-SQL) dönüştürerek verileri otomatik olarak panellere ve grafiklere aktaran açık kaynaklı bir üretken iş zekası (generative BI) aracıdır. Platform, yirmiden fazla veri kaynağını destekleyen yönetilebilir bir bağlam katmanı üzerinden yapay zekâ ajanları için güvenilir veri analitiği süreçleri sunar.</p>
 <ul class="disc-meta"><li>★ 17.046</li><li>Python</li><li>GitHub Trending · 2026-07-20</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>6 Ağustos 2026:</strong> Yıldız 16.780 → 17.046, son sürüm 0.29.2 (5 Ağustos 2026).</li><li><strong>2 Ağustos 2026:</strong> Yıldız 16.314 → 16.780, son sürüm wren-pydantic-v0.2.1 (29 Temmuz 2026).</li></ul></section>

--- a/discover/zhangxuefeng-skill/index.html
+++ b/discover/zhangxuefeng-skill/index.html
@@ -59,7 +59,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Zhangxuefeng Skill</span><span class="disc-momentum">🚀 +89 bugün</span></div>
-<h1 class="disc-title">Kariyer ve Tercih Rehberiniz yapay zekâ</h1>
+<h1 class="disc-title">Kariyer ve üniversite tercihi rehberi</h1>
 <p class="disc-lead">Zhangxuefeng-skill, üniversite sınavı tercihleri, lisansüstü eğitim ve kariyer planlama süreçleri için yapılandırılmış bir bilişsel işletim sistemi (cognitive operating system) sunuyor. Nuwa.skill altyapısıyla oluşturulan bu proje, karmaşık karar verme süreçlerini pratik bir düşünce çerçevesi (thought framework) ile standartlaştırıyor.</p>
 <ul class="disc-meta"><li>★ 10.048</li><li>GitHub Trending · 2026-06-12</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 8.114 → 10.048.</li></ul></section>

--- a/discover/zvec/index.html
+++ b/discover/zvec/index.html
@@ -60,7 +60,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Zvec</span><span class="disc-momentum">🚀 +156 bugün</span></div>
-<h1 class="disc-title">Uygulama içi hızlı yapay zekâ veritabanı</h1>
+<h1 class="disc-title">Hızlı uygulama içi vektör veritabanı</h1>
 <p class="disc-lead">Alibaba tarafından geliştirilen zvec, C++ diliyle yazılmış hafif ve yüksek hızlı bir süreç içi vektör veritabanı (in-process vector database) çözümüdür. Uygulamaların vektör verilerini doğrudan bellek üzerinde işlemesine olanak tanıyarak sistem performansını artırmayı hedefler.</p>
 <ul class="disc-meta"><li>★ 15.356</li><li>C++</li><li>GitHub Trending · 2026-06-17</li></ul>
       <section class="disc-sec"><h2>Güncelleme</h2><ul class="disc-wins"><li><strong>2 Ağustos 2026:</strong> Yıldız 10.691 → 15.356, son sürüm v0.6.0 (20 Temmuz 2026).</li></ul></section>

--- a/scripts/check-headline-consistency.py
+++ b/scripts/check-headline-consistency.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Başlık tutarlılık guard'ı (CI) · katalogdaki `headline` ile detay sayfasının H1'i aynı olmalı.
+
+Neden gerekti: 2026-08-06 denetiminde 30 keşif sayfasının H1'i katalogdan geride
+kalmıştı. Katkı PR'ları bayat dal yüzünden alan bazlı taşınıyor (bkz. landing#64) ·
+taşıma kataloğu düzeltiyor ama sayfayı yeniden basmıyordu. Sonuç: yayında hâlâ
+"Web Sunucunuzu yapay zekâyla Hızlandırın" (nginx) yazıyordu, katalogda düzeltilmişti.
+
+Nav / footer / logo guard'larının kardeşi: statik, hızlı, ağ yok.
+Kullanım: python3 scripts/check-headline-consistency.py
+"""
+import os, re, sys, json, html
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CATALOG = os.path.join(ROOT, "assets", "discover", "catalog.json")
+DISC = os.path.join(ROOT, "discover")
+H1 = re.compile(r'<h1 class="disc-title">(.*?)</h1>', re.S)
+
+
+def main():
+    cat = json.load(open(CATALOG, encoding="utf-8"))
+    sapan, sayfasiz = [], []
+    for c in cat:
+        beklenen = (c.get("headline") or "").strip()
+        if not beklenen:
+            continue
+        p = os.path.join(DISC, c["slug"], "index.html")
+        if not os.path.exists(p):
+            sayfasiz.append(c["slug"])
+            continue
+        m = H1.search(open(p, encoding="utf-8").read())
+        # H1 kaçışlı yazılır (' → &#x27;) · karşılaştırmadan önce çöz
+        if m and html.unescape(m.group(1)).strip() != beklenen:
+            sapan.append((c["slug"], html.unescape(m.group(1)).strip(), beklenen))
+
+    if sayfasiz:
+        print(f"✗ {len(sayfasiz)} katalog kaydının detay sayfası yok: {', '.join(sayfasiz[:6])}")
+    if sapan:
+        print(f"✗ {len(sapan)} sayfanın H1'i katalogla uyuşmuyor:")
+        for slug, bulunan, beklenen in sapan[:10]:
+            print(f"   {slug}\n     sayfa   : {bulunan}\n     katalog : {beklenen}")
+        if len(sapan) > 10:
+            print(f"   … +{len(sapan)-10} sayfa daha")
+        print("   Düzeltme: katalog doğruysa sayfaları yeniden bas (discover-sync `_set_page_headline`).")
+    if sapan or sayfasiz:
+        sys.exit(1)
+    print(f"✓ başlık tutarlı · {len(cat)} kayıt")
+
+
+main()

--- a/scripts/discover-sync.py
+++ b/scripts/discover-sync.py
@@ -427,12 +427,25 @@ HEADLINE_SYS=("Sen TreScout için Türkçe içerik editörüsün. Verilen GitHub
   "araç yapay zekâ ile ilgili değilse başlıkta 'yapay zekâ' GEÇMESİN (web sunucusu, derleyici, kütüphane, "
   "veri deposu gibi araçlara yapay zekâ iddiası eklemek yanlış bilgidir). Yapay zekâdan söz edeceksen "
   "MUTLAKA 'yapay zekâ' (şapkalı â, küçük harf) yaz, 'AI/yapay zeka' yazma. "
+  "YAZIM: Cümle düzeni kullan · yalnız ilk harf ve özel adlar büyük ('Kubernetes dağıtımlarını "
+  "otomatize edin'), İngilizcedeki gibi Her Kelimeyi Büyük yazma. "
   "ÇIKTI yalnızca JSON: {\"baslik\":\"...\"}. Başka metin yok.")
+
+def _bas_harf_buyut(s):
+    """Cümle başı büyük · Türkçe 'i' → 'İ' (str.upper() 'I' verir, yanlış)."""
+    if not s or not s[0].isalpha() or s[0].isupper(): return s
+    return ('İ' if s[0]=='i' else s[0].upper())+s[1:]
+
 def normalize_headline(s):
-    """Marka düzeltmeleri · 'AI' → 'yapay zekâ'; 'Yapay Zeka/Zekayla' → 'yapay zekâ...' (şapkalı, küçük); em dash → ·"""
+    """Marka düzeltmeleri · 'AI' → 'yapay zekâ'; 'Yapay Zeka/Zekayla' → 'yapay zekâ...' (şapkalı, küçük); em dash → ·
+
+    'yapay zekâ' kuralı küçük harf dayattığı için cümle başındaki başlıklar da küçük
+    başlıyordu (2026-08-06: 397 başlığın 117'si · 99'u 'yapay zekâ' ile). H1 olarak
+    basıldıkları için son adımda ilk harf tekrar büyütülür.
+    """
     s=re.sub(r'\bAI\b','yapay zekâ',s)
     s=re.sub(r'(?i)yapay\s+zek[aâ](\w*)', lambda m: 'yapay zekâ'+m.group(1), s)
-    return s.replace('—','·').strip()
+    return _bas_harf_buyut(s.replace('—','·').strip())
 
 def gemini_headline(title,tagline,key,extra=""):
     """Mevcut girdiler için yalnız başlık üreten küçük çağrı (full enrich'i tekrar etmez)."""


### PR DESCRIPTION
#72'nin denetimi sırasında çıkan iki bulgu · biri **yayında yanlış başlık gösteriyordu**.

## 1 · 117 başlık küçük harfle başlıyordu
99'u "yapay zekâ ile…" ile. Sebep bizim marka normalize edicimiz: "yapay zekâ" küçük harf kuralı cümle başına da uygulanıyordu. H1 olarak basıldıkları için göze çarpıyordu.

- `normalize_headline` son adımda ilk harfi büyütüyor · Türkçe `i` → `İ` (`str.upper()` `I` verir, yanlış olur).
- Üretim istemine cümle düzeni şartı eklendi · yeni başlıklarda "Her Kelimeyi Büyük" alışkanlığı tekrarlamasın.

## 2 · 30 sayfanın H1'i katalogdan geride kalmıştı
Bayat katkı dalları **alan bazlı taşındığı** için (landing#64) katalog düzeliyor, detay sayfası yeniden basılmıyordu. Yani Mustafa'nın #36'daki düzeltmelerinin bir kısmı yayına hiç çıkmamış:

| sayfa | yayındaki H1 (yanlış) | katalog (doğru) |
|---|---|---|
| nginx | Web Sunucunuzu yapay zekâyla Hızlandırın | Yüksek performanslı web sunucusu ve ters vekil |
| odoo | İş süreçlerinizi yapay zekâ ile yönetin | Açık kaynaklı kurumsal kaynak planlama |
| trivy | Konteyner ve Bulut Güvenliğinizi yapay zekâ… | Konteyner ve bulut güvenlik tarayıcısı |
| svelte | Web uygulamaları için derleyici yaklaşımı… | Derleme zamanında çalışan arayüz çerçevesi |

30 sayfanın hepsi kataloğa hizalandı.

## 3 · Guard
`scripts/check-headline-consistency.py` · nav / footer / logo guard'larının kardeşi: katalog `headline` ≠ sayfa H1 ise CI kırılır. Tetikleyici yollara `assets/discover/catalog.json` da eklendi (katalog tek başına değişince de çalışsın).

Doğrulama: dört guard + yeni guard yeşil · `✓ başlık tutarlı · 397 kayıt`.

## AI Traceability
### Plan Agent
- Outputs used: #35 denetimi · landing#72
- Tool: claude-code

### Skills Agent
- [ ] Kullanılmadı

### Türkçe İçerik
- [x] Yeni kullanıcı-yüzü metin yok · mevcut başlıkların yalnız ilk harfi ve sayfaya yazılması
- [x] Claude denetiminden geçti

### Manuel
- Guard'ın kapsamı ve cümle düzeni kararı