### PR TITLE
fix(claude-code): landing vaatlerini bugünkü gerçeğe hizala

### DIFF
--- a/assets/index.css
+++ b/assets/index.css
@@ -512,6 +512,27 @@
       border-bottom-color: var(--accent);
       outline: none;
     }
+    /* DURUM satırı · bugün çalışan ile erken erişimde gelecek olanı ayırır */
+    .hero-status {
+      margin-top: 10px;
+      padding-left: 12px;
+      border-left: 2px solid rgba(244, 211, 94, 0.45);
+      font-size: 13px;
+      line-height: 1.6;
+      color: var(--ink-muted);
+    }
+    .hero-status a {
+      color: var(--ink);
+      border-bottom: 1px solid rgba(244, 211, 94, 0.4);
+      text-decoration: none;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .hero-status a:hover,
+    .hero-status a:focus-visible {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+      outline: none;
+    }
 
     /* ---------- AYDINLATMA METNİ MODAL ---------- */
     .privacy-modal {
@@ -1448,6 +1469,33 @@
       color: var(--ink-muted);
       line-height: 1.55;
     }
+    /* Durum rozeti · yayında olanı yol haritasındakinden ayırır (pac-live ile aynı dil) */
+    .roadmap-live {
+      display: inline-block;
+      vertical-align: 3px;
+      margin-left: 8px;
+      font-family: Inter, system-ui, sans-serif;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: .1em;
+      color: #15202B;
+      background: var(--accent);
+      padding: 3px 8px;
+      border-radius: 999px;
+      white-space: nowrap;
+    }
+    .roadmap-soon {
+      color: var(--ink-muted);
+      background: transparent;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+    }
+    .roadmap-item p a {
+      color: var(--accent);
+      text-decoration: none;
+      white-space: nowrap;
+    }
+    .roadmap-item p a:hover,
+    .roadmap-item p a:focus-visible { text-decoration: underline; outline: none; }
     @media (max-width: 768px) {
       .roadmap {
         grid-template-columns: 1fr;

--- a/en/index.html
+++ b/en/index.html
@@ -90,6 +90,8 @@
           <input type="text" name="website" tabindex="-1" autocomplete="off" aria-hidden="true" class="hp-field">
         </form>
         <p class="hero-note">Join the early access list. You will be notified when TreScout launches. Zero clutter.</p>
+        <!-- STATUS · ties the future-tense copy below to what actually runs today -->
+        <p class="hero-status">Today: We build and publish a report every day in the <a href="/en/reports/">archive</a>. Email delivery, hour selection and topic filters arrive with early access.</p>
       </div>
 
       <aside class="hero-visual" aria-hidden="true">
@@ -302,7 +304,7 @@
         <div class="features-bento">
           <div class="feature feature-hero">
             <div class="feature-icon">⏰</div>
-            <h3>Flexible Scheduling</h3>
+            <h3>Flexible Scheduling <span class="roadmap-live roadmap-soon">WITH EARLY ACCESS</span></h3>
             <p>Pick whatever delivery hour fits your morning routine. Read whenever you are ready.</p>
             <div class="time-strip" aria-hidden="true">
               <div class="time-strip-rail">
@@ -353,8 +355,8 @@
 
           <div class="roadmap-item">
             <div class="roadmap-dot">🔁</div>
-            <h3 class="roadmap-title">Deduplicated Reports</h3>
-            <p>Previously sent repos won't re-clutter your report unless there's a major version release or fresh surge.</p>
+            <h3 class="roadmap-title">Deduplicated Reports <span class="roadmap-live">LIVE</span></h3>
+            <p>A repo that already appeared in a report will not appear again, even if it stays trending. Only fresh finds and major updates come through. <a href="/en/reports/fresh/">See today's fresh-only report →</a></p>
           </div>
 
           <div class="roadmap-item">

--- a/index.html
+++ b/index.html
@@ -93,6 +93,8 @@
           <input type="text" name="website" tabindex="-1" autocomplete="off" aria-hidden="true" class="hp-field">
         </form>
         <p class="hero-note">Erken erişim listesine kayıt olun. TreScout yayına alındığında bilgilendirme yapılacaktır. Gereksiz ileti gönderilmez.</p>
+        <!-- DURUM · sayfadaki gelecek zamanlı anlatımı bugüne bağlar (ne çalışıyor / ne erken erişimle) -->
+        <p class="hero-status">Bugün: Raporları her gün üretip <a href="/reports/">arşivde</a> yayımlıyoruz. E-posta teslimi, saat seçimi ve konu filtreleri erken erişimle başlayacak.</p>
       </div>
 
       <aside class="hero-visual" aria-hidden="true">
@@ -307,7 +309,7 @@
         <div class="features-bento">
           <div class="feature feature-hero">
             <div class="feature-icon">⏰</div>
-            <h3>Esnek Zamanlama</h3>
+            <h3>Esnek Zamanlama <span class="roadmap-live roadmap-soon">ERKEN ERİŞİMLE</span></h3>
             <p>Saat kaçta isterseniz siz seçin, biz teslim edelim. Ne zaman isterseniz okuyun.</p>
             <div class="time-strip" aria-hidden="true">
               <div class="time-strip-rail">
@@ -381,8 +383,8 @@
 
           <div class="roadmap-item">
             <div class="roadmap-dot">🔁</div>
-            <h3 class="roadmap-title">Tekrar İçermeyen Raporlar</h3>
-            <p>Önceden gönderilen repo trendde kalsa bile rapora girmez. Yeni keşifler, yeni sürümler ve büyük güncellemeler gelir; geri kalanı filtrelenir.</p>
+            <h3 class="roadmap-title">Tekrar İçermeyen Raporlar <span class="roadmap-live">YAYINDA</span></h3>
+            <p>Daha önce rapora giren repo trendde kalsa bile tekrar girmez. Yalnız yeni keşifler ve büyük güncellemeler gelir; geri kalanı filtrelenir. <a href="/reports/tekrarsiz/">Bugünkü tekrarsız raporu görün →</a></p>
           </div>
 
           <div class="roadmap-item">


### PR DESCRIPTION
## Neden
Landing gelecek zamanlı anlatıyor ("seçtiğiniz saatte gelen kutunuza düşer") ama **bugün nerede durduğumuzu** hiçbir yerde söylemiyordu. Erken erişim listesine kaydolan kişi e-posta tesliminin henüz çalışmadığını bilmiyordu. Buna karşılık gerçekten yaptığımız bir şeyi (tekrarsız raporlar) yol haritasında bekletiyorduk.

## Değişiklik

**1 · Hero'ya durum satırı** (TR + EN)
> Bugün: Raporları her gün üretip **arşivde** yayımlıyoruz. E-posta teslimi, saat seçimi ve konu filtreleri erken erişimle başlayacak.

Tek cümle, sayfanın altındaki bütün gelecek zamanlı anlatımı bugüne bağlıyor.

**2 · "Tekrar İçermeyen Raporlar" → YAYINDA**
Her gün `/reports/tekrarsiz/` altında üretiliyordu ama "İlk Sürümde" sekmesinde duruyordu. Rozet + bugünkü tekrarsız rapora link eklendi.

**3 · "yeni sürümler" iddiası kaldırıldı**
Aynı maddede "Yeni keşifler, **yeni sürümler** ve büyük güncellemeler gelir" yazıyordu · `releases` kaynağı `ALL_SOURCES`'tan çıkarıldığı için sürüm akışı raporlara girmiyor. Metin gerçeğe çekildi.

**4 · "Esnek Zamanlama" → ERKEN ERİŞİMLE**
Özellikler sekmesindeki en güçlü şimdiki-zaman iddiası buydu.

## Doğrulama
- Yerel önizlemede ölçüldü: rozetler doğru renkte basılıyor (YAYINDA 68×22 accent, ERKEN ERİŞİMLE çerçeveli), durum satırı hero-note altında.
- Mobil 375px: yatay taşma yok, link satıra sığıyor (sağ kenar 318 < 375).
- Link hedefleri diskte var: `/reports/tekrarsiz/`, `/en/reports/fresh/`.
- Beş guard yeşil (CSP · nav · footer · logo · başlık).

## AI Traceability
### Plan Agent
- Outputs used: landing vaat denetimi (bu oturum)
- Tool: claude-code

### Skills Agent
- [ ] Kullanılmadı

### Türkçe İçerik
- [ ] Gemini'den geçmedi · yeni metin iki kısa durum cümlesi, kullanıcı onayına sunuldu
- [x] Claude denetiminden geçti (siz dili, em dash yok, iki noktadan sonra büyük harf)

### Manuel
- Hangi vaadin bugün çalıştığı / çalışmadığı kararı