### PR TITLE
fix(claude-code): reprocess sayfaya denetlenmemiş başlık yazıyordu

### DIFF
--- a/discover/trek/index.html
+++ b/discover/trek/index.html
@@ -57,7 +57,7 @@
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
 <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · TREK</span></div>
-<h1 class="disc-title">Kendi sunucunuzda yapay zekâ destekli seyahat planlayıcı</h1>
+<h1 class="disc-title">Seyahat planlarınızı birlikte yönetin</h1>
 <p class="disc-lead">TREK, gerçek zamanlı iş birliği, etkileşimli haritalar ve bütçe yönetimi gibi özellikler sunan, kendi kendine barındırılan (self-hosted) bir seyahat planlama uygulamasıdır. Aşamalı web uygulaması (PWA) desteği ve tek oturum açma (SSO) entegrasyonu ile kullanıcıların seyahat süreçlerini dijital ortamda organize etmelerine olanak tanır.</p>
 <ul class="disc-meta"><li>★ 7.040</li><li>GitHub Trending · 2026-06-26</li></ul>
       <section class="disc-sec"><h2>Ne kazandırır?</h2><ul class="disc-wins"><li>Sürükle bırak yöntemiyle günlük seyahat rotaları ve planları oluşturma</li><li>Grup harcamalarını takip etme ve kişi başı bölüştürme</li><li>Yapay zekâ entegrasyonu ile otomatik seyahat ve bütçe yönetimi</li></ul></section>

--- a/scripts/discover-sync.py
+++ b/scripts/discover-sync.py
@@ -536,9 +536,28 @@ def headline_backfill(cat, key, limit):
     json.dump(cat,open(CATALOG,"w",encoding="utf-8"),ensure_ascii=False,indent=2)
     print(f"✅ {n} yeni başlık · {denetlenen} denetimden geçirildi · {fixed} normalize · catalog güncellendi")
 
+def _basligi_denetle(n, rich, key):
+    """Zenginleştirmeden gelen başlığı sayfaya yazmadan önce denetle · tek kaynak.
+
+    build_page sayfaya `rich["baslik"]`ı, base_entry kataloğa vet_headline'dan geçmiş
+    hâlini yazıyordu · ikisi ayrışıyordu (2026-08-06: trek sayfasında karşılıksız
+    yapay zekâ iddiası geri geldi, katalog temizdi). Denetim burada bir kez yapılır,
+    iki yol da aynı değeri kullanır (base_entry'nin tekrar denetlemesi zararsız).
+    """
+    if not rich or not rich.get("baslik"): return
+    if n.get("headline_locked") and n.get("headline"):   # insan doğrulaması · model üzerine yazamaz
+        rich["baslik"]=n["headline"]; return
+    b=vet_headline(normalize_headline(rich["baslik"].strip()), n, key)
+    eski=n.get("headline")
+    b=b or (eski if eski and not _ai_iddiasi(eski) else None)
+    if b: rich["baslik"]=b
+    else: rich.pop("baslik",None)   # temiz başlık yok · sayfa repo adına düşsün
+
+
 def process_one(n, key):
     """Entry'i zenginleştir + sayfa & kart yaz. Döner: (rich|None, reason|None)."""
     rich,reason=enrich_entry(n["url"],n["title"],n.get("summary",""),key)
+    _basligi_denetle(n, rich, key)
     os.makedirs(os.path.join(DISC,n["slug"]),exist_ok=True)
     open(os.path.join(DISC,n["slug"],"index.html"),"w",encoding="utf-8").write(build_page(n,rich))
     card=os.path.join(OGDIR,n["slug"]+".webp")


### PR DESCRIPTION
## Bulgu
landing#73'teki guard, eklendiği gün gerçek bir sapma yakaladı.

`trek` kaydını reprocess ettiğimde:
- **katalog** → "Seyahat planlarınızı birlikte yönetin" (doğru, `vet_headline`'dan geçmiş)
- **sayfa H1** → "Kendi sunucunuzda yapay zekâ destekli seyahat planlayıcı" (karşılıksız yapay zekâ iddiası)

## Kök neden
İki yazma yolu vardı ve yalnız biri denetimden geçiyordu:
- `build_page` → sayfaya `rich["baslik"]`ı **ham** yazıyor
- `base_entry` → kataloğa `vet_headline(normalize_headline(...))` sonucunu yazıyor

`process_one` önce sayfayı basıp sonra katalog kaydını ürettiği için her reprocess'te sayfa denetimden kaçıyordu · #35'te temizlediğimiz iddia bir reprocess ile geri gelebilirdi.

## Düzeltme
`_basligi_denetle()` · denetim `process_one`'da **bir kez** yapılıyor, sayfa ve katalog aynı değerden besleniyor. `headline_locked` korunuyor; temiz başlık üretilemezse sayfa repo adına düşüyor. `base_entry`'nin tekrar denetlemesi zararsız (denetlenmiş başlıkta iddia yok, `vet_headline` olduğu gibi döndürür).

`trek` sayfası kataloğa hizalandı · guard yeşil (`✓ başlık tutarlı · 397 kayıt`).

## AI Traceability
### Plan Agent
- Outputs used: #35 · landing#72 · landing#73
- Tool: claude-code

### Skills Agent
- [ ] Kullanılmadı

### Türkçe İçerik
- [x] Yeni kullanıcı-yüzü metin yok (trek başlığı Gemini akışında üretildi)
- [x] Claude denetiminden geçti

### Manuel
- Kök neden analizi · iki yazma yolunun ayrışması