### PR TITLE
fix(claude-code): 🚀 361 keşif sayfasından kaldırıldı + marka tipografi guard'ı

### DIFF
--- a/.github/workflows/csp-inline-guard.yml
+++ b/.github/workflows/csp-inline-guard.yml
@@ -6,6 +6,7 @@ name: CSP Inline Guard
 # 3) Footer tutarlılığı: footer-grid'li tüm sayfalarda aynı "Ürün" linkleri (footer üreticiden üreticiye kaymasın).
 # 4) Logo geometrisi: marka işaretinin şekli (3 yay + T) her yerde aynı (boyut/aria/çerçeve bağlama göre serbest).
 # 5) Başlık tutarlılığı: keşif detay sayfasının H1'i katalogdaki headline ile aynı (alan bazlı taşımada sayfa geride kalmasın).
+# 6) Marka tipografisi: 🚀 ve em dash (—) yayına giden sayfalarda geçmesin (kod blokları hariç).
 
 on:
   pull_request:
@@ -33,3 +34,5 @@ jobs:
         run: python3 scripts/check-logo-consistency.py
       - name: Başlık tutarlılık kontrolü (katalog ↔ sayfa H1)
         run: python3 scripts/check-headline-consistency.py
+      - name: Marka tipografi kontrolü (🚀 · em dash)
+        run: python3 scripts/check-brand-typography.py

--- a/discover/abseil-cpp/index.html
+++ b/discover/abseil-cpp/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Abseil Cpp</span><span class="disc-momentum">🚀 +89 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Abseil Cpp</span><span class="disc-momentum">↑ +89 bugün</span></div>
 <h1 class="disc-title">C++ standart kütüphanesini güçlendiren araçlar</h1>
 <p class="disc-lead">Google tarafından geliştirilen Abseil, C++ standart kütüphanesini tamamlayan açık kaynaklı kod parçaları (code snippets) sunuyor. Bu kütüphane, karmaşık yazılım projelerinde kodun sürdürülebilirliğini ve performansını artırmak amacıyla temel veri yapıları ile algoritmalar sağlıyor.</p>
 <ul class="disc-meta"><li>★ 18.043</li><li>C++</li><li>GitHub Trending · 2026-07-11</li></ul>

--- a/discover/adr/index.html
+++ b/discover/adr/index.html
@@ -57,7 +57,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · ADR</span><span class="disc-momentum">🚀 +148 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · ADR</span><span class="disc-momentum">↑ +148 bugün</span></div>
 <h1 class="disc-title">Kurumsal yapay zekâ ajanları için güvenlik</h1>
 <p class="disc-lead">Uber tarafından geliştirilen ADR, kurumsal yapay zekâ ajanlarını gözlemlenebilirlik, güvenlik kıyaslaması ve tehdit algılama yöntemleriyle koruma altına alıyor. Yazılım, yapay zekâ sistemlerinin güvenliğini artırmak için geliştirilmiş bir güvenlik çerçevesi (framework) sunuyor.</p>
 <ul class="disc-meta"><li>★ 1.123</li><li>Python</li><li>GitHub Trending · 2026-08-05</li></ul>

--- a/discover/ag-kit/index.html
+++ b/discover/ag-kit/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ag Kit</span><span class="disc-momentum">🚀 +14 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ag Kit</span><span class="disc-momentum">↑ +14 bugün</span></div>
 <h1 class="disc-title">Antigravity için otonom yapay zekâ kiti</h1>
 <p class="disc-lead">Ag-kit, TypeScript tabanlı projelerde otonom yapay zekâ ajanları (AI agents) oluşturmak için gerekli araçları ve yapıları sunan bir geliştirme kütüphanesidir. Geliştiricilerin karmaşık iş akışlarını yönetebilen ajan sistemlerini (agentic systems) hızlıca tasarlamasına olanak tanır.</p>
 <ul class="disc-meta"><li>★ 8.084</li><li>TypeScript</li><li>GitHub Trending · 2026-07-28</li></ul>

--- a/discover/agency-agents/index.html
+++ b/discover/agency-agents/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agency Agents</span><span class="disc-momentum">🚀 +1.599 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agency Agents</span><span class="disc-momentum">↑ +1.599 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanlarıyla dijital ajans kurun</h1>
 <p class="disc-lead">Agency-agents projesi, farklı uzmanlık alanlarına sahip yapay zekâ ajanlarını bir araya getirerek dijital bir ajans yapısı oluşturuyor. Yazılım geliştirme, içerik üretimi ve veri doğrulama gibi süreçleri özelleşmiş karakterler ve iş akışları üzerinden yönetmeyi sağlıyor.</p>
 <ul class="disc-meta"><li>★ 138.170</li><li>Shell</li><li>GitHub Trending · 2026-06-12</li></ul>

--- a/discover/agent-governance-toolkit/index.html
+++ b/discover/agent-governance-toolkit/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agent Governance Toolkit</span><span class="disc-momentum">🚀 +46 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agent Governance Toolkit</span><span class="disc-momentum">↑ +46 bugün</span></div>
 <h1 class="disc-title">Otonom yapay zekâ ajanları için güvenlik</h1>
 <p class="disc-lead">Microsoft tarafından geliştirilen ajan yönetişim araç seti (agent governance toolkit), otonom yapay zekâ ajanları için politika uygulama, sıfır güven kimlik doğrulaması (zero-trust identity) ve yalıtılmış çalışma ortamı (sandboxing) gibi güvenlik katmanları sunuyor. Yazılım, OWASP Ajan Odaklı İlk 10 (OWASP Agentic Top 10) listesindeki güvenlik açıklarına karşı koruma sağlamayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 5.564</li><li>Python</li><li>GitHub Trending · 2026-07-29</li></ul>

--- a/discover/agent-native/index.html
+++ b/discover/agent-native/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agent Native</span><span class="disc-momentum">🚀 +147 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agent Native</span><span class="disc-momentum">↑ +147 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları için uygulama çerçevesi</h1>
 <p class="disc-lead">BuilderIO tarafından geliştirilen agent-native, yapay zekâ ajanları için yerel uygulamalar (agent-native applications) oluşturmaya odaklanan bir TypeScript çerçevesidir (framework). Geliştiricilerin ajan tabanlı iş akışlarını doğrudan uygulama mimarisine entegre etmelerini sağlar.</p>
 <ul class="disc-meta"><li>★ 4.419</li><li>TypeScript</li><li>GitHub Trending · 2026-06-20</li></ul>

--- a/discover/agent-skills/index.html
+++ b/discover/agent-skills/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agent Skills</span><span class="disc-momentum">🚀 +443 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agent Skills</span><span class="disc-momentum">↑ +443 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanlarına mühendislik yeteneği kazandırın</h1>
 <p class="disc-lead">Yapay zekâ kodlama ajanları için geliştirilen bu kütüphane, üretim seviyesinde mühendislik yetenekleri (engineering skills) sunuyor. Yazılım geliştirme süreçlerini otomatize eden ajanların teknik kapasitesini artırmak için standartlaştırılmış araçlar sağlıyor.</p>
 <ul class="disc-meta"><li>★ 81.505</li><li>Shell</li><li>GitHub Trending · 2026-06-10</li></ul>

--- a/discover/agent-toolkit-for-aws/index.html
+++ b/discover/agent-toolkit-for-aws/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agent Toolkit for Aws</span><span class="disc-momentum">🚀 +47 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agent Toolkit for Aws</span><span class="disc-momentum">↑ +47 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları için AWS araç seti</h1>
 <p class="disc-lead">AWS, yapay zekâ ajanlarının bulut altyapısıyla etkileşimini kolaylaştırmak için Model Bağlantı Protokolü (Model Context Protocol) sunucuları, yetenekler (skills) ve eklentiler içeren bir araç seti yayımladı. Bu geliştirme, ajanların AWS servisleri üzerinde doğrudan işlem yapabilmesini sağlayan standartlaştırılmış bir yapı sunuyor.</p>
 <ul class="disc-meta"><li>★ 2.215</li><li>Python</li><li>GitHub Trending · 2026-06-26</li></ul>

--- a/discover/agents-cli/index.html
+++ b/discover/agents-cli/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agents CLI</span><span class="disc-momentum">🚀 +445 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agents CLI</span><span class="disc-momentum">↑ +445 bugün</span></div>
 <h1 class="disc-title">Kodlama asistanları için yapay zekâ araçları</h1>
 <p class="disc-lead">Google tarafından geliştirilen komut satırı arayüzü (CLI), kodlama asistanlarını Google Bulut (Google Cloud) üzerinde yapay zekâ ajanları oluşturma, değerlendirme ve dağıtma konusunda uzmanlaştırıyor. Python tabanlı bu araç, ajan geliştirme süreçlerini standartlaştırarak bulut altyapısı üzerindeki operasyonel iş akışlarını hızlandırıyor.</p>
 <ul class="disc-meta"><li>★ 5.491</li><li>Python</li><li>GitHub Trending · 2026-07-01</li></ul>

--- a/discover/agents/index.html
+++ b/discover/agents/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agents</span><span class="disc-momentum">🚀 +148 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agents</span><span class="disc-momentum">↑ +148 bugün</span></div>
 <h1 class="disc-title">Gerçek zamanlı sesli yapay zekâ ajanları</h1>
 <p class="disc-lead">LiveKit Agents, gerçek zamanlı sesli ve görüntülü yapay zekâ ajanları geliştirmek için kullanılan bir Python çerçevesidir (framework). Geliştiricilerin düşük gecikmeli sesli etkileşimler kurmasını sağlayarak, insan benzeri tepkiler veren yapay zekâ sistemlerinin oluşturulmasını kolaylaştırır.</p>
 <ul class="disc-meta"><li>★ 12.125</li><li>Python</li><li>GitHub Trending · 2026-08-04</li></ul>

--- a/discover/agentskills/index.html
+++ b/discover/agentskills/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agentskills</span><span class="disc-momentum">🚀 +86 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agentskills</span><span class="disc-momentum">↑ +86 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanlarına standart yetenekler kazandırın</h1>
 <p class="disc-lead">Agent Skills, yapay zekâ ajanlarının görevlerini yerine getirirken kullandığı yetenekleri (skills) standartlaştıran bir teknik şartname ve dokümantasyon projesidir. Python tabanlı bu yapı, farklı ajan sistemleri arasında yetenek paylaşımını ve birlikte çalışabilirliği (interoperability) kolaylaştırmayı amaçlar.</p>
 <ul class="disc-meta"><li>★ 23.755</li><li>Python</li><li>GitHub Trending · 2026-07-03</li></ul>

--- a/discover/agentsview/index.html
+++ b/discover/agentsview/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agentsview</span><span class="disc-momentum">🚀 +114 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Agentsview</span><span class="disc-momentum">↑ +114 bugün</span></div>
 <h1 class="disc-title">Kodlama ajanlarınızı yapay zekâ ile izleyin</h1>
 <p class="disc-lead">Agentsview, kodlama ajanları için yerel öncelikli (local-first) oturum zekası ve analitik verileri sunan bir izleme aracıdır. Claude Code ve Codex dahil yirmiden fazla ajanı destekleyen bu yazılım, ccusage aracına kıyasla daha hızlı bir performans vadediyor.</p>
 <ul class="disc-meta"><li>★ 4.714</li><li>Go</li><li>GitHub Trending · 2026-06-12</li></ul>

--- a/discover/ai-agent-book/index.html
+++ b/discover/ai-agent-book/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Agent Book</span><span class="disc-momentum">🚀 +1.734 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Agent Book</span><span class="disc-momentum">↑ +1.734 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları için rehber</h1>
 <p class="disc-lead">Yapay zekâ ajanları (AI agents) üzerine hazırlanan bu açık kaynaklı kitap, tasarım prensipleri ve mühendislik uygulamalarını kapsamlı bir şekilde ele alıyor. İçeriğinde teorik bilgilerin yanı sıra bölümlere ayrılmış uygulama kodları ve derlenmiş PDF dosyaları yer alıyor.</p>
 <ul class="disc-meta"><li>★ 33.116</li><li>Python</li><li>GitHub Trending · 2026-07-20</li></ul>

--- a/discover/ai-berkshire/index.html
+++ b/discover/ai-berkshire/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Berkshire</span><span class="disc-momentum">🚀 +309 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Berkshire</span><span class="disc-momentum">↑ +309 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile değer yatırımı araştırması</h1>
 <p class="disc-lead">AI-berkshire, Claude Code altyapısını kullanarak Warren Buffett ve Charlie Munger gibi yatırımcıların metodolojilerini uygulayan bir değer yatırımı araştırma çerçevesidir (research framework). Sistem, çoklu yapay zekâ ajanı (multi-agent) yapısıyla finansal verileri analiz ederek karşıt görüşlü incelemeler yürütmektedir.</p>
 <ul class="disc-meta"><li>★ 14.888</li><li>Python</li><li>GitHub Trending · 2026-06-26</li></ul>

--- a/discover/ai-engineering-from-scratch/index.html
+++ b/discover/ai-engineering-from-scratch/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Engineering from Scratch</span><span class="disc-momentum">🚀 Bir günde +2.169 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Engineering from Scratch</span><span class="disc-momentum">↑ Bir günde +2.169 yıldız</span></div>
       <h1 class="disc-title">Sıfırdan yapay zekâ Mühendisliği Eğitimi</h1>
       <p class="disc-lead">Yapay zekâ mühendisliğine sıfırdan giriş: <strong>485 ders, 20 faz ve yaklaşık 320 saatlik içerik.</strong> Lineer cebirden otonom ajanlara kadar her algoritmayı önce matematiğiyle, ardından <strong>elle kod yazarak</strong> öğretir. Python, TypeScript, Rust ve Julia dillerini kapsayan bu kurs tamamen ücretsiz ve açık kaynaklıdır.</p>
       <ul class="disc-meta"><li>★ 45.404</li><li>Python</li><li>MIT</li><li>GitHub Trending · 26 May 2026</li></ul>

--- a/discover/ai-for-beginners/index.html
+++ b/discover/ai-for-beginners/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI-For-Beginners</span><span class="disc-momentum">🚀 +252 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI-For-Beginners</span><span class="disc-momentum">↑ +252 bugün</span></div>
 <h1 class="disc-title">12 haftalık yapay zekâ müfredatı</h1>
 <p class="disc-lead">Microsoft tarafından hazırlanan AI for Beginners, 12 haftalık bir müfredatla yapay zekâya giriş konularını Jupyter not defterleri (Jupyter Notebooks) üzerinden öğretiyor. 24 derslik bu içerik, temel kavramları uygulamalı örneklerle öğrenmek isteyenler için yapılandırılmış bir eğitim kaynağı sunuyor.</p>
 <ul class="disc-meta"><li>★ 62.224</li><li>Jupyter Notebook</li><li>GitHub Trending · 2026-07-01</li></ul>

--- a/discover/ai-hedge-fund/index.html
+++ b/discover/ai-hedge-fund/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Hedge Fund</span><span class="disc-momentum">🚀 +115 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Hedge Fund</span><span class="disc-momentum">↑ +115 bugün</span></div>
 <h1 class="disc-title">Yatırım stratejileri için yapay zekâ ajanları</h1>
 <p class="disc-lead">Yapay zekâ destekli yatırım fonu (AI hedge fund), finansal piyasa analizi ve varlık yönetimi süreçlerini otomatize etmek için otonom ajanlar kullanıyor. Python tabanlı bu proje, piyasa verilerini işleyerek yatırım stratejileri geliştiren bir yapay zekâ ekibi (AI team) modeli sunuyor.</p>
 <ul class="disc-meta"><li>★ 62.684</li><li>Python</li><li>GitHub Trending · 2026-07-13</li></ul>

--- a/discover/ai-job-search/index.html
+++ b/discover/ai-job-search/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Job Search</span><span class="disc-momentum">🚀 +2.514 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Job Search</span><span class="disc-momentum">↑ +2.514 bugün</span></div>
 <h1 class="disc-title">Claude Code ile otomatik iş başvurusu</h1>
 <p class="disc-lead">Claude Code altyapısını kullanan ai-job-search, iş arama sürecini otomatikleştiren bir çerçeve (framework) sunuyor. Araç, kullanıcı profilini analiz ederek öz geçmiş düzenleme, ön yazı yazma ve mülakat hazırlığı gibi görevleri yapay zekâ desteğiyle gerçekleştiriyor.</p>
 <ul class="disc-meta"><li>★ 29.509</li><li>TypeScript</li><li>GitHub Trending · 2026-07-08</li></ul>

--- a/discover/ai-website-cloner-template/index.html
+++ b/discover/ai-website-cloner-template/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Website Cloner Template</span><span class="disc-momentum">🚀 +100 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AI Website Cloner Template</span><span class="disc-momentum">↑ +100 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile web sitesi kopyalama</h1>
 <p class="disc-lead">JCodesMore tarafından geliştirilen yapay zekâ web sitesi kopyalayıcı (AI website cloner), TypeScript tabanlı kodlama ajanlarını kullanarak tek komutla mevcut web sitelerinin kopyalanmasını sağlıyor. Bu araç, web tasarımı ve geliştirme süreçlerini otomatize etmek için yapay zekâ destekli kod oluşturma (AI-powered code generation) yönteminden yararlanıyor.</p>
 <ul class="disc-meta"><li>★ 30.826</li><li>TypeScript</li><li>GitHub Trending · 2026-06-23</li></ul>

--- a/discover/airi/index.html
+++ b/discover/airi/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AIRI</span><span class="disc-momentum">🚀 ★ 40.222 · aktif geliştirme</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AIRI</span><span class="disc-momentum">↑ ★ 40.222 · aktif geliştirme</span></div>
       <h1 class="disc-title">Kendi Sesli yapay zekâ Karakterinizi Oluşturun</h1>
       <p class="disc-lead"><strong>AIRI</strong>, kendi sunucunuzda barındırabileceğiniz, <strong>gerçek zamanlı sesli sohbet</strong> yapabilen ve Minecraft veya Factorio gibi oyunları oynayabilen AI tabanlı bir sanal karakter platformudur. Neuro-sama tarzı etkileşimli dijital varlıkları masaüstü ve web ortamına taşır.</p>
       <ul class="disc-meta"><li>★ 46.435</li><li>TypeScript</li><li>MIT</li><li>GitHub Trending · 28 May 2026</li></ul>

--- a/discover/airllm/index.html
+++ b/discover/airllm/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Airllm</span><span class="disc-momentum">🚀 +208 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Airllm</span><span class="disc-momentum">↑ +208 bugün</span></div>
 <h1 class="disc-title">Dev yapay zekâ modellerini 4GB VRAM ile çalıştırın</h1>
 <p class="disc-lead">AirLLM, 70 milyar parametreli büyük dil modellerinin (large language models) yalnızca 4 GB video belleğine (VRAM) sahip grafik işlem birimlerinde çalıştırılmasına olanak tanıyor. Bu kütüphane, bellek optimizasyonu tekniklerini kullanarak yüksek kapasiteli modellerin düşük donanım gereksinimleriyle kullanılmasını sağlıyor.</p>
 <ul class="disc-meta"><li>★ 29.265</li><li>Jupyter Notebook</li><li>GitHub Trending · 2026-06-04</li></ul>

--- a/discover/aisuite/index.html
+++ b/discover/aisuite/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Aisuite</span><span class="disc-momentum">🚀 +127 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Aisuite</span><span class="disc-momentum">↑ +127 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ modellerini tek arayüzde yönetin</h1>
 <p class="disc-lead">Andrew Ng tarafından geliştirilen aisuite, farklı üretken yapay zekâ (generative AI) sağlayıcılarını tek bir arayüz üzerinden yönetmeyi sağlayan bir Python kütüphanesidir. Geliştiricilerin çeşitli model servisleri arasında kod değişikliği yapmadan geçiş yapmasına olanak tanır.</p>
 <ul class="disc-meta"><li>★ 15.888</li><li>Python</li><li>GitHub Trending · 2026-06-14</li></ul>

--- a/discover/aitoearn/index.html
+++ b/discover/aitoearn/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AiToEarn</span><span class="disc-momentum">🚀 +183 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AiToEarn</span><span class="disc-momentum">↑ +183 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile gelir yönetimi</h1>
 <p class="disc-lead">AiToEarn, kullanıcıların yapay zekâ destekli otomasyonlar aracılığıyla gelir elde etme süreçlerini yönetmelerini sağlayan bir TypeScript tabanlı platformdur. Proje, otonom görev yürütme ve yapay zekâ tabanlı kazanç modellerini (AI-driven earning models) bir araya getirerek geliştiricilere açık bir altyapı sunuyor.</p>
 <ul class="disc-meta"><li>★ 24.551</li><li>TypeScript</li><li>GitHub Trending · 2026-06-08</li></ul>

--- a/discover/amnezia-client/index.html
+++ b/discover/amnezia-client/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Amnezia Client</span><span class="disc-momentum">🚀 +35 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Amnezia Client</span><span class="disc-momentum">↑ +35 bugün</span></div>
 <h1 class="disc-title">Kendi sunucunuzda kişisel VPN istemcisi</h1>
 <p class="disc-lead">Amnezia VPN istemcisi, kullanıcıların kendi sunucuları üzerinden sansürsüz internet erişimi sağlamasına olanak tanıyan açık kaynaklı bir ağ aracıdır. C++ diliyle geliştirilen bu yazılım, masaüstü ve mobil platformlarda kişisel gizliliği koruyan özelleştirilebilir tünelleme protokolleri sunar.</p>
 <ul class="disc-meta"><li>★ 14.262</li><li>C++</li><li>GitHub Trending · 2026-07-27</li></ul>

--- a/discover/ane/index.html
+++ b/discover/ane/index.html
@@ -58,7 +58,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · ANE</span><span class="disc-momentum">🚀 +22 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · ANE</span><span class="disc-momentum">↑ +22 bugün</span></div>
 <h1 class="disc-title">Apple Sinir Motorunda yapay zekâ eğitimi</h1>
 <p class="disc-lead">Maderix tarafından geliştirilen ANE, tersine mühendislik ile elde edilen özel uygulama programlama arayüzleri (private APIs) aracılığıyla Apple Sinir Motoru (Apple Neural Engine) üzerinde sinir ağı eğitimi (neural network training) yapılmasına olanak tanıyor. Bu çalışma, Apple donanımlarının yapay zekâ model eğitimi süreçlerinde doğrudan kullanımını mümkün kılıyor.</p>
 <ul class="disc-meta"><li>★ 7.185</li><li>GitHub Trending · 2026-07-30</li></ul>

--- a/discover/angular/index.html
+++ b/discover/angular/index.html
@@ -57,7 +57,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Angular</span><span class="disc-momentum">🚀 +13 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Angular</span><span class="disc-momentum">↑ +13 bugün</span></div>
 <h1 class="disc-title">Kapsamlı web uygulamaları için Angular</h1>
 <p class="disc-lead">Google tarafından geliştirilen Angular, ölçeklenebilir web uygulamaları oluşturmak için kullanılan kapsamlı bir çerçeve (framework). TypeScript tabanlı yapısıyla karmaşık projelerde geliştirme sürecini standartlaştıran ve yapılandıran araçlar sunuyor.</p>
 <ul class="disc-meta"><li>★ 100.952</li><li>TypeScript</li><li>GitHub Trending · 2026-08-05</li></ul>

--- a/discover/ansible/index.html
+++ b/discover/ansible/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ansible</span><span class="disc-momentum">🚀 +65 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ansible</span><span class="disc-momentum">↑ +65 bugün</span></div>
 <h1 class="disc-title">BT sistemlerini otomatikleştiren platform</h1>
 <p class="disc-lead">Ansible, uygulama dağıtımı ve sistem yönetimi süreçlerini otomatikleştiren bir bilişim teknolojileri otomasyon platformudur. Uzak sistemlere herhangi bir aracı yazılım (agent) yüklemeye gerek duymadan, SSH protokolü üzerinden basit bir dille yapılandırma işlemlerini gerçekleştirir.</p>
 <ul class="disc-meta"><li>★ 70.171</li><li>Python</li><li>GitHub Trending · 2026-07-04</li></ul>

--- a/discover/anthropic-cybersecurity-skills/index.html
+++ b/discover/anthropic-cybersecurity-skills/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Anthropic Cybersecurity Skills</span><span class="disc-momentum">🚀 Bir günde +871 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Anthropic Cybersecurity Skills</span><span class="disc-momentum">↑ Bir günde +871 yıldız</span></div>
       <h1 class="disc-title">Yapay zekâ için siber güvenlik becerileri</h1>
       <p class="disc-lead">Yapay zekâ ajanları için geliştirilmiş <strong>754 hazır siber güvenlik becerisi</strong>; 26 farklı güvenlik alanını kapsar ve MITRE ATT&CK, NIST CSF, MITRE ATLAS gibi 5 temel çerçeveyle eşlenir. Claude Code, GitHub Copilot, Codex, Cursor ve Gemini CLI gibi 20'den fazla platformda çalışır. <strong>(İsmine rağmen Anthropic'in resmi projesi değildir, bağımsız bir topluluk çalışmasıdır.)</strong></p>
       <ul class="disc-meta"><li>★ 27.085</li><li>Python</li><li>Apache-2.0</li><li>GitHub Trending · 26 May 2026</li></ul>

--- a/discover/anthropic-skills/index.html
+++ b/discover/anthropic-skills/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Anthropic Skills</span><span class="disc-momentum">🚀 Bir günde +718 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Anthropic Skills</span><span class="disc-momentum">↑ Bir günde +718 yıldız</span></div>
       <h1 class="disc-title">Claude için dinamik beceriler geliştirin</h1>
       <p class="disc-lead"><strong>Anthropic Skills</strong>; Claude'un özel görevlerde daha yüksek performans göstermek için <strong>dinamik olarak yüklediği</strong> beceri paketlerinin resmi deposudur. Talimatlar, scriptler ve kaynaklardan oluşan bu klasörler, Claude'a belirli işleri nasıl yapacağını öğretir.</p>
       <ul class="disc-meta"><li>★ 165.785</li><li>Python</li><li>Lisans: kontrol et</li><li>GitHub Trending · 29 May 2026</li></ul>

--- a/discover/apollo-11/index.html
+++ b/discover/apollo-11/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Apollo-11</span><span class="disc-momentum">🚀 +1.235 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Apollo-11</span><span class="disc-momentum">↑ +1.235 bugün</span></div>
 <h1 class="disc-title">Apollo 11 rehberlik bilgisayarı kaynak kodları</h1>
 <p class="disc-lead">Apollo 11 görevinde kullanılan komuta ve ay modülü rehberlik bilgisayarının (Guidance Computer) orijinal kaynak kodu, montaj dili (Assembly) ile GitHub üzerinde erişime açıldı. Yazılım, Ay&#x27;a iniş yapan ilk insanlı görevde kullanılan hesaplama algoritmalarının teknik detaylarını belgeliyor.</p>
 <ul class="disc-meta"><li>★ 70.068</li><li>Assembly</li><li>GitHub Trending · 2026-07-22</li></ul>

--- a/discover/argo-cd/index.html
+++ b/discover/argo-cd/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Argo Cd</span><span class="disc-momentum">🚀 +29 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Argo Cd</span><span class="disc-momentum">↑ +29 bugün</span></div>
 <h1 class="disc-title">Kubernetes Dağıtımlarını Otomatize Edin</h1>
 <p class="disc-lead">Argo CD, Kubernetes ortamları için bildirimsel sürekli dağıtım (declarative continuous deployment) süreçlerini yöneten bir araçtır. Uygulama durumlarını Git depolarıyla senkronize ederek altyapı üzerinde otomatik güncellemeler sağlar.</p>
 <ul class="disc-meta"><li>★ 23.853</li><li>Go</li><li>GitHub Trending · 2026-07-09</li></ul>

--- a/discover/asio/index.html
+++ b/discover/asio/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Asio</span><span class="disc-momentum">🚀 +92 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Asio</span><span class="disc-momentum">↑ +92 bugün</span></div>
 <h1 class="disc-title">Eşzamansız ağ programlama kütüphanesi</h1>
 <p class="disc-lead">Asio, eşzamansız giriş çıkış (asynchronous I/O) işlemleri için geliştirilmiş bir C++ kütüphanesidir. Ağ programlama ve düşük seviyeli sistem görevleri için taşınabilir bir ağ geçidi (network abstraction) sunar.</p>
 <ul class="disc-meta"><li>★ 6.090</li><li>C++</li><li>GitHub Trending · 2026-07-11</li></ul>

--- a/discover/astrbot/index.html
+++ b/discover/astrbot/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AstrBot</span><span class="disc-momentum">🚀 +83 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · AstrBot</span><span class="disc-momentum">↑ +83 bugün</span></div>
 <h1 class="disc-title">Mesajlaşma uygulamaları için yapay zekâ ajanı</h1>
 <p class="disc-lead">AstrBot, çeşitli anlık mesajlaşma platformları, büyük dil modelleri (large language models) ve eklentilerle entegre çalışan bir yapay zekâ ajanı geliştirme çerçevesidir (development framework). Python tabanlı bu araç, açık kaynaklı bir alternatif olarak özelleştirilebilir yapay zekâ asistanları oluşturulmasına olanak tanır.</p>
 <ul class="disc-meta"><li>★ 38.683</li><li>Python</li><li>GitHub Trending · 2026-07-20</li></ul>

--- a/discover/astryx/index.html
+++ b/discover/astryx/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Astryx</span><span class="disc-momentum">🚀 +364 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Astryx</span><span class="disc-momentum">↑ +364 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ uyumlu tasarım sistemi</h1>
 <p class="disc-lead">Meta tarafından geliştirilen Astryx, tamamen özelleştirilebilir ve yapay zekâ ajanlarıyla uyumlu (agent ready) bir tasarım sistemi (design system) sunuyor. TypeScript tabanlı bu açık kaynaklı kütüphane, arayüz bileşenlerini otonom sistemlerin kullanımına uygun şekilde yapılandırıyor.</p>
 <ul class="disc-meta"><li>★ 11.769</li><li>TypeScript</li><li>GitHub Trending · 2026-07-01</li></ul>

--- a/discover/autoremesher/index.html
+++ b/discover/autoremesher/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Autoremesher</span><span class="disc-momentum">🚀 +296 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Autoremesher</span><span class="disc-momentum">↑ +296 bugün</span></div>
 <h1 class="disc-title">Üç boyutlu modeller için otomatik dörtgenleştirme</h1>
 <p class="disc-lead">Autoremesher, üç boyutlu modellerdeki düzensiz yüzey yapılarını otomatik olarak dörtgen ağlara (quad remeshing) dönüştüren bir araçtır. C++ diliyle geliştirilen bu yazılım, karmaşık geometrileri animasyon ve modelleme süreçlerine uygun hale getirmek için optimize edilmiştir.</p>
 <ul class="disc-meta"><li>★ 3.087</li><li>C++</li><li>GitHub Trending · 2026-07-09</li></ul>

--- a/discover/awesome-artificial-intelligence/index.html
+++ b/discover/awesome-artificial-intelligence/index.html
@@ -58,7 +58,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Artificial Intelligence</span><span class="disc-momentum">🚀 +40 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Artificial Intelligence</span><span class="disc-momentum">↑ +40 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ geliştirme için temel kaynaklar</h1>
 <p class="disc-lead">Awesome-artificial-intelligence, yapay zekâ (artificial intelligence) alanındaki eğitimleri, kitapları, video dersleri ve akademik makaleleri bir araya getiren kapsamlı bir kaynak listesidir. Bu derleme, öğrenme sürecindeki kullanıcılar için disipline dayalı yapılandırılmış bir içerik havuzu sunar.</p>
 <ul class="disc-meta"><li>★ 15.631</li><li>GitHub Trending · 2026-06-19</li></ul>

--- a/discover/awesome-claude-code/index.html
+++ b/discover/awesome-claude-code/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Claude Code</span><span class="disc-momentum">🚀 +148 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Claude Code</span><span class="disc-momentum">↑ +148 bugün</span></div>
 <h1 class="disc-title">Claude Code için kapsamlı kaynak rehberi</h1>
 <p class="disc-lead">Anthropic tarafından geliştirilen kodlama asistanı Claude Code için hazırlanan bu seçki, yazılım geliştirme süreçlerini hızlandıran araçları, eklentileri ve yetenek paketlerini (skills) bir araya getiriyor. Geliştiricilerin bu yapay zekâ aracını projelerine entegre etmelerini kolaylaştıran kaynaklar, otomasyon kapasitesini artırmaya odaklanıyor.</p>
 <ul class="disc-meta"><li>★ 51.520</li><li>Python</li><li>GitHub Trending · 2026-07-06</li></ul>

--- a/discover/awesome-claude-skills/index.html
+++ b/discover/awesome-claude-skills/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Claude Skills</span><span class="disc-momentum">🚀 +163 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Claude Skills</span><span class="disc-momentum">↑ +163 bugün</span></div>
 <h1 class="disc-title">Claude için hazır yapay zekâ yetenekleri</h1>
 <p class="disc-lead">ComposioHQ tarafından derlenen awesome-claude-skills, Claude yapay zekâ iş akışlarını özelleştirmeye yönelik araçları ve kaynakları bir araya getiriyor. Bu liste, geliştiricilerin Claude için yetenek (skill) paketleri oluşturmasını ve mevcut projeleri entegre etmesini kolaylaştırıyor.</p>
 <ul class="disc-meta"><li>★ 68.956</li><li>Python</li><li>GitHub Trending · 2026-07-23</li></ul>

--- a/discover/awesome-design-md/index.html
+++ b/discover/awesome-design-md/index.html
@@ -58,7 +58,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Design Md</span><span class="disc-momentum">🚀 +1.391 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Design Md</span><span class="disc-momentum">↑ +1.391 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ için hazır tasarım dokümanları</h1>
 <p class="disc-lead">Awesome-design-md, popüler marka tasarım sistemlerine ait tasarım dokümanlarını (DESIGN.md) bir araya getiren bir koleksiyondur. Yazılım ajanları, bu dokümanları kullanarak projelere uygun kullanıcı arayüzleri (UI) oluşturabilir.</p>
 <ul class="disc-meta"><li>★ 105.953</li><li>GitHub Trending · 2026-07-10</li></ul>

--- a/discover/awesome-free-apps/index.html
+++ b/discover/awesome-free-apps/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Free Apps</span><span class="disc-momentum">🚀 Bir günde +738 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Free Apps</span><span class="disc-momentum">↑ Bir günde +738 yıldız</span></div>
       <h1 class="disc-title">En İyi Ücretsiz Uygulama Seçkisi</h1>
       <p class="disc-lead"><strong>Awesome Free Apps</strong>, bilgisayar ve telefonunuz için seçilmiş <strong>ücretsiz uygulamaların</strong> kategorize edilmiş bir rehberidir. Windows, macOS, Linux, Android ve iOS filtreleri ile 'açık kaynak' ve 'önerilen' işaretlerini kullanarak aradığınız araca hızla ulaşabilirsiniz.</p>
       <ul class="disc-meta"><li>★ 7.106</li><li>Liste</li><li>Lisans: belirsiz</li><li>GitHub Trending · 26 May 2026</li></ul>

--- a/discover/awesome-generative-ai-guide/index.html
+++ b/discover/awesome-generative-ai-guide/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Generative AI Guide</span><span class="disc-momentum">🚀 +107 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Generative AI Guide</span><span class="disc-momentum">↑ +107 bugün</span></div>
 <h1 class="disc-title">Üretken yapay zekâ için kapsamlı rehber</h1>
 <p class="disc-lead">Awesome-generative-ai-guide deposu, üretken yapay zekâ (generative AI) alanındaki güncel araştırmaları, mülakat kaynaklarını ve uygulama defterlerini (notebooks) tek bir noktada topluyor. Bu kaynak, geliştiriciler ve araştırmacılar için kapsamlı bir öğrenme ve referans merkezi görevi görüyor.</p>
 <ul class="disc-meta"><li>★ 27.722</li><li>HTML</li><li>GitHub Trending · 2026-06-20</li></ul>

--- a/discover/awesome-llm-apps/index.html
+++ b/discover/awesome-llm-apps/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome LLM Apps</span><span class="disc-momentum">🚀 +408 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome LLM Apps</span><span class="disc-momentum">↑ +408 bugün</span></div>
 <h1 class="disc-title">Hazır yapay zekâ uygulama şablonları</h1>
 <p class="disc-lead">Awesome-llm-apps deposu, doğrudan çalıştırılabilir 100&#x27;den fazla yapay zekâ ajanı (AI agent) ve getirilmiş nesil artırımlı (RAG) uygulama örneği sunuyor. Python tabanlı bu projeler, geliştiricilerin uygulamaları kopyalayıp özelleştirerek hızlıca yayına almasına olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 129.783</li><li>Python</li><li>GitHub Trending · 2026-07-13</li></ul>

--- a/discover/awesome-systematic-trading/index.html
+++ b/discover/awesome-systematic-trading/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Systematic Trading</span><span class="disc-momentum">🚀 +309 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome Systematic Trading</span><span class="disc-momentum">↑ +309 bugün</span></div>
 <h1 class="disc-title">Sistematik alım satım kaynak kütüphanesi</h1>
 <p class="disc-lead">Sistematik alım satım (systematic trading) alanındaki kütüphaneleri, stratejileri ve eğitim kaynaklarını bir araya getiren bu liste, Python tabanlı finansal modelleme süreçlerini destekliyor. Algoritmik ticaret (algorithmic trading) dünyasına giriş yapmak isteyenler için gerekli araçları ve literatürü tek bir merkezde topluyor.</p>
 <ul class="disc-meta"><li>★ 12.499</li><li>Python</li><li>GitHub Trending · 2026-07-29</li></ul>

--- a/discover/awesome/index.html
+++ b/discover/awesome/index.html
@@ -58,7 +58,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome</span><span class="disc-momentum">🚀 +345 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Awesome</span><span class="disc-momentum">↑ +345 bugün</span></div>
 <h1 class="disc-title">Teknoloji dünyasında küratörlü kaynak rehberi</h1>
 <p class="disc-lead">Awesome listeleri, yazılım geliştirme ve teknoloji dünyasındaki çeşitli konulara dair küratörlü kaynak koleksiyonları sunuyor. Bu depo, farklı alanlardaki en iyi araçları, kütüphaneleri ve öğrenme materyallerini bir araya getiren kapsamlı bir dizin (directory) işlevi görüyor.</p>
 <ul class="disc-meta"><li>★ 482.524</li><li>GitHub Trending · 2026-07-07</li></ul>

--- a/discover/babysitter/index.html
+++ b/discover/babysitter/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Babysitter</span><span class="disc-momentum">🚀 Bir günde +58 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Babysitter</span><span class="disc-momentum">↑ Bir günde +58 yıldız</span></div>
       <h1 class="disc-title">Yapay zekâ ajanlarınızı hatasız yönetin</h1>
       <p class="disc-lead"><strong>Babysitter</strong>, yapay zekâ ajanlarından oluşan iş gücünün karmaşık görevleri <strong>hatasız ve halüsinasyonsuz</strong> bir şekilde yürütebilmesi için deterministik bir denetim mekanizması sunar.</p>
       <ul class="disc-meta"><li>★ 1.632</li><li>JavaScript</li><li>MIT</li><li>GitHub Trending · 1 Haziran 2026</li></ul>

--- a/discover/background-agents/index.html
+++ b/discover/background-agents/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Background Agents</span><span class="disc-momentum">🚀 +16 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Background Agents</span><span class="disc-momentum">↑ +16 bugün</span></div>
 <h1 class="disc-title">Otonom yazılım geliştiren yapay zekâ ajanları</h1>
 <p class="disc-lead">ColeMurray tarafından geliştirilen background-agents, TypeScript tabanlı açık kaynaklı bir arka plan ajanları kodlama sistemidir. Geliştiricilerin uygulamalar içerisinde otonom süreçler yürüten yapay zekâ ajanları (AI agents) oluşturmasına olanak tanır.</p>
 <ul class="disc-meta"><li>★ 2.329</li><li>TypeScript</li><li>GitHub Trending · 2026-07-13</li></ul>

--- a/discover/baileys/index.html
+++ b/discover/baileys/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Baileys</span><span class="disc-momentum">🚀 +19 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Baileys</span><span class="disc-momentum">↑ +19 bugün</span></div>
 <h1 class="disc-title">WhatsApp Web protokolü ile entegrasyon</h1>
 <p class="disc-lead">Baileys, WhatsApp Web protokolünü temel alan ve TypeScript ile JavaScript tabanlı uygulamalar geliştirmeye olanak tanıyan soket tabanlı bir arayüz (API) sunuyor. Geliştiriciler, bu kütüphane sayesinde WhatsApp mesajlaşma işlevlerini kendi projelerine doğrudan entegre edebiliyor.</p>
 <ul class="disc-meta"><li>★ 10.556</li><li>JavaScript</li><li>GitHub Trending · 2026-07-31</li></ul>

--- a/discover/bitchat-android/index.html
+++ b/discover/bitchat-android/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Bitchat Android</span><span class="disc-momentum">🚀 +260 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Bitchat Android</span><span class="disc-momentum">↑ +260 bugün</span></div>
 <h1 class="disc-title">İnternetsiz Bluetooth üzerinden güvenli mesajlaşma</h1>
 <p class="disc-lead">Bitchat-android, Bluetooth ağ (mesh) teknolojisini kullanarak internet bağlantısı gerektirmeyen, merkeziyetsiz bir mesajlaşma deneyimi sunuyor. Kotlin diliyle geliştirilen uygulama, kullanıcıların yerel ağ üzerinden IRC benzeri bir iletişim kurmasını sağlıyor.</p>
 <ul class="disc-meta"><li>★ 7.246</li><li>Kotlin</li><li>GitHub Trending · 2026-07-27</li></ul>

--- a/discover/bitchat/index.html
+++ b/discover/bitchat/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Bitchat</span><span class="disc-momentum">🚀 +1.720 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Bitchat</span><span class="disc-momentum">↑ +1.720 bugün</span></div>
 <h1 class="disc-title">İnternetsiz iletişim için Bluetooth ağı</h1>
 <p class="disc-lead">Bitchat, Bluetooth ağ (mesh) teknolojisini kullanarak internet bağlantısı gerektirmeyen, yerel bir sohbet ortamı sunuyor. Swift diliyle geliştirilen uygulama, kullanıcıların yakın mesafede doğrudan iletişim kurmasını sağlayan IRC benzeri bir deneyim vadediyor.</p>
 <ul class="disc-meta"><li>★ 34.123</li><li>Swift</li><li>GitHub Trending · 2026-07-26</li></ul>

--- a/discover/bonsai-demo/index.html
+++ b/discover/bonsai-demo/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Bonsai-demo</span><span class="disc-momentum">🚀 +196 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Bonsai-demo</span><span class="disc-momentum">↑ +196 bugün</span></div>
 <h1 class="disc-title">Yerel cihazda yapay zekâ modelleri</h1>
 <p class="disc-lead">Bonsai demo projesi, makine öğrenimi (machine learning) modellerinin dağıtım süreçlerini basitleştirmek için tasarlanmış bir araç seti sunuyor. Yazılım, karmaşık model mimarilerini yönetilebilir iş akışlarına dönüştürerek geliştiricilerin uygulama süreçlerini optimize etmesine yardımcı oluyor.</p>
 <ul class="disc-meta"><li>★ 1.587</li><li>Shell</li><li>GitHub Trending · 2026-07-17</li></ul>

--- a/discover/book-to-skill/index.html
+++ b/discover/book-to-skill/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Book to Skill</span><span class="disc-momentum">🚀 +423 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Book to Skill</span><span class="disc-momentum">↑ +423 bugün</span></div>
 <h1 class="disc-title">Teknik kitapları yapay zekâ yeteneğine dönüştürün</h1>
 <p class="disc-lead">Book-to-skill projesi, teknik kitapların taşınabilir belge biçimlerini (PDF) Claude Code için kullanılabilir yetenek paketlerine (skills) dönüştürüyor. Bu araç, teknik kaynakların çalışma süreçlerinde doğrudan referans alınmasını ve uygulanmasını sağlıyor.</p>
 <ul class="disc-meta"><li>★ 17.132</li><li>Python</li><li>GitHub Trending · 2026-07-29</li></ul>

--- a/discover/build-your-own-x/index.html
+++ b/discover/build-your-own-x/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Build Your Own X</span><span class="disc-momentum">🚀 Bir günde +1.066 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Build Your Own X</span><span class="disc-momentum">↑ Bir günde +1.066 yıldız</span></div>
       <h1 class="disc-title">Kendi Teknolojilerinizi Sıfırdan İnşa Edin</h1>
       <p class="disc-lead"><strong>Build Your Own X</strong>; veritabanı, işletim sistemi, Git, Docker ve programlama dili gibi en sevdiğiniz teknolojileri <strong>sıfırdan yeniden yazmanızı</strong> sağlayan adım adım rehberlerin derlemesidir. Feynman'ın 'Yaratamadığım şeyi anlayamam' felsefesiyle, yaparak öğrenme deneyimi sunar.</p>
       <ul class="disc-meta"><li>★ 534.641</li><li>Rehber</li><li>Lisans: yok</li><li>GitHub Trending · 29 May 2026</li></ul>

--- a/discover/bun/index.html
+++ b/discover/bun/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · BUN</span><span class="disc-momentum">🚀 +209 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · BUN</span><span class="disc-momentum">↑ +209 bugün</span></div>
 <h1 class="disc-title">JavaScript projeleri için hızlı çalışma zamanı</h1>
 <p class="disc-lead">Bun, JavaScript çalışma zamanı (runtime), paket yöneticisi, test çalıştırıcı ve paketleyiciyi tek bir çatı altında toplayan yüksek performanslı bir araçtır. Rust diliyle geliştirilen bu platform, yazılım geliştirme süreçlerini hızlandırmak için tümleşik bir altyapı sunar.</p>
 <ul class="disc-meta"><li>★ 95.153</li><li>Rust</li><li>GitHub Trending · 2026-07-11</li></ul>

--- a/discover/buzz/index.html
+++ b/discover/buzz/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Buzz</span><span class="disc-momentum">🚀 +2.162 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Buzz</span><span class="disc-momentum">↑ +2.162 bugün</span></div>
 <h1 class="disc-title">Merkeziyetsiz kovan zihni iletişim platformu</h1>
 <p class="disc-lead">Block tarafından Rust diliyle geliştirilen Buzz, merkeziyetsiz bir kovan zihni iletişim platformu (hive mind communication platform) olarak tasarlanmıştır. Dağıtık ağ yapısı üzerinden kolektif veri paylaşımını ve eş zamanlı etkileşimi destekleyen bir altyapı sunar.</p>
 <ul class="disc-meta"><li>★ 23.428</li><li>Rust</li><li>GitHub Trending · 2026-07-24</li></ul>

--- a/discover/career-ops/index.html
+++ b/discover/career-ops/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Career Ops</span><span class="disc-momentum">🚀 +193 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Career Ops</span><span class="disc-momentum">↑ +193 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile kariyerinizi yönetin</h1>
 <p class="disc-lead">Claude Code altyapısını kullanan career-ops, yapay zekâ destekli iş arama süreçlerini 14 farklı yetenek moduyla otomatikleştiriyor. Sistem, Go tabanlı bir kontrol paneli üzerinden toplu işlem yönetimi ve özgeçmiş oluşturma gibi işlevleri tek bir merkezde topluyor.</p>
 <ul class="disc-meta"><li>★ 62.979</li><li>JavaScript</li><li>GitHub Trending · 2026-06-07</li></ul>

--- a/discover/casaos/index.html
+++ b/discover/casaos/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · CasaOS</span><span class="disc-momentum">🚀 +223 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · CasaOS</span><span class="disc-momentum">↑ +223 bugün</span></div>
 <h1 class="disc-title">Kişisel bulut sunucunuzu yönetin</h1>
 <p class="disc-lead">CasaOS, Docker tabanlı uygulamaları yönetmeyi kolaylaştıran açık kaynaklı bir kişisel bulut sistemi (personal cloud system) sunuyor. Go diliyle geliştirilen bu arayüz, kullanıcıların kendi sunucularını görsel bir panel üzerinden basit şekilde yönetmelerine imkan tanıyor.</p>
 <ul class="disc-meta"><li>★ 36.953</li><li>Go</li><li>GitHub Trending · 2026-06-26</li></ul>

--- a/discover/cassandra/index.html
+++ b/discover/cassandra/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cassandra</span><span class="disc-momentum">🚀 +11 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cassandra</span><span class="disc-momentum">↑ +11 bugün</span></div>
 <h1 class="disc-title">Dağıtık sistemler için ölçeklenebilir veritabanı</h1>
 <p class="disc-lead">Apache Cassandra, standart donanımlar veya bulut altyapıları üzerinde performans kaybı yaşatmadan doğrusal ölçeklenebilirlik (linear scalability) ve hata toleransı (fault-tolerance) sağlayan açık kaynaklı, dağıtık bir işlemsel veritabanıdır (transactional distributed database). Java diliyle geliştirilen bu sistem, yüksek erişilebilirlik gerektiren büyük ölçekli veri yönetim süreçleri için tasarlanmıştır.</p>
 <ul class="disc-meta"><li>★ 10.004</li><li>Java</li><li>GitHub Trending · 2026-07-28</li></ul>

--- a/discover/catch2/index.html
+++ b/discover/catch2/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Catch2</span><span class="disc-momentum">🚀 +76 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Catch2</span><span class="disc-momentum">↑ +76 bugün</span></div>
 <h1 class="disc-title">C++ projeleri için birim test çatısı</h1>
 <p class="disc-lead">Catch2, C++14 ve sonraki sürümleri destekleyen modern bir birim testi (unit testing) çatısıdır. Yazılım geliştirme süreçlerinde test güdümlü geliştirme (TDD) ve davranış odaklı geliştirme (BDD) pratiklerini desteklemek için tasarlanmıştır.</p>
 <ul class="disc-meta"><li>★ 21.404</li><li>C++</li><li>GitHub Trending · 2026-07-11</li></ul>

--- a/discover/caveman/index.html
+++ b/discover/caveman/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Caveman</span><span class="disc-momentum">🚀 +926 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Caveman</span><span class="disc-momentum">↑ +926 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ yanıtlarını kısaltarak tasarruf edin</h1>
 <p class="disc-lead">Caveman, Claude Code için geliştirilen ve yapay zekâ modelinin dil kullanımını basitleştirerek belirteç (token) tüketimini yüzde 65 oranında azaltan bir yetenek paketidir. Bu araç, karmaşık komutları ilkel bir dil yapısına indirgeyerek işlem maliyetlerini düşürmeyi hedefler.</p>
 <ul class="disc-meta"><li>★ 95.589</li><li>JavaScript</li><li>GitHub Trending · 2026-07-03</li></ul>

--- a/discover/chat2db/index.html
+++ b/discover/chat2db/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Chat2DB</span><span class="disc-momentum">🚀 +82 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Chat2DB</span><span class="disc-momentum">↑ +82 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ destekli veritabanı yönetimi</h1>
 <p class="disc-lead">Chat2DB, yapay zekâ destekli bir veritabanı yönetim aracı ve SQL istemcisi (SQL client) olarak öne çıkıyor. Java ile geliştirilen bu platform, MySQL, PostgreSQL ve Oracle gibi çok sayıda veritabanı sistemini tek bir grafik kullanıcı arayüzü (GUI) üzerinden yönetme imkânı sağlıyor.</p>
 <ul class="disc-meta"><li>★ 27.657</li><li>Java</li><li>GitHub Trending · 2026-07-25</li></ul>

--- a/discover/checkout/index.html
+++ b/discover/checkout/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Checkout</span><span class="disc-momentum">🚀 +26 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Checkout</span><span class="disc-momentum">↑ +26 bugün</span></div>
 <h1 class="disc-title">GitHub iş akışlarında depo kopyalama</h1>
 <p class="disc-lead">GitHub tarafından geliştirilen actions/checkout, yazılım geliştirme süreçlerinde depo kopyalama (repository checkout) işlemlerini otomatize eden bir araçtır. Sürekli entegrasyon (continuous integration) iş akışlarında kaynak kodun çalışma ortamına aktarılmasını sağlar.</p>
 <ul class="disc-meta"><li>★ 8.589</li><li>TypeScript</li><li>GitHub Trending · 2026-07-03</li></ul>

--- a/discover/chinatextbook/index.html
+++ b/discover/chinatextbook/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · ChinaTextbook</span><span class="disc-momentum">🚀 +350 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · ChinaTextbook</span><span class="disc-momentum">↑ +350 bugün</span></div>
 <h1 class="disc-title">Çin eğitim müfredatı ve ders kitapları</h1>
 <p class="disc-lead">ChinaTextbook deposu, ilkokuldan üniversite seviyesine kadar Çin eğitim müfredatında kullanılan ders kitaplarının taşınabilir belge formatındaki (PDF) dijital arşivini sunuyor. Bu kaynak, geniş kapsamlı akademik materyallere merkezi bir erişim noktası sağlıyor.</p>
 <ul class="disc-meta"><li>★ 76.412</li><li>Roff</li><li>GitHub Trending · 2026-06-08</li></ul>

--- a/discover/chinese-independent-developer/index.html
+++ b/discover/chinese-independent-developer/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Chinese Independent Developer</span><span class="disc-momentum">🚀 +1.196 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Chinese Independent Developer</span><span class="disc-momentum">↑ +1.196 bugün</span></div>
 <h1 class="disc-title">Çinli bağımsız geliştiricilerin projelerini keşfedin</h1>
 <p class="disc-lead">Çinli bağımsız geliştiricilerin yürüttüğü projeleri listeleyen bu açık kaynaklı veri tabanı, yazılımcıların geliştirdiği uygulamaları ve çalışma alanlarını bir araya getiriyor. Platform, bağımsız geliştiricilik (indie hacking) ekosistemindeki güncel eğilimleri ve ürün odaklı çalışmaları takip etmeyi sağlıyor.</p>
 <ul class="disc-meta"><li>★ 60.379</li><li>Python</li><li>GitHub Trending · 2026-07-15</li></ul>

--- a/discover/chrome-devtools-mcp/index.html
+++ b/discover/chrome-devtools-mcp/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Chrome Devtools MCP</span><span class="disc-momentum">🚀 +104 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Chrome Devtools MCP</span><span class="disc-momentum">↑ +104 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ için tarayıcı hata ayıklama</h1>
 <p class="disc-lead">Chrome Geliştirici Araçları (Chrome DevTools) için geliştirilen bu sunucu, kodlama yapan yapay zekâ ajanlarının (coding agents) tarayıcı tabanlı hata ayıklama süreçlerini yönetmesini sağlıyor. Model Bağlam Protokolü (Model Context Protocol) üzerinden çalışan bu araç, ajanların web uygulamalarını doğrudan incelemesine ve hata giderme işlemlerini otomatize etmesine olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 48.381</li><li>TypeScript</li><li>GitHub Trending · 2026-07-03</li></ul>

--- a/discover/claude-code-best-practice/index.html
+++ b/discover/claude-code-best-practice/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Code Best Practice</span><span class="disc-momentum">🚀 +344 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Code Best Practice</span><span class="disc-momentum">↑ +344 bugün</span></div>
 <h1 class="disc-title">Claude Code için yapay zekâ rehberi</h1>
 <p class="disc-lead">Claude Code için geliştirilen bu rehber, sezgisel kodlama (vibe coding) yaklaşımından ajan tabanlı mühendisliğe (agentic engineering) geçiş süreçlerini ele alıyor. Yazılım geliştirme süreçlerinde yapay zekâ ajanlarının verimliliğini artırmak adına pratik uygulama yöntemleri ve en iyi pratikler (best practices) sunuyor.</p>
 <ul class="disc-meta"><li>★ 63.889</li><li>HTML</li><li>GitHub Trending · 2026-06-24</li></ul>

--- a/discover/claude-code-harness/index.html
+++ b/discover/claude-code-harness/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Code Harness</span><span class="disc-momentum">🚀 Bir günde +87 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Code Harness</span><span class="disc-momentum">↑ Bir günde +87 yıldız</span></div>
       <h1 class="disc-title">Claude Code ile Disiplinli Geliştirme</h1>
       <p class="disc-lead"><strong>Claude Code Harness</strong>, ham ajan çalışmasının dağılma eğilimini frenleyerek <strong>planla, yap, gözden geçir ve teslim et</strong> disiplinini sunar. Planların sohbette kaybolmasını önler, testleri sınırlandırır ve daha tutarlı kod üretimi sağlar. Claude Code merkezli olsa da Codex ve OpenCode için de entegrasyon yolları sunar.</p>
       <figure class="disc-shot"><img src="/assets/discover/claude-code-harness.webp" width="1440" height="960" loading="lazy" decoding="async" alt="Claude Code Harness arayüzünden bir görünüm"><figcaption>Görsel: Claude Code Harness (proje deposundan)</figcaption></figure>

--- a/discover/claude-code-templates/index.html
+++ b/discover/claude-code-templates/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Code Templates</span><span class="disc-momentum">🚀 +118 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Code Templates</span><span class="disc-momentum">↑ +118 bugün</span></div>
 <h1 class="disc-title">Claude Code için hazır yapılandırmalar</h1>
 <p class="disc-lead">Claude Code şablonları, Claude Code aracı için yapılandırma ve izleme süreçlerini kolaylaştıran bir komut satırı arayüzü (CLI) sunuyor. Python tabanlı bu araç, geliştiricilerin kodlama asistanı üzerindeki kontrolünü ve iş akışı yönetimini standartlaştırıyor.</p>
 <ul class="disc-meta"><li>★ 30.058</li><li>Python</li><li>GitHub Trending · 2026-07-11</li></ul>

--- a/discover/claude-code/index.html
+++ b/discover/claude-code/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Code</span><span class="disc-momentum">🚀 Bir günde +595 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Code</span><span class="disc-momentum">↑ Bir günde +595 yıldız</span></div>
       <h1 class="disc-title">Terminalde yapay zekâ Destekli Kodlama</h1>
       <p class="disc-lead"><strong>Claude Code</strong>; terminalinizde yaşayan ve <strong>kod tabanınızı derinlemesine anlayan</strong> ajan tabanlı bir kodlama aracıdır. Doğal dil komutlarıyla dosyaları okur, değişiklik yapar ve testleri çalıştırarak geliştirme sürecinizi hızlandırır. (Bu sayfadaki birçok aracı onunla birlikte kullanabilirsiniz.)</p>
       <ul class="disc-meta"><li>★ 140.418</li><li>Anthropic ürünü</li><li>Açık kaynak değil</li><li>GitHub Trending · 30 May 2026</li></ul>

--- a/discover/claude-cookbooks/index.html
+++ b/discover/claude-cookbooks/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Cookbooks</span><span class="disc-momentum">🚀 +194 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Cookbooks</span><span class="disc-momentum">↑ +194 bugün</span></div>
 <h1 class="disc-title">Claude modelleri için pratik uygulama rehberi</h1>
 <p class="disc-lead">Anthropics tarafından paylaşılan Claude yemek kitapları (cookbooks), Claude modellerinin kullanımı için pratik kod örnekleri ve Jupyter not defterleri (notebooks) sunuyor. Bu kaynak, geliştiricilerin yapay zekâ uygulamalarında Claude entegrasyonunu hızlandırmak için çeşitli iş akışı şablonları sağlıyor.</p>
 <ul class="disc-meta"><li>★ 50.838</li><li>Jupyter Notebook</li><li>GitHub Trending · 2026-07-10</li></ul>

--- a/discover/claude-howto/index.html
+++ b/discover/claude-howto/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Howto</span><span class="disc-momentum">🚀 +312 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Howto</span><span class="disc-momentum">↑ +312 bugün</span></div>
 <h1 class="disc-title">Claude Code ile yapay zekâ geliştirin</h1>
 <p class="disc-lead">Claude Code için hazırlanan bu görsel rehber, temel kavramlardan ileri seviye ajan (agent) yapılandırmalarına kadar geniş bir yelpazede örnekler sunuyor. Kopyalanabilir şablonlar aracılığıyla kullanıcıların kod yazma süreçlerini hızlandırmayı ve uygulama geliştirme pratiklerini standartlaştırmayı amaçlıyor.</p>
 <ul class="disc-meta"><li>★ 40.779</li><li>Python</li><li>GitHub Trending · 2026-06-09</li></ul>

--- a/discover/claude-mem/index.html
+++ b/discover/claude-mem/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · claude-mem</span><span class="disc-momentum">🚀 Bir günde +319 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · claude-mem</span><span class="disc-momentum">↑ Bir günde +319 yıldız</span></div>
       <h1 class="disc-title">Yapay zekâ Ajanınıza Kalıcı Hafıza Kazandırın</h1>
       <p class="disc-lead"><strong>claude-mem</strong>, AI ajanlarınızın <strong>oturumlar arası hatırlama</strong> yapabilmesini sağlar. Bir oturumda gerçekleşen her şeyi yakalar, AI ile anlamlı özetlere dönüştürür ve sonraki oturumda ilgili bağlamı geri sunar. Claude Code, Codex, Gemini, Copilot ve OpenCode ile uyumludur.</p>
       <figure class="disc-shot"><img src="/assets/discover/claude-mem.webp" width="640" height="360" loading="lazy" decoding="async" alt="claude-mem arayüzünden bir görünüm"><figcaption>Görsel: claude-mem (proje deposundan)</figcaption></figure>

--- a/discover/claude-plugins-official/index.html
+++ b/discover/claude-plugins-official/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Plugins Official</span><span class="disc-momentum">🚀 +77 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Plugins Official</span><span class="disc-momentum">↑ +77 bugün</span></div>
 <h1 class="disc-title">Claude kodlama asistanı için eklentiler</h1>
 <p class="disc-lead">Anthropic, Claude Code için geliştirilen yüksek kaliteli eklentileri (plugins) tek bir merkezde toplayan resmi bir dizin sunuyor. Bu Python tabanlı yapı, geliştiricilerin kodlama asistanları için hazırlanan araçları (tools) standart bir formatta paylaşmasını ve keşfetmesini sağlıyor.</p>
 <ul class="disc-meta"><li>★ 32.968</li><li>Python</li><li>GitHub Trending · 2026-06-24</li></ul>

--- a/discover/claude-skills/index.html
+++ b/discover/claude-skills/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Skills</span><span class="disc-momentum">🚀 +136 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Skills</span><span class="disc-momentum">↑ +136 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ kodlama ajanlarına uzmanlık kazandırın</h1>
 <p class="disc-lead">Claude Code ve çeşitli kodlama ajanları için geliştirilen bu kütüphane, mühendislikten pazarlamaya kadar farklı alanlarda 330&#x27;dan fazla yetenek paketi (skills) ve 70&#x27;in üzerinde özel komut sunuyor. Python tabanlı bu araç seti, yapay zekâ tabanlı iş akışlarını standartlaştırmak ve üretkenliği artırmak amacıyla özelleştirilebilir betikler sağlıyor.</p>
 <ul class="disc-meta"><li>★ 23.654</li><li>Python</li><li>GitHub Trending · 2026-07-05</li></ul>

--- a/discover/claude-video/index.html
+++ b/discover/claude-video/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Video</span><span class="disc-momentum">🚀 +427 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Claude Video</span><span class="disc-momentum">↑ +427 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile video analizi</h1>
 <p class="disc-lead">Claude-video, Claude modeline video içeriğini analiz etme yeteneği kazandıran bir Python aracıdır. Yazılım, videoları indirip karelere ayırarak ve metne dönüştürerek (transcription) görsel veriyi yapay zekâ modelinin işleyebileceği formata getirir.</p>
 <ul class="disc-meta"><li>★ 13.424</li><li>Python</li><li>GitHub Trending · 2026-07-07</li></ul>

--- a/discover/clean-code-javascript/index.html
+++ b/discover/clean-code-javascript/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Clean Code Javascript</span><span class="disc-momentum">🚀 +27 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Clean Code Javascript</span><span class="disc-momentum">↑ +27 bugün</span></div>
 <h1 class="disc-title">JavaScript ile temiz kod yazımı</h1>
 <p class="disc-lead">Temiz kod (clean code) prensiplerini JavaScript diline uyarlayan bu rehber, yazılım geliştirme süreçlerinde okunabilir ve sürdürülebilir kod yazımı için standartlar sunuyor. Nesne yönelimli programlama (object-oriented programming) ve fonksiyonel programlama ilkelerini pratik örneklerle birleştiriyor.</p>
 <ul class="disc-meta"><li>★ 94.633</li><li>JavaScript</li><li>GitHub Trending · 2026-07-03</li></ul>

--- a/discover/clone-wars/index.html
+++ b/discover/clone-wars/index.html
@@ -58,7 +58,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Clone-Wars</span><span class="disc-momentum">🚀 +337 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Clone-Wars</span><span class="disc-momentum">↑ +337 bugün</span></div>
 <h1 class="disc-title">Popüler Platformların Açık Kaynak Kopyaları</h1>
 <p class="disc-lead">Clone-Wars, Airbnb, Instagram ve Netflix gibi popüler platformların 100&#x27;den fazla açık kaynaklı kopyasını (clone) tek bir çatı altında topluyor. Geliştiriciler, projelerin kaynak kodlarına, teknoloji yığınlarına (tech stack) ve canlı demo bağlantılarına erişerek uygulama mimarilerini inceleyebiliyor.</p>
 <ul class="disc-meta"><li>★ 35.393</li><li>GitHub Trending · 2026-06-15</li></ul>

--- a/discover/cloudflare-temp-email/index.html
+++ b/discover/cloudflare-temp-email/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cloudflare Temp Email</span><span class="disc-momentum">🚀 +68 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cloudflare Temp Email</span><span class="disc-momentum">↑ +68 bugün</span></div>
 <h1 class="disc-title">Cloudflare üzerinde ücretsiz geçici e-posta</h1>
 <p class="disc-lead">Cloudflare altyapısını kullanarak ücretsiz geçici e-posta (temporary email) hizmeti oluşturmayı sağlayan bu araç, e-posta alıp gönderme işlemlerini destekliyor. Proje, eklerin yönetimi, IMAP ve SMTP protokolleri ile Telegram botu entegrasyonu gibi özellikler sunuyor.</p>
 <ul class="disc-meta"><li>★ 11.156</li><li>TypeScript</li><li>GitHub Trending · 2026-07-23</li></ul>

--- a/discover/clypra/index.html
+++ b/discover/clypra/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Clypra</span><span class="disc-momentum">🚀 +85 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Clypra</span><span class="disc-momentum">↑ +85 bugün</span></div>
 <h1 class="disc-title">Açık kaynaklı masaüstü video düzenleyici</h1>
 <p class="disc-lead">Clypra, Tauri, React ve TypeScript kullanılarak geliştirilen açık kaynak kodlu bir video düzenleyici (video editor) uygulamasıdır. Yazılım, ücretli video düzenleme araçlarında bulunan gelişmiş özellikleri ücretsiz bir alternatif olarak sunmayı hedefler.</p>
 <ul class="disc-meta"><li>★ 2.965</li><li>TypeScript</li><li>GitHub Trending · 2026-07-15</li></ul>

--- a/discover/code-review-graph/index.html
+++ b/discover/code-review-graph/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Code Review Graph</span><span class="disc-momentum">🚀 +74 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Code Review Graph</span><span class="disc-momentum">↑ +74 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ kod incelemesinde token tasarrufu</h1>
 <p class="disc-lead">Code-review-graph, kod tabanını analiz ederek yapay zekâ araçları için yerel odaklı bir kod zekası haritası (code intelligence graph) oluşturuyor. Bu yapı, büyük projelerde bağlam azaltma (context reduction) yöntemlerini kullanarak yapay zekâ destekli kod inceleme süreçlerini daha verimli hale getiriyor.</p>
 <ul class="disc-meta"><li>★ 28.041</li><li>Python</li><li>GitHub Trending · 2026-07-18</li></ul>

--- a/discover/codebase-memory-mcp/index.html
+++ b/discover/codebase-memory-mcp/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Codebase Memory MCP</span><span class="disc-momentum">🚀 +371 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Codebase Memory MCP</span><span class="disc-momentum">↑ +371 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ kodlama ajanları için hızlı indeksleme</h1>
 <p class="disc-lead">Codebase-memory-mcp, kod tabanlarını kalıcı bir bilgi grafiğine (knowledge graph) dönüştürerek yüksek performanslı kod istihbaratı sunuyor. C diliyle geliştirilen araç, 158 programlama dilini desteklerken sorgu sürelerini milisaniyenin altına indiriyor ve jeton (token) kullanımını azaltıyor.</p>
 <ul class="disc-meta"><li>★ 37.095</li><li>C</li><li>GitHub Trending · 2026-06-18</li></ul>

--- a/discover/codex-plugin-cc/index.html
+++ b/discover/codex-plugin-cc/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Codex Plugin Cc</span><span class="disc-momentum">🚀 +352 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Codex Plugin Cc</span><span class="disc-momentum">↑ +352 bugün</span></div>
 <h1 class="disc-title">Claude Code için yapay zekâ destekli kod inceleme</h1>
 <p class="disc-lead">OpenAI tarafından geliştirilen Codex eklentisi, Claude Code üzerinde kod inceleme süreçlerini otomatize etmek ve görev delegasyonu sağlamak için kullanılıyor. Bu araç, yazılım geliştirme iş akışlarında farklı yapay zekâ modellerinin (large language models) entegre çalışmasına olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 30.950</li><li>JavaScript</li><li>GitHub Trending · 2026-07-03</li></ul>

--- a/discover/codexbar/index.html
+++ b/discover/codexbar/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · CodexBar</span><span class="disc-momentum">🚀 +153 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · CodexBar</span><span class="disc-momentum">↑ +153 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ kullanım limitlerini izleyin</h1>
 <p class="disc-lead">CodexBar, OpenAI Codex ve Claude Code kullanım verilerini oturum açma zorunluluğu olmadan görüntülemeyi sağlayan bir araçtır. Swift diliyle geliştirilen bu uygulama, geliştiricilerin yapay zekâ destekli kodlama araçlarındaki tüketim istatistiklerini izlemelerini kolaylaştırır.</p>
 <ul class="disc-meta"><li>★ 19.597</li><li>Swift</li><li>GitHub Trending · 2026-07-06</li></ul>

--- a/discover/coding-interview-university/index.html
+++ b/discover/coding-interview-university/index.html
@@ -58,7 +58,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Coding Interview University</span><span class="disc-momentum">🚀 +330 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Coding Interview University</span><span class="disc-momentum">↑ +330 bugün</span></div>
 <h1 class="disc-title">Yazılım Mülakatlarına Hazırlık Rehberi</h1>
 <p class="disc-lead">Coding-interview-university, yazılım mühendisi olmak isteyenler için bilgisayar bilimleri (computer science) temellerini kapsayan kapsamlı bir çalışma planı sunuyor. Bu kaynak, teknik mülakatlara hazırlık sürecinde ihtiyaç duyulan teorik ve pratik bilgileri yapılandırılmış bir müfredatla birleştiriyor.</p>
 <ul class="disc-meta"><li>★ 349.290</li><li>GitHub Trending · 2026-06-04</li></ul>

--- a/discover/cognee/index.html
+++ b/discover/cognee/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cognee</span><span class="disc-momentum">🚀 +347 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cognee</span><span class="disc-momentum">↑ +347 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanınıza kalıcı hafıza</h1>
 <p class="disc-lead">Cognee, yapay zekâ ajanlarına oturumlar arası kalıcı uzun süreli bellek (long-term memory) sağlayan açık kaynaklı bir platformdur. Kendi kendine barındırılan bir bilgi grafiği motoru (knowledge graph engine) kullanarak ajanların verileri yapılandırılmış şekilde saklamasına ve geri çağırmasına olanak tanır.</p>
 <ul class="disc-meta"><li>★ 29.804</li><li>Python</li><li>GitHub Trending · 2026-06-22</li></ul>

--- a/discover/compound-engineering-plugin/index.html
+++ b/discover/compound-engineering-plugin/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Compound Engineering</span><span class="disc-momentum">🚀 Bir günde +184 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Compound Engineering</span><span class="disc-momentum">↑ Bir günde +184 yıldız</span></div>
       <h1 class="disc-title">Yapay zekâ Destekli Mühendislik Süreçleri</h1>
       <p class="disc-lead"><strong>Compound Engineering</strong>; Claude Code, Codex ve Cursor için geliştirilmiş resmi bir eklentidir. Temel felsefesi nettir: <strong>her mühendislik işi bir sonrakini zorlaştırmamalı, aksine kolaylaştırmalıdır.</strong> Bu amaçla, geliştirme sürecini iyileştiren yapay zekâ becerileri ve ajanları sunar.</p>
       <ul class="disc-meta"><li>★ 24.046</li><li>TypeScript</li><li>MIT</li><li>GitHub Trending · 29 May 2026</li></ul>

--- a/discover/computer-science/index.html
+++ b/discover/computer-science/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Computer Science</span><span class="disc-momentum">🚀 +107 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Computer Science</span><span class="disc-momentum">↑ +107 bugün</span></div>
 <h1 class="disc-title">Ücretsiz bilgisayar bilimleri eğitim yolu</h1>
 <p class="disc-lead">Bilgisayar bilimleri (computer science) alanında ücretsiz ve kendi kendine öğrenme odaklı bir müfredat sunan bu kaynak, akademik standartlara uygun bir eğitim yolu oluşturuyor. Yazılım geliştirme ve temel bilişim disiplinlerini kapsayan yapılandırılmış bir öğrenme süreci sağlıyor.</p>
 <ul class="disc-meta"><li>★ 206.669</li><li>HTML</li><li>GitHub Trending · 2026-07-17</li></ul>

--- a/discover/computer/index.html
+++ b/discover/computer/index.html
@@ -57,7 +57,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Computer</span><span class="disc-momentum">🚀 +891 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Computer</span><span class="disc-momentum">↑ +891 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanlarına bilgisayar kontrolü</h1>
 <p class="disc-lead">Cloudflare tarafından geliştirilen Computer, yapay zekâ ajanlarına yerel veya uzak bir bilgisayarı kontrol etme yeteneği kazandıran bir TypeScript kütüphanesi. Bu araç, ajanların işletim sistemi üzerinde komut çalıştırmasına ve dosya sistemine erişerek karmaşık görevleri otomatize etmesine olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 3.677</li><li>TypeScript</li><li>GitHub Trending · 2026-08-06</li></ul>

--- a/discover/container/index.html
+++ b/discover/container/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Container</span><span class="disc-momentum">🚀 +1.611 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Container</span><span class="disc-momentum">↑ +1.611 bugün</span></div>
 <h1 class="disc-title">Mac üzerinde hızlı Linux sanallaştırma</h1>
 <p class="disc-lead">Apple tarafından geliştirilen container, Mac üzerinde hafif sanal makineler (virtual machines) kullanarak Linux kapsayıcıları (containers) oluşturmaya ve çalıştırmaya olanak tanıyor. Swift diliyle yazılan araç, Apple silikon (Apple silicon) mimarisi için optimize edilmiş bir performans sunuyor.</p>
 <ul class="disc-meta"><li>★ 48.543</li><li>Swift</li><li>GitHub Trending · 2026-06-11</li></ul>

--- a/discover/copilotkit/index.html
+++ b/discover/copilotkit/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · CopilotKit</span><span class="disc-momentum">🚀 +366 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · CopilotKit</span><span class="disc-momentum">↑ +366 bugün</span></div>
 <h1 class="disc-title">Uygulamalarınız İçin yapay zekâ Arayüzleri</h1>
 <p class="disc-lead">CopilotKit, yapay zekâ ajanları ve üretken arayüzler (generative UI) geliştirmek için React ve Angular tabanlı bir ön yüz yığını (frontend stack) sunuyor. AG-UI protokolü üzerinden uygulamalara akıllı yetenekler entegre edilmesini sağlayan bir altyapı sağlıyor.</p>
 <ul class="disc-meta"><li>★ 36.508</li><li>TypeScript</li><li>GitHub Trending · 2026-06-06</li></ul>

--- a/discover/core/index.html
+++ b/discover/core/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Core</span><span class="disc-momentum">🚀 +80 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Core</span><span class="disc-momentum">↑ +80 bugün</span></div>
 <h1 class="disc-title">Yerel kontrollü ev otomasyonu platformu</h1>
 <p class="disc-lead">Home Assistant, yerel kontrol ve gizliliği önceliklendiren açık kaynaklı bir ev otomasyonu (home automation) platformudur. Python diliyle geliştirilen bu sistem, kullanıcıların akıllı cihazlarını merkezi bir ağ üzerinden yönetmelerine olanak tanır.</p>
 <ul class="disc-meta"><li>★ 89.760</li><li>Python</li><li>GitHub Trending · 2026-07-12</li></ul>

--- a/discover/cosmos/index.html
+++ b/discover/cosmos/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cosmos</span><span class="disc-momentum">🚀 +133 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cosmos</span><span class="disc-momentum">↑ +133 bugün</span></div>
 <h1 class="disc-title">Fiziksel sistemler için yapay zekâ modelleri</h1>
 <p class="disc-lead">NVIDIA tarafından geliştirilen Cosmos, robotlar ve otonom araçlar gibi fiziksel sistemler için dünya modelleri (world models), veri setleri ve araçlar sunan açık bir platformdur. Geliştiricilerin fiziksel yapay zekâ (physical AI) uygulamaları oluşturmasını kolaylaştıran bir altyapı sağlar.</p>
 <ul class="disc-meta"><li>★ 11.343</li><li>Jupyter Notebook</li><li>GitHub Trending · 2026-06-05</li></ul>

--- a/discover/council-of-high-intelligence/index.html
+++ b/discover/council-of-high-intelligence/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Council of High Intelligence</span><span class="disc-momentum">🚀 +331 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Council of High Intelligence</span><span class="disc-momentum">↑ +331 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile çok yönlü karar verme</h1>
 <p class="disc-lead">Council of High Intelligence, farklı büyük dil modellerini (large language models) kullanarak çeşitli uzman kişilikler üzerinden yapılandırılmış karar verme süreçleri yürütüyor. Sistem, karmaşık problemleri çok turlu tartışmalarla analiz ederek farklı yapay zekâ modellerinin bakış açılarını birleştiriyor.</p>
 <ul class="disc-meta"><li>★ 3.808</li><li>Shell</li><li>GitHub Trending · 2026-06-30</li></ul>

--- a/discover/crawl4ai/index.html
+++ b/discover/crawl4ai/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Crawl4AI</span><span class="disc-momentum">🚀 Bir günde +154 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Crawl4AI</span><span class="disc-momentum">↑ Bir günde +154 yıldız</span></div>
       <h1 class="disc-title">Web Verilerini yapay zekâya Hazırlayın</h1>
       <p class="disc-lead"><strong>Crawl4AI</strong>; büyük dil modelleri için optimize edilmiş, açık kaynak bir <strong>web tarayıcı ve kazıyıcıdır</strong>. Web sayfalarını, yapay zekâ modellerinin kolayca işleyebileceği temiz ve yapılandırılmış formatlara (Markdown vb.) dönüştürür.</p>
       <ul class="disc-meta"><li>★ 75.853</li><li>Python</li><li>Apache-2.0</li><li>GitHub Trending · 29 May 2026</li></ul>

--- a/discover/croc/index.html
+++ b/discover/croc/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Croc</span><span class="disc-momentum">🚀 +361 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Croc</span><span class="disc-momentum">↑ +361 bugün</span></div>
 <h1 class="disc-title">Güvenli ve kolay dosya transferi</h1>
 <p class="disc-lead">Croc, iki bilgisayar arasında uçtan uca şifreleme (end-to-end encryption) kullanarak güvenli dosya ve veri aktarımı sağlayan bir araçtır. Go programlama diliyle geliştirilen bu yazılım, aktarım sürecini kolaylaştırmak için geçici bir röle (relay) mekanizması kullanır.</p>
 <ul class="disc-meta"><li>★ 39.265</li><li>Go</li><li>GitHub Trending · 2026-07-22</li></ul>

--- a/discover/cs-self-learning/index.html
+++ b/discover/cs-self-learning/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cs Self Learning</span><span class="disc-momentum">🚀 +134 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cs Self Learning</span><span class="disc-momentum">↑ +134 bugün</span></div>
 <h1 class="disc-title">Bilgisayar bilimleri için kapsamlı yol haritası</h1>
 <p class="disc-lead">Pekin Üniversitesi öğrencileri tarafından hazırlanan bu rehber, bilgisayar bilimleri (computer science) alanında kendi kendine öğrenmek isteyenler için kapsamlı bir yol haritası sunuyor. Temel derslerden uzmanlık alanlarına kadar geniş bir müfredatı kaynaklar ve çalışma yöntemleriyle birleştiriyor.</p>
 <ul class="disc-meta"><li>★ 74.728</li><li>HTML</li><li>GitHub Trending · 2026-07-20</li></ul>

--- a/discover/cs249r-book/index.html
+++ b/discover/cs249r-book/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cs249r Book</span><span class="disc-momentum">🚀 +68 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cs249r Book</span><span class="disc-momentum">↑ +68 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ sistemleri için kapsamlı rehber</h1>
 <p class="disc-lead">Harvard Üniversitesi tarafından paylaşılan bu kaynak, makine öğrenmesi sistemleri (machine learning systems) üzerine kapsamlı bir teknik rehber sunuyor. Donanım ve yazılım katmanlarını birleştiren bu çalışma, ölçeklenebilir yapay zekâ altyapılarının tasarım süreçlerini ele alıyor.</p>
 <ul class="disc-meta"><li>★ 27.689</li><li>Python</li><li>GitHub Trending · 2026-07-03</li></ul>

--- a/discover/cua/index.html
+++ b/discover/cua/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · CUA</span><span class="disc-momentum">🚀 +70 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · CUA</span><span class="disc-momentum">↑ +70 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları için bilgisayar kontrolü</h1>
 <p class="disc-lead">CUA, bilgisayar kullanım yeteneğine sahip yapay zekâ ajanları için açık kaynaklı bir altyapı sunuyor. Masaüstü işletim sistemlerini kontrol edebilen ajanların eğitimi ve değerlendirilmesi amacıyla kum havuzu (sandbox), yazılım geliştirme kiti (SDK) ve kıyaslama (benchmark) araçlarını tek bir çatı altında topluyor.</p>
 <ul class="disc-meta"><li>★ 20.962</li><li>HTML</li><li>GitHub Trending · 2026-06-16</li></ul>

--- a/discover/cubesandbox/index.html
+++ b/discover/cubesandbox/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · CubeSandbox</span><span class="disc-momentum">🚀 +79 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · CubeSandbox</span><span class="disc-momentum">↑ +79 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları için güvenli çalışma ortamı</h1>
 <p class="disc-lead">TencentCloud tarafından Rust diliyle geliştirilen CubeSandbox, yapay zekâ ajanları (AI agents) için anlık, eş zamanlı ve güvenli bir çalışma ortamı (sandbox) sunuyor. Hafif yapısıyla dikkat çeken bu araç, ajan tabanlı sistemlerin yalıtılmış bir alanda çalışmasını sağlıyor.</p>
 <ul class="disc-meta"><li>★ 10.828</li><li>Rust</li><li>GitHub Trending · 2026-07-02</li></ul>

--- a/discover/cupp/index.html
+++ b/discover/cupp/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cupp</span><span class="disc-momentum">🚀 +32 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cupp</span><span class="disc-momentum">↑ +32 bugün</span></div>
 <h1 class="disc-title">Hedef odaklı parola listesi oluşturma</h1>
 <p class="disc-lead">Ortak Kullanıcı Parola Profilleyici (Common User Passwords Profiler), hedef odaklı parola listeleri oluşturmak için kullanılan bir Python aracıdır. Belirli kullanıcı verilerini analiz ederek özelleştirilmiş sözlük dosyaları (wordlists) hazırlar.</p>
 <ul class="disc-meta"><li>★ 6.161</li><li>Python</li><li>GitHub Trending · 2026-07-01</li></ul>

--- a/discover/cupy/index.html
+++ b/discover/cupy/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cupy</span><span class="disc-momentum">🚀 +174 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cupy</span><span class="disc-momentum">↑ +174 bugün</span></div>
 <h1 class="disc-title">GPU destekli sayısal hesaplama kütüphanesi</h1>
 <p class="disc-lead">CuPy, sayısal hesaplama kütüphanesi NumPy ve SciPy arayüzlerini grafik işlem birimi (GPU) hızlandırmasıyla birleştiriyor. Python tabanlı bu kütüphane, CUDA çekirdeklerini kullanarak karmaşık matematiksel işlemleri hızlandırıyor.</p>
 <ul class="disc-meta"><li>★ 12.227</li><li>Python</li><li>GitHub Trending · 2026-06-29</li></ul>

--- a/discover/cursor-plugins/index.html
+++ b/discover/cursor-plugins/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cursor Plugins</span><span class="disc-momentum">🚀 Bir günde +206 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cursor Plugins</span><span class="disc-momentum">↑ Bir günde +206 yıldız</span></div>
       <h1 class="disc-title">Cursor Editörünü Eklentilerle Özelleştirin</h1>
       <p class="disc-lead"><strong>Cursor Plugins</strong>; Cursor kod editörü için hazırlanan <strong>resmi eklenti spesifikasyonu</strong> ve hazır resmi eklentileri içerir. Geliştiricilerin kendi eklentilerini oluşturmalarına olanak tanır.</p>
       <ul class="disc-meta"><li>★ 2.515</li><li>TypeScript</li><li>Lisans: kontrol et</li><li>GitHub Trending · 30 May 2026</li></ul>

--- a/discover/cwc-workshops/index.html
+++ b/discover/cwc-workshops/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cwc Workshops</span><span class="disc-momentum">🚀 +45 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cwc Workshops</span><span class="disc-momentum">↑ +45 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları için uygulamalı atölye</h1>
 <p class="disc-lead">Anthropic tarafından paylaşılan bu atölye çalışmaları, geliştiricilere bilgisayar kullanımı (computer use) yeteneğine sahip yapay zekâ ajanları oluşturma süreçlerini uygulamalı olarak gösteriyor. TypeScript tabanlı örnekler, modellerin ekran arayüzleriyle etkileşime girerek karmaşık görevleri yönetmesine olanak tanıyan teknik yapıları içeriyor.</p>
 <ul class="disc-meta"><li>★ 1.632</li><li>TypeScript</li><li>GitHub Trending · 2026-07-18</li></ul>

--- a/discover/cypress/index.html
+++ b/discover/cypress/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cypress</span><span class="disc-momentum">🚀 +121 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Cypress</span><span class="disc-momentum">↑ +121 bugün</span></div>
 <h1 class="disc-title">Uçtan uca testlerinizi hızlandırın</h1>
 <p class="disc-lead">Cypress, tarayıcı tabanlı uygulamalar için uçtan uca test (end-to-end testing) süreçlerini hızlandıran ve kolaylaştıran bir otomasyon çerçevesidir (framework). TypeScript ile geliştirilen bu araç, web uygulamalarının güvenilirliğini artırmak adına geliştiricilere hızlı hata ayıklama ve test yönetimi imkânı sunar.</p>
 <ul class="disc-meta"><li>★ 50.916</li><li>TypeScript</li><li>GitHub Trending · 2026-06-15</li></ul>

--- a/discover/daily-stock-analysis/index.html
+++ b/discover/daily-stock-analysis/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Daily Stock Analysis</span><span class="disc-momentum">🚀 +568 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Daily Stock Analysis</span><span class="disc-momentum">↑ +568 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile otomatik borsa analizi</h1>
 <p class="disc-lead">Büyük dil modelleri (large language models) ile desteklenen bu sistem, çok kaynaklı piyasa verilerini ve gerçek zamanlı haberleri analiz ederek yatırım kararları için görselleştirilmiş paneller sunuyor. Otomatik bildirimler ve ücretsiz zamanlanmış çalışma desteğiyle farklı borsalar için analiz süreçlerini standartlaştırıyor.</p>
 <ul class="disc-meta"><li>★ 59.863</li><li>Python</li><li>GitHub Trending · 2026-06-22</li></ul>

--- a/discover/data-engineering-zoomcamp/index.html
+++ b/discover/data-engineering-zoomcamp/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Data Engineering Zoomcamp</span><span class="disc-momentum">🚀 Bir günde +277 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Data Engineering Zoomcamp</span><span class="disc-momentum">↑ Bir günde +277 yıldız</span></div>
       <h1 class="disc-title">Veri Mühendisliğinde Uzmanlaşın</h1>
       <p class="disc-lead"><strong>Data Engineering Zoomcamp</strong>, üretime hazır <strong>veri hatları (data pipelines)</strong> oluşturmayı kapsayan, DataTalksClub tarafından sunulan dokuz haftalık ücretsiz bir eğitimdir. Uygulamalı ve projeye dayalı bir müfredat sunar.</p>
       <ul class="disc-meta"><li>★ 44.237</li><li>Kurs</li><li>Lisans: kontrol et</li><li>GitHub Trending · 30 May 2026</li></ul>

--- a/discover/dbt-core/index.html
+++ b/discover/dbt-core/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Dbt Core</span><span class="disc-momentum">🚀 +18 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Dbt Core</span><span class="disc-momentum">↑ +18 bugün</span></div>
 <h1 class="disc-title">Veri ambarında standartlaştırılmış dönüşüm süreçleri</h1>
 <p class="disc-lead">Veri dönüştürme aracı (dbt-core), veri analistlerinin ve mühendislerinin yazılım geliştirme süreçlerine benzer yöntemlerle veri dönüşümü (data transformation) yapmalarını sağlıyor. Sürüm kontrolü ve test süreçlerini veri ambarlarına entegre ederek analitik iş akışlarını standartlaştırıyor.</p>
 <ul class="disc-meta"><li>★ 13.561</li><li>Rust</li><li>GitHub Trending · 2026-06-28</li></ul>

--- a/discover/deepseek-reasonix/index.html
+++ b/discover/deepseek-reasonix/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · DeepSeek-Reasonix</span><span class="disc-momentum">🚀 +333 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · DeepSeek-Reasonix</span><span class="disc-momentum">↑ +333 bugün</span></div>
 <h1 class="disc-title">Terminal için yapay zekâ kodlama ajanı</h1>
 <p class="disc-lead">DeepSeek-Reasonix, terminal üzerinde çalışan ve DeepSeek modellerini temel alan bir yapay zekâ kodlama ajanıdır. Önek önbelleği (prefix-cache) kararlılığına odaklanan bu araç, geliştiricilerin uzun süreli oturumlarda kesintisiz kodlama desteği almasını sağlar.</p>
 <ul class="disc-meta"><li>★ 31.870</li><li>Go</li><li>GitHub Trending · 2026-08-03</li></ul>

--- a/discover/deeptutor/index.html
+++ b/discover/deeptutor/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · DeepTutor</span><span class="disc-momentum">🚀 +172 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · DeepTutor</span><span class="disc-momentum">↑ +172 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ destekli kişiselleştirilmiş eğitim</h1>
 <p class="disc-lead">DeepTutor, öğrenci verilerini kullanarak kişiselleştirilmiş eğitim süreçleri sunan yaşam boyu öğrenme (lifelong learning) tabanlı bir özel ders sistemidir. Proje, yapay zekâ destekli bireyselleştirilmiş öğretim (personalized tutoring) yöntemleriyle öğrenme deneyimini optimize etmeyi amaçlamaktadır.</p>
 <ul class="disc-meta"><li>★ 32.640</li><li>Python</li><li>GitHub Trending · 2026-07-16</li></ul>

--- a/discover/deer-flow/index.html
+++ b/discover/deer-flow/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Deer Flow</span><span class="disc-momentum">🚀 +442 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Deer Flow</span><span class="disc-momentum">↑ +442 bugün</span></div>
 <h1 class="disc-title">Karmaşık görevler için yapay zekâ ajanı</h1>
 <p class="disc-lead">ByteDance tarafından geliştirilen Deer-Flow, uzun süreli görevleri yerine getirmek için tasarlanmış açık kaynaklı bir süper ajan (SuperAgent) çerçevesidir. Sistem; kum havuzu (sandbox), hafıza yönetimi ve alt ajanlar kullanarak karmaşık iş akışlarını otonom şekilde araştırıp kodlayabilmektedir.</p>
 <ul class="disc-meta"><li>★ 78.818</li><li>Python</li><li>GitHub Trending · 2026-06-22</li></ul>

--- a/discover/deno/index.html
+++ b/discover/deno/index.html
@@ -57,7 +57,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Deno</span><span class="disc-momentum">🚀 +31 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Deno</span><span class="disc-momentum">↑ +31 bugün</span></div>
 <h1 class="disc-title">Modern JavaScript ve TypeScript çalışma zamanı</h1>
 <p class="disc-lead">Deno, JavaScript ve TypeScript dilleri için tasarlanmış modern bir çalışma zamanı (runtime) ortamıdır. Rust diliyle geliştirilen bu araç, güvenlik ve performans odaklı yapısıyla geleneksel Node.js platformuna alternatif bir altyapı sunar.</p>
 <ul class="disc-meta"><li>★ 108.166</li><li>Rust</li><li>GitHub Trending · 2026-08-05</li></ul>

--- a/discover/design-md/index.html
+++ b/discover/design-md/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Design.md</span><span class="disc-momentum">🚀 +619 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Design.md</span><span class="disc-momentum">↑ +619 bugün</span></div>
 <h1 class="disc-title">Tasarım sistemlerini yapay zekâya tanıtın</h1>
 <p class="disc-lead">Google Labs tarafından geliştirilen DESIGN.md, görsel kimlik bilgilerini kodlama ajanlarına aktarmak için yapılandırılmış bir format spesifikasyonu sunuyor. Bu standart, tasarım sistemlerinin (design systems) yapay zekâ ajanları tarafından tutarlı ve kalıcı bir şekilde anlaşılmasını sağlıyor.</p>
 <ul class="disc-meta"><li>★ 26.873</li><li>TypeScript</li><li>GitHub Trending · 2026-06-25</li></ul>

--- a/discover/desktopcommandermcp/index.html
+++ b/discover/desktopcommandermcp/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · DesktopCommanderMCP</span><span class="disc-momentum">🚀 +28 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · DesktopCommanderMCP</span><span class="disc-momentum">↑ +28 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile bilgisayarınızı yönetin</h1>
 <p class="disc-lead">DesktopCommanderMCP, Claude için geliştirilen ve yapay zekâ modeline uçbirim denetimi (terminal control), dosya sistemi araması ve fark tabanlı dosya düzenleme (diff file editing) yetenekleri kazandıran bir Model Bağlantı Protokolü (Model Context Protocol) sunucusudur. TypeScript ile yazılan bu araç, yapay zekânın yerel dosya sistemleri üzerinde doğrudan işlem yapabilmesini sağlar.</p>
 <ul class="disc-meta"><li>★ 9.072</li><li>TypeScript</li><li>GitHub Trending · 2026-07-09</li></ul>

--- a/discover/destructive-command-guard/index.html
+++ b/discover/destructive-command-guard/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Destructive Command Guard</span><span class="disc-momentum">🚀 +444 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Destructive Command Guard</span><span class="disc-momentum">↑ +444 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları için komut koruması</h1>
 <p class="disc-lead">Yıkıcı Komut Koruması (destructive command guard), yapay zekâ ajanları tarafından çalıştırılan tehlikeli git ve kabuk (shell) komutlarını engellemek için geliştirilmiş bir güvenlik katmanıdır. Rust diliyle yazılan bu araç, sistem seviyesinde komut yürütme süreçlerini denetleyerek istenmeyen veri kaybı veya sistem hasarı risklerini azaltır.</p>
 <ul class="disc-meta"><li>★ 5.642</li><li>Rust</li><li>GitHub Trending · 2026-07-13</li></ul>

--- a/discover/developer-portfolios/index.html
+++ b/discover/developer-portfolios/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Developer Portfolios</span><span class="disc-momentum">🚀 Bir günde +73 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Developer Portfolios</span><span class="disc-momentum">↑ Bir günde +73 yıldız</span></div>
       <h1 class="disc-title">İlham Veren Geliştirici Portfolyoları</h1>
       <p class="disc-lead"><strong>Developer Portfolios</strong>, yazılımcıların kişisel projelerini ve yetkinliklerini sergilediği <strong>portfolyo örneklerinden</strong> oluşan derli toplu bir koleksiyondur. Kendi sitenizi tasarlarken ilham almak için idealdir.</p>
       <ul class="disc-meta"><li>★ 25.746</li><li>Koleksiyon</li><li>Lisans: yok</li><li>GitHub Trending · 1 Haziran 2026</li></ul>

--- a/discover/dioxus/index.html
+++ b/discover/dioxus/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Dioxus</span><span class="disc-momentum">🚀 +271 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Dioxus</span><span class="disc-momentum">↑ +271 bugün</span></div>
 <h1 class="disc-title">Rust ile çok platformlu uygulamalar</h1>
 <p class="disc-lead">Dioxus, web, masaüstü ve mobil platformlar için tek bir kod tabanıyla uçtan uca (fullstack) uygulamalar geliştirmeye olanak tanıyan bir Rust çerçevesidir (framework). React benzeri bileşen tabanlı yapısıyla kullanıcı arayüzü oluşturma sürecini hızlandırarak Rust ekosistemindeki uygulama geliştirme deneyimini standartlaştırır.</p>
 <ul class="disc-meta"><li>★ 38.444</li><li>Rust</li><li>GitHub Trending · 2026-07-22</li></ul>

--- a/discover/dive-into-llms/index.html
+++ b/discover/dive-into-llms/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Dive Into Llms</span><span class="disc-momentum">🚀 +328 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Dive Into Llms</span><span class="disc-momentum">↑ +328 bugün</span></div>
 <h1 class="disc-title">Uygulamalı yapay zekâ eğitim serisi</h1>
 <p class="disc-lead">Dive into LLMs, büyük dil modellerinin (large language models) çalışma prensiplerini Jupyter Notebook dosyaları üzerinden uygulamalı olarak öğreten bir eğitim serisidir. Proje, temel kavramlardan ileri seviye tekniklere kadar geniş bir yelpazede kodlama pratikleri sunarak model geliştirme süreçlerini somutlaştırır.</p>
 <ul class="disc-meta"><li>★ 47.047</li><li>Jupyter Notebook</li><li>GitHub Trending · 2026-07-25</li></ul>

--- a/discover/docuseal/index.html
+++ b/discover/docuseal/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Docuseal</span><span class="disc-momentum">🚀 +91 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Docuseal</span><span class="disc-momentum">↑ +91 bugün</span></div>
 <h1 class="disc-title">Dijital belgeleri kolayca imzalayın</h1>
 <p class="disc-lead">DocuSeal, dijital belge oluşturma, doldurma ve imzalama süreçleri için açık kaynaklı bir alternatif sunuyor. Ruby diliyle geliştirilen bu platform, elektronik imza (e-signature) süreçlerini kendi altyapısında yönetmek isteyen kullanıcılar için çözüm sağlıyor.</p>
 <ul class="disc-meta"><li>★ 18.183</li><li>Ruby</li><li>GitHub Trending · 2026-07-18</li></ul>

--- a/discover/ds4/index.html
+++ b/discover/ds4/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ds4</span><span class="disc-momentum">🚀 +139 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ds4</span><span class="disc-momentum">↑ +139 bugün</span></div>
 <h1 class="disc-title">Yerel donanımda DeepSeek çalıştırma motoru</h1>
 <p class="disc-lead">Redis&#x27;in yaratıcısı Salvatore Sanfilippo tarafından geliştirilen ds4, DeepSeek modellerini yerel donanımlar üzerinde çalıştırmayı sağlayan bir çıkarım motoru (inference engine). C diliyle yazılan bu araç, Metal, CUDA ve ROCm desteği sayesinde farklı grafik işlemcilerinde yüksek performanslı model çalıştırma imkânı sunuyor.</p>
 <ul class="disc-meta"><li>★ 20.117</li><li>C</li><li>GitHub Trending · 2026-08-03</li></ul>

--- a/discover/ecc/index.html
+++ b/discover/ecc/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · ECC</span><span class="disc-momentum">🚀 Bir günde +1.912 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · ECC</span><span class="disc-momentum">↑ Bir günde +1.912 yıldız</span></div>
       <h1 class="disc-title">Yapay zekâ Ajanlarınıza Güç Katın</h1>
       <p class="disc-lead">ECC; Claude Code, Codex, Cursor ve OpenCode gibi yapay zekâ kodlama araçlarına <strong>beceriler, içgüdüler, hafıza optimizasyonu ve güvenlik taraması</strong> kazandıran kapsamlı bir sistemdir. Tekil konfigürasyon dosyaları yerine, ajanın daha tutarlı, güvenli ve önce-araştır mantığıyla çalışmasını sağlayan hazır bir katman sunar.</p>
       <figure class="disc-shot"><img src="/assets/discover/ecc.webp" width="1440" height="810" loading="lazy" decoding="async" alt="ECC arayüzünden bir görünüm"><figcaption>Görsel: ECC (proje deposundan)</figcaption></figure>

--- a/discover/editor/index.html
+++ b/discover/editor/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Editor</span><span class="disc-momentum">🚀 +341 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Editor</span><span class="disc-momentum">↑ +341 bugün</span></div>
 <h1 class="disc-title">Web tabanlı 3 boyutlu mimari düzenleyici</h1>
 <p class="disc-lead">TypeScript tabanlı pascalorg/editor, kullanıcıların tarayıcı üzerinden üç boyutlu mimari projeler oluşturmasına ve bu projeleri paylaşmasına olanak tanıyor. Yazılım, mimari tasarım süreçlerini web tabanlı bir arayüzle erişilebilir kılmayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 20.706</li><li>TypeScript</li><li>GitHub Trending · 2026-07-29</li></ul>

--- a/discover/ego-lite/index.html
+++ b/discover/ego-lite/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ego Lite</span><span class="disc-momentum">🚀 +247 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ego Lite</span><span class="disc-momentum">↑ +247 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları için eş zamanlı tarayıcı</h1>
 <p class="disc-lead">Ego-lite, kullanıcılar ve yapay zekâ ajanları (AI agents) için eş zamanlı çalışma imkânı sunan bir tarayıcıdır. JavaScript tabanlı bu araç, insan ve makine etkileşimini aynı tarayıcı ortamında paralel şekilde yürütmeyi hedefler.</p>
 <ul class="disc-meta"><li>★ 8.875</li><li>JavaScript</li><li>GitHub Trending · 2026-07-24</li></ul>

--- a/discover/elasticsearch/index.html
+++ b/discover/elasticsearch/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Elasticsearch</span><span class="disc-momentum">🚀 +91 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Elasticsearch</span><span class="disc-momentum">↑ +91 bugün</span></div>
 <h1 class="disc-title">Büyük verilerde hızlı arama yapın</h1>
 <p class="disc-lead">Java ile geliştirilen Elasticsearch, büyük veri kümeleri üzerinde hızlı arama ve analiz yapılmasına olanak tanıyan dağıtık (distributed) ve açık kaynaklı bir arama motorudur. RESTful mimarisi sayesinde verilerin gerçek zamanlı olarak indekslenmesini ve sorgulanmasını destekler.</p>
 <ul class="disc-meta"><li>★ 77.787</li><li>Java</li><li>GitHub Trending · 2026-07-04</li></ul>

--- a/discover/english-level-up-tips/index.html
+++ b/discover/english-level-up-tips/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · English Level Up Tips</span><span class="disc-momentum">🚀 Bir günde +1.163 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · English Level Up Tips</span><span class="disc-momentum">↑ Bir günde +1.163 yıldız</span></div>
       <h1 class="disc-title">İngilizcenizi İleri Seviyeye Taşıyın</h1>
       <p class="disc-lead"><strong>English Level Up Tips</strong>, ileri seviye İngilizce için stratejik çalışma planları, seçilmiş kaynaklar ve yöntemler sunan kapsamlı bir rehberdir. Dil becerilerini gerçekten geliştirmek isteyenler için derli toplu bir kaynak niteliğindedir.</p>
       <ul class="disc-meta"><li>★ 56.687</li><li>Rehber</li><li>Lisans: yok</li><li>GitHub Trending · 28 May 2026</li></ul>

--- a/discover/esp32-bit-pirate/index.html
+++ b/discover/esp32-bit-pirate/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · ESP32-Bit-Pirate</span><span class="disc-momentum">🚀 +83 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · ESP32-Bit-Pirate</span><span class="disc-momentum">↑ +83 bugün</span></div>
 <h1 class="disc-title">Donanım analizi için çok protokollü araç</h1>
 <p class="disc-lead">ESP32-Bit-Pirate, web tabanlı bir komut satırı arayüzü (CLI) üzerinden çok sayıda haberleşme protokolünü destekleyen bir donanım hackleme aracıdır. C++ diliyle geliştirilen bu sistem, farklı protokolleri tek bir platform üzerinden yöneterek donanım analizi süreçlerini kolaylaştırır.</p>
 <ul class="disc-meta"><li>★ 5.281</li><li>C++</li><li>GitHub Trending · 2026-08-01</li></ul>

--- a/discover/espectre/index.html
+++ b/discover/espectre/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Espectre</span><span class="disc-momentum">🚀 +134 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Espectre</span><span class="disc-momentum">↑ +134 bugün</span></div>
 <h1 class="disc-title">Wi-Fi sinyalleri ile hareket algılama</h1>
 <p class="disc-lead">ESPectre, Wi-Fi kanal durum bilgisi (CSI) analizi üzerinden hareket algılama gerçekleştiren bir sistemdir. Ev otomasyon platformu Ev Asistanı (Home Assistant) ile entegre çalışarak kablosuz ağ sinyallerini izleme yeteneği sunar.</p>
 <ul class="disc-meta"><li>★ 8.905</li><li>Python</li><li>GitHub Trending · 2026-06-10</li></ul>

--- a/discover/exercises-dataset/index.html
+++ b/discover/exercises-dataset/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Exercises Dataset</span><span class="disc-momentum">🚀 +1.343 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Exercises Dataset</span><span class="disc-momentum">↑ +1.343 bugün</span></div>
 <h1 class="disc-title">Çok dilli fitness egzersiz veri seti</h1>
 <p class="disc-lead">Hasaneyldrm tarafından paylaşılan egzersiz veri seti (exercises-dataset), 433 farklı fitness hareketini isim, hedef kas grubu, ekipman ve görsel talimatlarla birlikte sunuyor. Bu kapsamlı kaynak, spor teknolojileri uygulamaları geliştirenler için yapılandırılmış bir veri altyapısı sağlıyor.</p>
 <ul class="disc-meta"><li>★ 18.515</li><li>HTML</li><li>GitHub Trending · 2026-07-01</li></ul>

--- a/discover/faceswap/index.html
+++ b/discover/faceswap/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Faceswap</span><span class="disc-momentum">🚀 +166 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Faceswap</span><span class="disc-momentum">↑ +166 bugün</span></div>
 <h1 class="disc-title">Görüntülerde Yüz Değiştirme Rehberi</h1>
 <p class="disc-lead">Python tabanlı Faceswap, derin sahte (deepfake) teknolojisini kullanarak görüntülerdeki yüzleri değiştirmeye olanak tanıyan açık kaynaklı bir yazılımdır. Kullanıcıların video ve görseller üzerinde yüz dönüştürme (face swapping) işlemleri gerçekleştirmesine imkân sağlar.</p>
 <ul class="disc-meta"><li>★ 57.204</li><li>Python</li><li>GitHub Trending · 2026-07-30</li></ul>

--- a/discover/fanqiang/index.html
+++ b/discover/fanqiang/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Fanqiang</span><span class="disc-momentum">🚀 +161 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Fanqiang</span><span class="disc-momentum">↑ +161 bugün</span></div>
 <h1 class="disc-title">Kotlin ile internet sansürünü aşın</h1>
 <p class="disc-lead">Fanqiang projesi, internet sansürünü aşmak için geliştirilen ve Kotlin diliyle yazılmış bir ağ geçidi (gateway) aracıdır. Kullanıcılara kısıtlı ağ kaynaklarına erişim sağlamak amacıyla tasarlanmış açık kaynaklı bir yazılımdır.</p>
 <ul class="disc-meta"><li>★ 49.405</li><li>Kotlin</li><li>GitHub Trending · 2026-06-12</li></ul>

--- a/discover/fastmcp/index.html
+++ b/discover/fastmcp/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Fastmcp</span><span class="disc-momentum">🚀 +96 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Fastmcp</span><span class="disc-momentum">↑ +96 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ için hızlı araç entegrasyonu</h1>
 <p class="disc-lead">FastMCP, Model Bağlam Protokolü (Model Context Protocol - MCP) sunucuları ve istemcileri geliştirmeyi kolaylaştıran Python tabanlı bir çerçevedir (framework). Geliştiricilerin yapay zekâ modelleri ile yerel araçlar arasında hızlı entegrasyon kurmasını sağlar.</p>
 <ul class="disc-meta"><li>★ 27.084</li><li>Python</li><li>GitHub Trending · 2026-07-21</li></ul>

--- a/discover/firecrawl/index.html
+++ b/discover/firecrawl/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Firecrawl</span><span class="disc-momentum">🚀 +615 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Firecrawl</span><span class="disc-momentum">↑ +615 bugün</span></div>
 <h1 class="disc-title">Web verilerini yapay zekâya hazırlayın</h1>
 <p class="disc-lead">Firecrawl, web sitelerindeki verileri büyük ölçekte taramak, ayıklamak ve yapay zekâ modellerinin işleyebileceği temiz metin formatına dönüştürmek için bir arayüz (API) sunuyor. Bu araç, web içeriğiyle etkileşimi otomatize ederek veri toplama süreçlerini kolaylaştırıyor.</p>
 <ul class="disc-meta"><li>★ 159.421</li><li>TypeScript</li><li>GitHub Trending · 2026-06-23</li></ul>

--- a/discover/flashkda/index.html
+++ b/discover/flashkda/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · FlashKDA</span><span class="disc-momentum">🚀 +91 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · FlashKDA</span><span class="disc-momentum">↑ +91 bugün</span></div>
 <h1 class="disc-title">Kimi Delta Attention için yüksek performanslı çekirdekler</h1>
 <p class="disc-lead">Moonshot AI tarafından geliştirilen FlashKDA, Kimi Delta Attention mekanizması için yüksek performanslı çekirdekler (kernels) sunuyor. CUDA tabanlı bu teknoloji, büyük dil modellerinde dikkat (attention) hesaplamalarını hızlandırmayı amaçlıyor.</p>
 <ul class="disc-meta"><li>★ 1.043</li><li>Cuda</li><li>GitHub Trending · 2026-07-30</li></ul>

--- a/discover/flclash/index.html
+++ b/discover/flclash/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · FlClash</span><span class="disc-momentum">🚀 Bir günde +190 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · FlClash</span><span class="disc-momentum">↑ Bir günde +190 yıldız</span></div>
       <h1 class="disc-title">Açık kaynaklı modern proxy istemcisi</h1>
       <p class="disc-lead"><strong>FlClash</strong>; ClashMeta tabanlı, <strong>çok platformlu</strong> bir proxy (vekil sunucu) istemcisidir. Dart ile geliştirilmiş olup reklamsız, kullanıcı dostu ve açık kaynaklı bir yapıya sahiptir.</p>
       <figure class="disc-shot"><img src="/assets/discover/flclash.webp" width="640" height="420" loading="lazy" decoding="async" alt="FlClash arayüzünden bir görünüm"><figcaption>Görsel: FlClash (proje deposundan)</figcaption></figure>

--- a/discover/flue/index.html
+++ b/discover/flue/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Flue</span><span class="disc-momentum">🚀 +126 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Flue</span><span class="disc-momentum">↑ +126 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları için TypeScript çatısı</h1>
 <p class="disc-lead">Astro ekibi tarafından geliştirilen Flue, TypeScript tabanlı bir kum havuzu ajan çatısı (sandbox agent framework) olarak öne çıkıyor. Bu yapı, geliştiricilerin güvenli ve izole edilmiş ortamlarda yapay zekâ ajanları oluşturmasına olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 7.625</li><li>TypeScript</li><li>GitHub Trending · 2026-06-06</li></ul>

--- a/discover/fluidvoice/index.html
+++ b/discover/fluidvoice/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · FluidVoice</span><span class="disc-momentum">🚀 +365 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · FluidVoice</span><span class="disc-momentum">↑ +365 bugün</span></div>
 <h1 class="disc-title">MacOS için gizlilik odaklı sesli dikte</h1>
 <p class="disc-lead">FluidVoice, macOS işletim sistemi üzerinde tamamen çevrim dışı çalışan hızlı bir sesli dikte (voice to text) uygulamasıdır. Swift diliyle geliştirilen bu araç, verileri yerel olarak işleyerek gizlilik odaklı bir ses dönüştürme deneyimi sunar.</p>
 <ul class="disc-meta"><li>★ 9.360</li><li>Swift</li><li>GitHub Trending · 2026-06-29</li></ul>

--- a/discover/flutter/index.html
+++ b/discover/flutter/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Flutter</span><span class="disc-momentum">🚀 +73 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Flutter</span><span class="disc-momentum">↑ +73 bugün</span></div>
 <h1 class="disc-title">Tek kodla çoklu platform uygulaması</h1>
 <p class="disc-lead">Google tarafından geliştirilen Flutter, tek bir kod tabanı kullanarak mobil, web ve masaüstü platformları için hızlı bir şekilde kullanıcı arayüzü (user interface) oluşturulmasına olanak tanıyor. Dart programlama dilini temel alan bu açık kaynaklı çerçeve (framework), yüksek performanslı ve görsel açıdan zengin uygulamalar geliştirmek için yaygın olarak tercih ediliyor.</p>
 <ul class="disc-meta"><li>★ 178.068</li><li>Dart</li><li>GitHub Trending · 2026-06-25</li></ul>

--- a/discover/folia-major/index.html
+++ b/discover/folia-major/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Folia Major</span><span class="disc-momentum">🚀 +175 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Folia Major</span><span class="disc-momentum">↑ +175 bugün</span></div>
 <h1 class="disc-title">Müzik deneyimini görselleştiren şarkı oynatıcı</h1>
 <p class="disc-lead">Folia-major, yerel müzik dosyaları ve çevrimiçi platformlar için görselleştirilmiş şarkı sözü animasyonları sunan bir oynatıcı arayüzüdür. TypeScript ile geliştirilen bu araç, müzik dinleme deneyimini dinamik görsel efektlerle zenginleştirmeyi amaçlar.</p>
 <ul class="disc-meta"><li>★ 1.640</li><li>TypeScript</li><li>GitHub Trending · 2026-07-05</li></ul>

--- a/discover/fprime/index.html
+++ b/discover/fprime/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Fprime</span><span class="disc-momentum">🚀 +22 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Fprime</span><span class="disc-momentum">↑ +22 bugün</span></div>
 <h1 class="disc-title">NASA uçuş yazılımları geliştirme çerçevesi</h1>
 <p class="disc-lead">NASA tarafından geliştirilen F´, uçuş yazılımları ve gömülü sistemler (embedded systems) için tasarlanmış açık kaynaklı bir çerçevedir (framework). C++ diliyle yazılan bu yapı, uzay araçları ve karmaşık sistemler için modüler bir geliştirme ortamı sunar.</p>
 <ul class="disc-meta"><li>★ 11.610</li><li>C++</li><li>GitHub Trending · 2026-07-12</li></ul>

--- a/discover/free-claude-code/index.html
+++ b/discover/free-claude-code/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Free Claude Code</span><span class="disc-momentum">🚀 +278 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Free Claude Code</span><span class="disc-momentum">↑ +278 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanlarına ücretsiz erişim</h1>
 <p class="disc-lead">Alishahryar1 tarafından geliştirilen free-claude-code, Claude Code ve Codex gibi yapay zekâ modellerine terminal, uygulama veya geliştirme ortamı (IDE) üzerinden ücretsiz erişim sağlıyor. Bu açık kaynaklı araç, OpenClaw gibi sesli komut desteği sunan platformlarla entegre çalışarak kullanıcıların yapay zekâ yeteneklerini farklı cihazlarda kullanmasına imkân tanıyor.</p>
 <ul class="disc-meta"><li>★ 44.150</li><li>Python</li><li>GitHub Trending · 2026-08-04</li></ul>

--- a/discover/free-domain/index.html
+++ b/discover/free-domain/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · FreeDomain</span><span class="disc-momentum">🚀 Bir günde +1.127 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · FreeDomain</span><span class="disc-momentum">↑ Bir günde +1.127 yıldız</span></div>
       <h1 class="disc-title">Ücretsiz Alan Adı Alın</h1>
       <p class="disc-lead"><strong>FreeDomain</strong>, herkesin dijital bir kimliğe sahip olabilmesi için <strong>ücretsiz alan adı</strong> hizmeti sunar. Benzersiz bir adres kaydedebilir ve Cloudflare gibi dilediğiniz DNS sağlayıcısıyla yönetebilirsiniz. Web'de var olmanın maliyetini sıfıra indirin.</p>
       <ul class="disc-meta"><li>★ 190.061</li><li>HTML</li><li>AGPL-3.0</li><li>GitHub Trending · 26 May 2026</li></ul>

--- a/discover/free-for-dev/index.html
+++ b/discover/free-for-dev/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Free for Dev</span><span class="disc-momentum">🚀 +90 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Free for Dev</span><span class="disc-momentum">↑ +90 bugün</span></div>
 <h1 class="disc-title">Ücretsiz geliştirici araçları kaynak listesi</h1>
 <p class="disc-lead">Free-for-dev, yazılım geliştirme süreçlerinde kullanılan hizmet olarak yazılım (SaaS), hizmet olarak platform (PaaS) ve hizmet olarak altyapı (IaaS) çözümlerinin ücretsiz katmanlarını bir araya getiren bir kaynak listesidir. Geliştiricilerin ve altyapı mühendislerinin maliyetsiz araçlara erişimini kolaylaştırmayı amaçlar.</p>
 <ul class="disc-meta"><li>★ 131.012</li><li>HTML</li><li>GitHub Trending · 2026-06-27</li></ul>

--- a/discover/free-stockdb/index.html
+++ b/discover/free-stockdb/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Free Stockdb</span><span class="disc-momentum">🚀 +50 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Free Stockdb</span><span class="disc-momentum">↑ +50 bugün</span></div>
 <h1 class="disc-title">Yerel borsa verisi ve analiz motoru</h1>
 <p class="disc-lead">Free-stockdb, A hisse senetleri ve borsa yatırım fonları (ETF) için günlük ve dakikalık verileri yöneten yerel bir nicel analiz motorudur. Sistem, verilerin artımlı senkronizasyonu, yerel önbellekleme, fiyat düzeltme, geriye dönük test (backtesting) ve teknik gösterge hesaplamaları gibi işlevleri bir arada sunar.</p>
 <ul class="disc-meta"><li>★ 1.684</li><li>HTML</li><li>GitHub Trending · 2026-07-29</li></ul>

--- a/discover/freecodecamp/index.html
+++ b/discover/freecodecamp/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · freeCodeCamp</span><span class="disc-momentum">🚀 +253 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · freeCodeCamp</span><span class="disc-momentum">↑ +253 bugün</span></div>
 <h1 class="disc-title">Yazılım dünyasına ücretsiz adım atın</h1>
 <p class="disc-lead">freeCodeCamp, matematik, programlama ve bilgisayar bilimi konularında ücretsiz eğitim materyalleri sunan açık kaynaklı bir öğrenme platformudur. TypeScript diliyle geliştirilen bu proje, kullanıcıların yazılım geliştirme becerilerini uygulamalı müfredat üzerinden edinmelerini sağlar.</p>
 <ul class="disc-meta"><li>★ 447.139</li><li>TypeScript</li><li>GitHub Trending · 2026-06-15</li></ul>

--- a/discover/g0dm0d3/index.html
+++ b/discover/g0dm0d3/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · G0DM0D3</span><span class="disc-momentum">🚀 +69 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · G0DM0D3</span><span class="disc-momentum">↑ +69 bugün</span></div>
 <h1 class="disc-title">Kısıtlamasız yapay zekâ etkileşim arayüzü</h1>
 <p class="disc-lead">G0DM0D3, büyük dil modellerinin (large language models) güvenlik katmanlarını aşmayı hedefleyen özgürleştirilmiş bir yapay zekâ sohbet arayüzüdür. TypeScript ile geliştirilen bu açık kaynaklı proje, kullanıcıların kısıtlamalara takılmadan modellerle etkileşime girmesini sağlar.</p>
 <ul class="disc-meta"><li>★ 9.570</li><li>TypeScript</li><li>GitHub Trending · 2026-07-19</li></ul>

--- a/discover/gastown/index.html
+++ b/discover/gastown/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Gastown</span><span class="disc-momentum">🚀 +51 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Gastown</span><span class="disc-momentum">↑ +51 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları için çalışma alanı yönetimi</h1>
 <p class="disc-lead">Gas Town, çoklu ajan çalışma alanı yöneticisi (multi-agent workspace manager) olarak farklı yapay zekâ ajanlarının bir arada çalışmasını sağlayan bir altyapı sunuyor. Go diliyle geliştirilen bu araç, karmaşık iş akışlarında ajanlar arası koordinasyonu ve kaynak yönetimini merkezileştiriyor.</p>
 <ul class="disc-meta"><li>★ 17.403</li><li>Go</li><li>GitHub Trending · 2026-07-06</li></ul>

--- a/discover/generative-ai-for-beginners/index.html
+++ b/discover/generative-ai-for-beginners/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Generative AI for Beginners</span><span class="disc-momentum">🚀 +108 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Generative AI for Beginners</span><span class="disc-momentum">↑ +108 bugün</span></div>
 <h1 class="disc-title">Üretken yapay zekâ uygulamaları geliştirme eğitimi</h1>
 <p class="disc-lead">Microsoft tarafından hazırlanan bu eğitim içeriği, üretken yapay zekâ (generative AI) teknolojilerine giriş yapmak isteyenler için 21 derslik bir müfredat sunuyor. Jupyter Notebook formatındaki bu kaynak, geliştiricilerin kendi projelerini oluşturmaları için temel kavramları ve uygulama yöntemlerini öğretiyor.</p>
 <ul class="disc-meta"><li>★ 114.349</li><li>Jupyter Notebook</li><li>GitHub Trending · 2026-08-02</li></ul>

--- a/discover/geolibre/index.html
+++ b/discover/geolibre/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · GeoLibre</span><span class="disc-momentum">🚀 +420 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · GeoLibre</span><span class="disc-momentum">↑ +420 bugün</span></div>
 <h1 class="disc-title">Bulut tabanlı açık kaynaklı haritalama</h1>
 <p class="disc-lead">GeoLibre, coğrafi verileri görselleştirmek, keşfetmek ve analiz etmek için tasarlanmış hafif, bulut tabanlı bir coğrafi bilgi sistemi (GIS) platformudur. TypeScript ile geliştirilen bu araç, web tarayıcıları, masaüstü, mobil cihazlar ve Jupyter not defterleri (Jupyter notebooks) üzerinde çalışabilmektedir.</p>
 <ul class="disc-meta"><li>★ 5.470</li><li>TypeScript</li><li>GitHub Trending · 2026-07-28</li></ul>

--- a/discover/gh-stack/index.html
+++ b/discover/gh-stack/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Gh Stack</span><span class="disc-momentum">🚀 +46 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Gh Stack</span><span class="disc-momentum">↑ +46 bugün</span></div>
 <h1 class="disc-title">Yığınlı çekme isteklerini yönetin</h1>
 <p class="disc-lead">GitHub tarafından geliştirilen gh-stack, yazılım geliştirme sürecinde yığınlı çekme istekleri (stacked pull requests) oluşturmayı ve yönetmeyi kolaylaştıran bir komut satırı aracıdır. Karmaşık kod değişikliklerini küçük ve bağımsız parçalara bölerek inceleme sürecini hızlandırmayı hedefler.</p>
 <ul class="disc-meta"><li>★ 911</li><li>Go</li><li>GitHub Trending · 2026-08-02</li></ul>

--- a/discover/github-docs/index.html
+++ b/discover/github-docs/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · GitHub Docs</span><span class="disc-momentum">🚀 Bir günde +27 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · GitHub Docs</span><span class="disc-momentum">↑ Bir günde +27 yıldız</span></div>
       <h1 class="disc-title">GitHub dokümantasyonuna katkıda bulunun</h1>
       <p class="disc-lead"><strong>GitHub Docs</strong>, docs.github.com adresindeki belgelerin kaynak kodlarını içeren açık kaynak deposudur. GitHub'ın resmi belgelerine katkıda bulunabilir ve içeriklerin nasıl hazırlandığını inceleyebilirsiniz.</p>
       <ul class="disc-meta"><li>★ 20.600</li><li>TypeScript</li><li>CC-BY-4.0</li><li>GitHub Trending · 1 Haziran 2026</li></ul>

--- a/discover/goose/index.html
+++ b/discover/goose/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Goose</span><span class="disc-momentum">🚀 +322 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Goose</span><span class="disc-momentum">↑ +322 bugün</span></div>
 <h1 class="disc-title">Yazılım süreçlerini yapay zekâ ile yönetinşa otomatize edin</h1>
 <p class="disc-lead">Goose, kod önerilerinin ötesine geçerek yazılım kurulumu, yürütme, düzenleme ve test süreçlerini otomatize eden açık kaynaklı bir yapay zekâ ajanıdır. Rust diliyle geliştirilen bu araç, farklı büyük dil modelleriyle (LLM) entegre çalışarak yazılım geliştirme iş akışlarını uçtan uca yönetmeyi hedefler.</p>
 <ul class="disc-meta"><li>★ 52.110</li><li>Rust</li><li>GitHub Trending · 2026-06-08</li></ul>

--- a/discover/grafana/index.html
+++ b/discover/grafana/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Grafana</span><span class="disc-momentum">🚀 +32 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Grafana</span><span class="disc-momentum">↑ +32 bugün</span></div>
 <h1 class="disc-title">Verilerinizi tek arayüzde görselleştirin</h1>
 <p class="disc-lead">Grafana, farklı veri kaynaklarından gelen metrikleri, günlükleri (logs) ve izleme verilerini (traces) tek bir arayüzde birleştiren açık kaynaklı bir gözlemlenebilirlik ve veri görselleştirme platformudur. Prometheus, Elasticsearch ve PostgreSQL gibi birçok sistemle entegre çalışarak karmaşık veri setlerinin analiz edilmesini sağlar.</p>
 <ul class="disc-meta"><li>★ 76.114</li><li>TypeScript</li><li>GitHub Trending · 2026-06-27</li></ul>

--- a/discover/graphify/index.html
+++ b/discover/graphify/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Graphify</span><span class="disc-momentum">🚀 +1.095 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Graphify</span><span class="disc-momentum">↑ +1.095 bugün</span></div>
 <h1 class="disc-title">Projelerinizi yapay zekâ için bilgi çizgesine dönüştürün</h1>
 <p class="disc-lead">Graphify, kod dosyaları, veritabanı şemaları ve dokümantasyon gibi farklı veri türlerini sorgulanabilir bir bilgi çizgesi (knowledge graph) yapısına dönüştürüyor. Python tabanlı bu araç, çeşitli yapay zekâ kod yardımcıları (AI coding assistants) için merkezi bir veri katmanı oluşturmayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 103.155</li><li>Python</li><li>GitHub Trending · 2026-07-14</li></ul>

--- a/discover/grok2api/index.html
+++ b/discover/grok2api/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Grok2api</span><span class="disc-momentum">🚀 +186 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Grok2api</span><span class="disc-momentum">↑ +186 bugün</span></div>
 <h1 class="disc-title">Grok servisleri için merkezi yönetim</h1>
 <p class="disc-lead">Grok Build, Grok Web ve Grok Console platformları için geliştirilen bu ağ geçidi (API gateway), çoklu hesap yönetimini tek bir merkezde topluyor. Go diliyle yazılan araç, kullanıcıların farklı Grok servislerine erişimini standartlaştırarak yönetilebilir bir arayüz sunuyor.</p>
 <ul class="disc-meta"><li>★ 7.022</li><li>Go</li><li>GitHub Trending · 2026-07-15</li></ul>

--- a/discover/grpc/index.html
+++ b/discover/grpc/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Grpc</span><span class="disc-momentum">🚀 +78 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Grpc</span><span class="disc-momentum">↑ +78 bugün</span></div>
 <h1 class="disc-title">Farklı diller arası hızlı iletişim</h1>
 <p class="disc-lead">gRPC, farklı programlama dilleri arasında yüksek performanslı iletişim sağlayan açık kaynaklı bir uzaktan yordam çağrısı (remote procedure call) çerçevesidir. C++ tabanlı altyapısı sayesinde Python, Ruby, C# ve PHP gibi diller için ölçeklenebilir ağ hizmetleri geliştirilmesine olanak tanır.</p>
 <ul class="disc-meta"><li>★ 45.240</li><li>C++</li><li>GitHub Trending · 2026-07-11</li></ul>

--- a/discover/gstack/index.html
+++ b/discover/gstack/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Gstack</span><span class="disc-momentum">🚀 +573 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Gstack</span><span class="disc-momentum">↑ +573 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile yazılım geliştirme fabrikası</h1>
 <p class="disc-lead">Gstack, Garry Tan&#x27;ın Claude Code yapılandırmasını temel alan ve CEO, tasarımcı, mühendislik yöneticisi gibi farklı roller üstlenen 23 özelleşmiş araçtan oluşan bir sistemdir. Bu TypeScript tabanlı yapı, yazılım geliştirme süreçlerini otomatize etmek için tanımlanmış iş akışları (workflows) sunar.</p>
 <ul class="disc-meta"><li>★ 125.874</li><li>TypeScript</li><li>GitHub Trending · 2026-06-23</li></ul>

--- a/discover/hallmark/index.html
+++ b/discover/hallmark/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hallmark</span><span class="disc-momentum">🚀 +155 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hallmark</span><span class="disc-momentum">↑ +155 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ tasarımlarına özgünlük kazandırın</h1>
 <p class="disc-lead">Hallmark, yapay zekâ tarafından üretilen standart içeriklerin (AI slop) tasarım üzerindeki etkisini azaltmak amacıyla geliştirilen bir stil dosyasıdır. Claude Code, Cursor ve Codex gibi araçlarda kullanılan arayüzlerin özgün ve insani bir estetik kazanmasını sağlar.</p>
 <ul class="disc-meta"><li>★ 22.106</li><li>CSS</li><li>GitHub Trending · 2026-07-13</li></ul>

--- a/discover/harness/index.html
+++ b/discover/harness/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Harness · Ajan Ekip Fabrikası</span><span class="disc-momentum">🚀 Bir günde +65 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Harness · Ajan Ekip Fabrikası</span><span class="disc-momentum">↑ Bir günde +65 yıldız</span></div>
       <h1 class="disc-title">Claude Code için uzman ajanlar tasarlayın</h1>
       <p class="disc-lead"><strong>Harness</strong>, Claude Code'un ajan ekip sistemini kullanarak karmaşık görevleri <strong>uzmanlaşmış ajanlardan oluşan koordineli ekiplere</strong> böler. 'Şunun için bir harness kur' komutuyla, gereken ekibi ve becerileri sizin için tasarlar.</p>
       <figure class="disc-shot"><img src="/assets/discover/harness.webp" width="1440" height="804" loading="lazy" decoding="async" alt="Harness · Ajan Ekip Fabrikası arayüzünden bir görünüm"><figcaption>Görsel: harness (proje deposundan)</figcaption></figure>

--- a/discover/harper/index.html
+++ b/discover/harper/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Harper</span><span class="disc-momentum">🚀 +624 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Harper</span><span class="disc-momentum">↑ +624 bugün</span></div>
 <h1 class="disc-title">Gizlilik odaklı çevrim dışı dil bilgisi denetleyicisi</h1>
 <p class="disc-lead">Harper, Rust diliyle geliştirilen çevrim dışı ve gizlilik odaklı bir dil bilgisi denetleyicisi (grammar checker) sunuyor. Açık kaynaklı bu araç, metin analizi süreçlerinde yüksek performanslı ve güvenli bir alternatif oluşturmayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 14.110</li><li>Rust</li><li>GitHub Trending · 2026-07-24</li></ul>

--- a/discover/headunit-revived/index.html
+++ b/discover/headunit-revived/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Headunit Revived</span><span class="disc-momentum">🚀 +41 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Headunit Revived</span><span class="disc-momentum">↑ +41 bugün</span></div>
 <h1 class="disc-title">Tabletinizi Android Auto ekranına dönüştürün</h1>
 <p class="disc-lead">Headunit-revived projesi, Android Auto arayüzünü farklı ekranlarda görüntülemeyi sağlayan bir uygulama sunuyor. Kotlin diliyle geliştirilen bu yazılım, araç içi bilgi-eğlence sistemleri (infotainment systems) için alternatif bir görüntüleme çözümü sağlıyor.</p>
 <ul class="disc-meta"><li>★ 1.484</li><li>Kotlin</li><li>GitHub Trending · 2026-06-25</li></ul>

--- a/discover/hello-algo/index.html
+++ b/discover/hello-algo/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hello Algo</span><span class="disc-momentum">🚀 +71 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hello Algo</span><span class="disc-momentum">↑ +71 bugün</span></div>
 <h1 class="disc-title">Animasyonlarla veri yapıları ve algoritmalar</h1>
 <p class="disc-lead">Hello 算法, veri yapıları ve algoritmaları animasyonlu görselleştirmelerle destekleyerek öğreten açık kaynaklı bir eğitim platformudur. Proje, çok sayıda programlama dili desteği ve tek tıkla çalıştırılabilir kod örnekleri sunarak öğrenme sürecini standartlaştırıyor.</p>
 <ul class="disc-meta"><li>★ 129.072</li><li>Java</li><li>GitHub Trending · 2026-06-16</li></ul>

--- a/discover/herdr/index.html
+++ b/discover/herdr/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Herdr</span><span class="disc-momentum">🚀 +486 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Herdr</span><span class="disc-momentum">↑ +486 bugün</span></div>
 <h1 class="disc-title">Terminalde çoklu yapay zekâ yönetimi</h1>
 <p class="disc-lead">Rust diliyle geliştirilen herdr, uçbirim (terminal) üzerinde çalışan bir ajan çoklayıcı (agent multiplexer) olarak görev yapıyor. Bu araç, kullanıcıların terminal ortamında birden fazla yapay zekâ ajanını eş zamanlı yönetmesine olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 9.203</li><li>Rust</li><li>GitHub Trending · 2026-07-01</li></ul>

--- a/discover/heretic/index.html
+++ b/discover/heretic/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Heretic</span><span class="disc-momentum">🚀 Bir günde +211 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Heretic</span><span class="disc-momentum">↑ Bir günde +211 yıldız</span></div>
       <h1 class="disc-title">Dil Modellerinde Güvenlik Sınırlarını Aşın</h1>
       <p class="disc-lead"><strong>Heretic</strong>, transformer tabanlı dil modellerinden <strong>güvenlik hizalaması (safety alignment)</strong> kısıtlarını, pahalı yeniden eğitim süreçlerine gerek kalmadan kaldıran teknik bir araçtır. 'Abliteration' tekniğini kullanan bu çözüm, ileri düzey ve araştırma odaklı bir yapıdadır.</p>
       <ul class="disc-meta"><li>★ 27.018</li><li>Python</li><li>AGPL-3.0</li><li>GitHub Trending · 28 May 2026</li></ul>

--- a/discover/hermes-agent/index.html
+++ b/discover/hermes-agent/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hermes Agent</span><span class="disc-momentum">🚀 +1.735 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hermes Agent</span><span class="disc-momentum">↑ +1.735 bugün</span></div>
 <h1 class="disc-title">Kullanıcı Etkileşimleriyle Gelişen yapay zekâ</h1>
 <p class="disc-lead">NousResearch tarafından geliştirilen Hermes Agent, kullanıcı etkileşimleriyle öğrenerek zaman içinde gelişen bir otonom ajan (autonomous agent) altyapısı sunuyor. Python tabanlı bu sistem, kişiselleştirilmiş iş akışları oluşturmak için sürekli öğrenen bir yapı (continuous learning) kullanıyor.</p>
 <ul class="disc-meta"><li>★ 225.045</li><li>Python</li><li>GitHub Trending · 2026-06-04</li></ul>

--- a/discover/hermes-webui/index.html
+++ b/discover/hermes-webui/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hermes WebUI</span><span class="disc-momentum">🚀 Bir günde +357 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hermes WebUI</span><span class="disc-momentum">↑ Bir günde +357 yıldız</span></div>
       <h1 class="disc-title">Yapay zekâ ajanlarınızı webden yönetin</h1>
       <p class="disc-lead"><strong>Hermes WebUI</strong>, Hermes AI ajanlarını <strong>web tarayıcısı veya mobil cihazlar</strong> üzerinden yönetmenizi sağlayan bir arayüzdür. Ajan etkileşimlerini tek bir merkezden takip edip kontrol etmenize olanak tanır.</p>
       <figure class="disc-shot"><img src="/assets/discover/hermes-webui.webp" width="1440" height="1028" loading="lazy" decoding="async" alt="Hermes WebUI arayüzünden bir görünüm"><figcaption>Görsel: Hermes WebUI (proje deposundan)</figcaption></figure>

--- a/discover/hiring-agent/index.html
+++ b/discover/hiring-agent/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hiring Agent</span><span class="disc-momentum">🚀 +203 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hiring Agent</span><span class="disc-momentum">↑ +203 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile özgeçmiş değerlendirme</h1>
 <p class="disc-lead">Hiring-agent, özgeçmişleri değerlendirmek ve puanlamak için tasarlanmış bir yapay zekâ ajanıdır (AI agent). Python diliyle geliştirilen bu araç, işe alım süreçlerinde aday tarama işlemlerini otomatize etmeyi amaçlar.</p>
 <ul class="disc-meta"><li>★ 6.694</li><li>Python</li><li>GitHub Trending · 2026-06-25</li></ul>

--- a/discover/hivemind/index.html
+++ b/discover/hivemind/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hivemind</span><span class="disc-momentum">🚀 +64 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hivemind</span><span class="disc-momentum">↑ +64 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları için merkezi bellek</h1>
 <p class="disc-lead">Activeloop tarafından geliştirilen Hivemind, tüm yapay zekâ ajanları için merkezi bir bellek ve koordinasyon katmanı (centralized memory layer) sunuyor. TypeScript tabanlı bu yapı, farklı ajanların verileri paylaşmasını ve ortak bir zekâ havuzu üzerinden iletişim kurmasını sağlıyor.</p>
 <ul class="disc-meta"><li>★ 1.526</li><li>TypeScript</li><li>GitHub Trending · 2026-06-11</li></ul>

--- a/discover/how-to-secure-a-linux-server/index.html
+++ b/discover/how-to-secure-a-linux-server/index.html
@@ -58,7 +58,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · How-To-Secure-A-Linux-Server</span><span class="disc-momentum">🚀 +243 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · How-To-Secure-A-Linux-Server</span><span class="disc-momentum">↑ +243 bugün</span></div>
 <h1 class="disc-title">Linux sunucunuzu güvenli hale getirin</h1>
 <p class="disc-lead">Linux sunucu güvenliği (Linux server security) üzerine hazırlanan bu rehber, sistemleri dış tehditlere karşı korumak için izlenmesi gereken temel yapılandırma adımlarını bir araya getiriyor. Sürekli güncellenen içerik, sunucu sıkılaştırma (server hardening) süreçlerinde uygulanabilecek en iyi yöntemleri pratik bir kılavuz olarak sunuyor.</p>
 <ul class="disc-meta"><li>★ 29.237</li><li>GitHub Trending · 2026-07-10</li></ul>

--- a/discover/hyperframes/index.html
+++ b/discover/hyperframes/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hyperframes</span><span class="disc-momentum">🚀 +395 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hyperframes</span><span class="disc-momentum">↑ +395 bugün</span></div>
 <h1 class="disc-title">HTML kodlarını videoya dönüştürün</h1>
 <p class="disc-lead">Heygen tarafından geliştirilen Hyperframes, HTML kodlarını doğrudan videoya dönüştüren bir çerçeve (framework) sunuyor. Yapay zekâ ajanlarının görsel içerik üretmesini kolaylaştırmak amacıyla tasarlanan bu araç, web tabanlı arayüzleri video formatına çeviriyor.</p>
 <ul class="disc-meta"><li>★ 39.666</li><li>TypeScript</li><li>GitHub Trending · 2026-06-23</li></ul>

--- a/discover/hyprland/index.html
+++ b/discover/hyprland/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hyprland</span><span class="disc-momentum">🚀 +58 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Hyprland</span><span class="disc-momentum">↑ +58 bugün</span></div>
 <h1 class="disc-title">Wayland üzerinde özelleştirilebilir masaüstü deneyimi</h1>
 <p class="disc-lead">Hyprland, Wayland görüntü sunucusu (compositor) üzerinde çalışan ve özelleştirilebilir dinamik döşeme (tiling) yapısı sunan bir pencere yöneticisidir. C++ ile geliştirilen bu araç, görsel estetikten ödün vermeden yüksek performanslı bir masaüstü deneyimi sağlar.</p>
 <ul class="disc-meta"><li>★ 37.732</li><li>C++</li><li>GitHub Trending · 2026-07-22</li></ul>

--- a/discover/i-have-adhd/index.html
+++ b/discover/i-have-adhd/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · I Have Adhd</span><span class="disc-momentum">🚀 +1.866 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · I Have Adhd</span><span class="disc-momentum">↑ +1.866 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ yanıtlarını odaklı hale getirin</h1>
 <p class="disc-lead">Kodlama ajanlarının çıktılarını daha odaklı ve düzenli hale getirmek için geliştirilen i-have-adhd, karmaşık yanıtları parçalara bölerek kullanıcı deneyimini iyileştiriyor. Bu Python tabanlı yetenek (skill), yapay zekânın bilgi sunumunu dikkat eksikliği ve hiperaktivite bozukluğu (ADHD) dostu bir formatta standartlaştırıyor.</p>
 <ul class="disc-meta"><li>★ 17.370</li><li>Python</li><li>GitHub Trending · 2026-07-22</li></ul>

--- a/discover/iii/index.html
+++ b/discover/iii/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · iii</span><span class="disc-momentum">🚀 Bir günde +376 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · iii</span><span class="disc-momentum">↑ Bir günde +376 yıldız</span></div>
       <h1 class="disc-title">Servislerinizi Gerçek Zamanlı Yönetin</h1>
       <p class="disc-lead"><strong>iii</strong>, backend yığınınızdaki tüm servisleri (kuyruk, cron, HTTP, state, gözlemlenebilirlik, ajanlar, sandbox) <strong>gerçek zamanlı oluşturma, genişletme ve izleme</strong> yöntemidir. Normalde ayrı entegrasyon zorlukları çıkaran parçaları tek bir noktadan yönetilebilir kılar.</p>
       <ul class="disc-meta"><li>★ 18.547</li><li>Rust</li><li>Lisans: yok</li><li>GitHub Trending · 28 May 2026</li></ul>

--- a/discover/imgui/index.html
+++ b/discover/imgui/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Imgui</span><span class="disc-momentum">🚀 +51 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Imgui</span><span class="disc-momentum">↑ +51 bugün</span></div>
 <h1 class="disc-title">C++ projeleri için hafif arayüz</h1>
 <p class="disc-lead">Dear ImGui, C++ projeleri için minimum bağımlılıkla çalışan, hafif bir grafik kullanıcı arayüzü (graphical user interface) kütüphanesidir. Yazılım geliştiricilere hızlı prototipleme ve araç geliştirme süreçlerinde sade bir arayüz oluşturma imkânı tanır.</p>
 <ul class="disc-meta"><li>★ 75.457</li><li>C++</li><li>GitHub Trending · 2026-07-28</li></ul>

--- a/discover/immich/index.html
+++ b/discover/immich/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Immich</span><span class="disc-momentum">🚀 +201 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Immich</span><span class="disc-momentum">↑ +201 bugün</span></div>
 <h1 class="disc-title">Kendi fotoğraf ve video arşivinizi yönetin</h1>
 <p class="disc-lead">Immich, fotoğraf ve video dosyalarını yönetmek için geliştirilmiş, yüksek performanslı bir öz sunuculu (self-hosted) medya yönetim çözümüdür. TypeScript ile yazılan bu platform, kullanıcılara kendi altyapıları üzerinde merkezi bir medya arşivi oluşturma imkânı tanır.</p>
 <ul class="disc-meta"><li>★ 109.538</li><li>TypeScript</li><li>GitHub Trending · 2026-07-05</li></ul>

--- a/discover/insomnia/index.html
+++ b/discover/insomnia/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Insomnia</span><span class="disc-momentum">🚀 +18 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Insomnia</span><span class="disc-momentum">↑ +18 bugün</span></div>
 <h1 class="disc-title">Modern API isteklerini kolayca yönetin</h1>
 <p class="disc-lead">Insomnia, GraphQL, REST, WebSockets, SSE ve gRPC protokollerini destekleyen açık kaynaklı bir uygulama programlama arayüzü (API) istemcisidir. Yazılım, bulut tabanlı, yerel ve Git üzerinden depolama seçenekleriyle çapraz platform desteği sunar.</p>
 <ul class="disc-meta"><li>★ 39.916</li><li>TypeScript</li><li>GitHub Trending · 2026-06-19</li></ul>

--- a/discover/instatic/index.html
+++ b/discover/instatic/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Instatic</span><span class="disc-momentum">🚀 +351 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Instatic</span><span class="disc-momentum">↑ +351 bugün</span></div>
 <h1 class="disc-title">Kendi sunucunuzda modern görsel CMS</h1>
 <p class="disc-lead">Instatic, TypeScript tabanlı, kendi kendine barındırılan (self-hosted) modern bir görsel içerik yönetim sistemi (CMS) olarak sunuluyor. Kullanıcıların hızlı kurulum süreciyle içerik yönetimi arayüzünü kendi sunucularında çalıştırmasına olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 7.250</li><li>TypeScript</li><li>GitHub Trending · 2026-07-01</li></ul>

--- a/discover/introduction-to-autonomous-robots/index.html
+++ b/discover/introduction-to-autonomous-robots/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Introduction-to-Autonomous-Robots</span><span class="disc-momentum">🚀 +276 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Introduction-to-Autonomous-Robots</span><span class="disc-momentum">↑ +276 bugün</span></div>
 <h1 class="disc-title">Otonom Robotik Dünyasına Giriş Yapın</h1>
 <p class="disc-lead">Otonom robotlara giriş (Introduction to Autonomous Robots) projesi, robotik sistemlerin temel prensiplerini ve algoritmik yapılarını akademik bir yaklaşımla sunuyor. TeX dilinde hazırlanan bu kaynak, otonom hareket ve sistem tasarımı konularında teknik bir rehberlik sağlıyor.</p>
 <ul class="disc-meta"><li>★ 3.301</li><li>TeX</li><li>GitHub Trending · 2026-06-15</li></ul>

--- a/discover/invidious/index.html
+++ b/discover/invidious/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Invidious</span><span class="disc-momentum">🚀 +435 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Invidious</span><span class="disc-momentum">↑ +435 bugün</span></div>
 <h1 class="disc-title">Reklamsız ve takipsiz video izleme</h1>
 <p class="disc-lead">Invidious, YouTube platformuna alternatif olarak geliştirilen açık kaynaklı bir arayüzdür. Kullanıcılara reklam içermeyen ve veri takibi yapmayan bir video izleme deneyimi sunar.</p>
 <ul class="disc-meta"><li>★ 22.400</li><li>Crystal</li><li>GitHub Trending · 2026-08-02</li></ul>

--- a/discover/iptv/index.html
+++ b/discover/iptv/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Iptv</span><span class="disc-momentum">🚀 +179 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Iptv</span><span class="disc-momentum">↑ +179 bugün</span></div>
 <h1 class="disc-title">Dünya televizyonlarını tek merkezde izleyin</h1>
 <p class="disc-lead">Dünya genelindeki halka açık televizyon kanallarını tek bir merkezde toplayan iptv-org projesi, internet protokolü üzerinden televizyon yayını (IPTV) listelerini düzenli bir veri kümesi olarak sunuyor. TypeScript ile geliştirilen bu açık kaynaklı koleksiyon, kullanıcıların farklı ülkelerdeki yayınlara erişimini standartlaştırıyor.</p>
 <ul class="disc-meta"><li>★ 134.991</li><li>TypeScript</li><li>GitHub Trending · 2026-06-13</li></ul>

--- a/discover/jcode/index.html
+++ b/discover/jcode/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Jcode</span><span class="disc-momentum">🚀 +87 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Jcode</span><span class="disc-momentum">↑ +87 bugün</span></div>
 <h1 class="disc-title">Kodlama ajanları için yüksek performanslı çerçeve</h1>
 <p class="disc-lead">Rust diliyle geliştirilen jcode, kodlama odaklı yapay zekâ ajanlarını test etmek ve değerlendirmek için bir çerçeve (harness) sunuyor. Yazılım geliştirme süreçlerinde kullanılan ajanların performansını ölçmek amacıyla standart bir altyapı sağlıyor.</p>
 <ul class="disc-meta"><li>★ 16.118</li><li>Rust</li><li>GitHub Trending · 2026-06-21</li></ul>

--- a/discover/jellium-desktop/index.html
+++ b/discover/jellium-desktop/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Jellium Desktop</span><span class="disc-momentum">🚀 +43 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Jellium Desktop</span><span class="disc-momentum">↑ +43 bugün</span></div>
 <h1 class="disc-title">Jellyfin medya kütüphanenize masaüstü erişimi</h1>
 <p class="disc-lead">Jellium-desktop, medya sunucusu Jellyfin için Rust diliyle geliştirilmiş resmi olmayan bir masaüstü istemcisidir (desktop client). Yazılım, kullanıcıların medya kütüphanelerine doğrudan işletim sistemi üzerinden erişmelerini sağlayan yerel bir arayüz sunar.</p>
 <ul class="disc-meta"><li>★ 1.342</li><li>Rust</li><li>GitHub Trending · 2026-07-20</li></ul>

--- a/discover/jellyfin/index.html
+++ b/discover/jellyfin/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Jellyfin</span><span class="disc-momentum">🚀 ★ 52.316 · olgun ve aktif</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Jellyfin</span><span class="disc-momentum">↑ ★ 52.316 · olgun ve aktif</span></div>
       <h1 class="disc-title">Kendi Medya Sunucunuzu Kurun</h1>
       <p class="disc-lead"><strong>Jellyfin</strong>, kendi film, dizi ve müzik koleksiyonunuzu yönetip <strong>tüm cihazlarınıza yayınlamanızı</strong> sağlayan özgür bir medya sunucusudur. Plex ve Emby'ye alternatif olan bu platformda premium kilitler, reklamlar veya gizli ücretler bulunmaz.</p>
       <ul class="disc-meta"><li>★ 55.268</li><li>C#</li><li>GPL-2.0</li><li>GitHub Trending · 26 May 2026</li></ul>

--- a/discover/jenkins/index.html
+++ b/discover/jenkins/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Jenkins</span><span class="disc-momentum">🚀 +18 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Jenkins</span><span class="disc-momentum">↑ +18 bugün</span></div>
 <h1 class="disc-title">Yazılım süreçlerini otomatize eden sunucu</h1>
 <p class="disc-lead">Jenkins, yazılım geliştirme süreçlerini otomatize eden açık kaynaklı bir sürekli entegrasyon (continuous integration) ve sürekli dağıtım (continuous delivery) sunucusudur. Java tabanlı bu platform, yazılım projelerinin derleme, test ve dağıtım aşamalarını yönetmek için geniş bir eklenti ekosistemi sunar.</p>
 <ul class="disc-meta"><li>★ 26.422</li><li>Java</li><li>GitHub Trending · 2026-07-27</li></ul>

--- a/discover/k-skill/index.html
+++ b/discover/k-skill/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · K Skill</span><span class="disc-momentum">🚀 +53 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · K Skill</span><span class="disc-momentum">↑ +53 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanınıza yerel yetenekler kazandırın</h1>
 <p class="disc-lead">NomaDamas/k-skill, yapay zekâ ajanlarına (AI agents) kültürel bağlamda yerel yetenekler kazandırmak için tasarlanmış bir kütüphane. Ajanların kullanıcılarla daha doğal ve kültürel kodlara uygun etkileşim kurmasını sağlayan özelleştirilmiş beceri setleri (skill sets) sunuyor.</p>
 <ul class="disc-meta"><li>★ 6.780</li><li>JavaScript</li><li>GitHub Trending · 2026-08-02</li></ul>

--- a/discover/kaneo/index.html
+++ b/discover/kaneo/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Kaneo</span><span class="disc-momentum">🚀 +194 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Kaneo</span><span class="disc-momentum">↑ +194 bugün</span></div>
 <h1 class="disc-title">Sade ve hızlı proje yönetimi</h1>
 <p class="disc-lead">Kaneo, kullanıcı odaklı bir arayüzle geliştirilen açık kaynaklı bir proje yönetimi (project management) aracıdır. TypeScript ile yazılan platform, karmaşıklıktan arındırılmış iş akışları oluşturmayı hedefler.</p>
 <ul class="disc-meta"><li>★ 7.502</li><li>TypeScript</li><li>GitHub Trending · 2026-08-01</li></ul>

--- a/discover/karakeep/index.html
+++ b/discover/karakeep/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Karakeep</span><span class="disc-momentum">🚀 +199 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Karakeep</span><span class="disc-momentum">↑ +199 bugün</span></div>
 <h1 class="disc-title">Kendi sunucunuzda dijital arşiv yönetimi</h1>
 <p class="disc-lead">Karakeep, bağlantıları, notları ve görselleri tek bir merkezde toplayan, kendi sunucunuzda barındırabileceğiniz (self-hostable) bir içerik yönetim uygulamasıdır. Yapay zekâ destekli otomatik etiketleme (automatic tagging) ve tam metin arama (full text search) özellikleri ile dijital arşivleme süreçlerini kolaylaştırır.</p>
 <ul class="disc-meta"><li>★ 28.017</li><li>TypeScript</li><li>GitHub Trending · 2026-07-07</li></ul>

--- a/discover/karukan/index.html
+++ b/discover/karukan/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Karukan</span><span class="disc-momentum">🚀 +42 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Karukan</span><span class="disc-momentum">↑ +42 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ destekli japonca giriş sistemi</h1>
 <p class="disc-lead">Rust diliyle geliştirilen Karukan, Linux ve macOS işletim sistemleri için sinirsel kana-kanji dönüştürme motoru (neural kana-kanji conversion engine) kullanan bir Japonca giriş yöntemi sistemidir (Japanese Input Method System). Yazılım, geleneksel yöntemlerin ötesine geçerek metin dönüştürme süreçlerinde yapay zekâ tabanlı bir yaklaşım sunar.</p>
 <ul class="disc-meta"><li>★ 692</li><li>Rust</li><li>GitHub Trending · 2026-07-02</li></ul>

--- a/discover/keycloak/index.html
+++ b/discover/keycloak/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Keycloak</span><span class="disc-momentum">🚀 +20 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Keycloak</span><span class="disc-momentum">↑ +20 bugün</span></div>
 <h1 class="disc-title">Uygulamalarınız için merkezi kimlik yönetimi</h1>
 <p class="disc-lead">Keycloak, modern uygulamalar ve hizmetler için açık kaynaklı kimlik ve erişim yönetimi (identity and access management) çözümleri sunuyor. Java tabanlı bu platform, merkezi kimlik doğrulama ve yetkilendirme süreçlerini standartlaştırmak için kullanılıyor.</p>
 <ul class="disc-meta"><li>★ 36.028</li><li>Java</li><li>GitHub Trending · 2026-06-28</li></ul>

--- a/discover/kilocode/index.html
+++ b/discover/kilocode/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Kilocode</span><span class="disc-momentum">🚀 +1.345 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Kilocode</span><span class="disc-momentum">↑ +1.345 bugün</span></div>
 <h1 class="disc-title">Çok yönlü yapay zekâ kodlama ajanı</h1>
 <p class="disc-lead">Kilo, yazılım geliştirme süreçlerini hızlandırmak amacıyla tasarlanmış hepsi bir arada ajan tabanlı mühendislik platformudur (agentic engineering platform). Açık kaynak kodlu yazılım geliştirme ajanı (coding agent) üzerinden uygulama oluşturma, dağıtma ve yineleme süreçlerini standartlaştırır.</p>
 <ul class="disc-meta"><li>★ 26.733</li><li>TypeScript</li><li>GitHub Trending · 2026-06-19</li></ul>

--- a/discover/kimi-cli/index.html
+++ b/discover/kimi-cli/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Kimi CLI</span><span class="disc-momentum">🚀 +65 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Kimi CLI</span><span class="disc-momentum">↑ +65 bugün</span></div>
 <h1 class="disc-title">Terminalda yapay zekâ destekli geliştirme</h1>
 <p class="disc-lead">Moonshot AI tarafından geliştirilen Kimi CLI, komut satırı arayüzü (CLI) üzerinden çalışan bir yapay zekâ ajanıdır. Python tabanlı bu araç, yazılım geliştirme süreçlerinde komut satırı etkileşimlerini otomatikleştirmek için tasarlanmıştır.</p>
 <ul class="disc-meta"><li>★ 11.074</li><li>Python</li><li>GitHub Trending · 2026-07-19</li></ul>

--- a/discover/knowledge-work-plugins/index.html
+++ b/discover/knowledge-work-plugins/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Knowledge Work Plugins</span><span class="disc-momentum">🚀 Bir günde +1.698 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Knowledge Work Plugins</span><span class="disc-momentum">↑ Bir günde +1.698 yıldız</span></div>
       <h1 class="disc-title">Claude ile Uzman Asistan Deneyimi</h1>
       <p class="disc-lead">Anthropic tarafından sunulan bu açık kaynaklı eklenti seti, her iş fonksiyonu için <strong>beceriler, bağlayıcılar, slash komutları ve alt-ajanları</strong> bir araya getirir. Claude'un o işin uzmanı gibi davranmasını sağlayan bu çözüm, <strong>Claude Cowork</strong> için tasarlanmış 11 hazır eklenti içerir.</p>
       <ul class="disc-meta"><li>★ 23.222</li><li>Python</li><li>Apache-2.0</li><li>GitHub Trending · 26 May 2026</li></ul>

--- a/discover/kronos/index.html
+++ b/discover/kronos/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Kronos</span><span class="disc-momentum">🚀 Bir günde +401 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Kronos</span><span class="disc-momentum">↑ Bir günde +401 yıldız</span></div>
       <h1 class="disc-title">Finansal Piyasaları Analiz Eden Model</h1>
       <p class="disc-lead"><strong>Kronos</strong>, finansal piyasaların kendine has örüntülerini çözümlemek için tasarlanmış bir <strong>temel modeldir (foundation model)</strong>. Piyasa verilerinin karmaşık yapısını analiz etmeye odaklanır ve kantitatif finans ile makine öğrenmesi çalışmalarında kullanılır.</p>
       <figure class="disc-shot"><img src="/assets/discover/kronos.webp" width="1440" height="1080" loading="lazy" decoding="async" alt="Kronos arayüzünden bir görünüm"><figcaption>Görsel: Kronos (proje deposundan)</figcaption></figure>

--- a/discover/ktransformers/index.html
+++ b/discover/ktransformers/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ktransformers</span><span class="disc-momentum">🚀 +360 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ktransformers</span><span class="disc-momentum">↑ +360 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ modelleri için heterojen hızlandırma</h1>
 <p class="disc-lead">Ktransformers, büyük dil modellerinin (large language models) çıkarım ve ince ayar (fine-tuning) süreçlerinde heterojen donanım optimizasyonlarını destekleyen esnek bir çerçeve sunuyor. Bu yapı, farklı donanım kaynaklarını verimli kullanarak model performansını artırmayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 19.145</li><li>Python</li><li>GitHub Trending · 2026-07-20</li></ul>

--- a/discover/langflow/index.html
+++ b/discover/langflow/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Langflow</span><span class="disc-momentum">🚀 +117 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Langflow</span><span class="disc-momentum">↑ +117 bugün</span></div>
 <h1 class="disc-title">Görsel arayüzle yapay zekâ iş akışları</h1>
 <p class="disc-lead">Langflow, yapay zekâ destekli ajanlar ve iş akışları oluşturmak için görsel bir arayüz sunan Python tabanlı bir geliştirme platformudur. Kullanıcılar, karmaşık dil modeli uygulamalarını kod yazmadan sürükle bırak yöntemiyle tasarlayıp yayına alabilir.</p>
 <ul class="disc-meta"><li>★ 152.874</li><li>Python</li><li>GitHub Trending · 2026-07-03</li></ul>

--- a/discover/last30days-skill/index.html
+++ b/discover/last30days-skill/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Last30days Skill</span><span class="disc-momentum">🚀 +199 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Last30days Skill</span><span class="disc-momentum">↑ +199 bugün</span></div>
 <h1 class="disc-title">Son 30 Günün yapay zekâ Destekli Özeti</h1>
 <p class="disc-lead">Last30days-skill, Reddit, X, YouTube, Hacker News ve Polymarket gibi platformlarda araştırma yaparak güncel verileri sentezleyen bir yapay zekâ yeteneği (AI agent skill) sunuyor. Python tabanlı bu araç, farklı kaynaklardan elde edilen bilgileri birleştirerek kullanıcılar için doğrulanabilir özetler oluşturuyor.</p>
 <ul class="disc-meta"><li>★ 56.777</li><li>Python</li><li>GitHub Trending · 2026-06-05</li></ul>

--- a/discover/lighthouse/index.html
+++ b/discover/lighthouse/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Lighthouse</span><span class="disc-momentum">🚀 +65 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Lighthouse</span><span class="disc-momentum">↑ +65 bugün</span></div>
 <h1 class="disc-title">Banjo Kazooie oyununu modern sistemlerde oynayın</h1>
 <p class="disc-lead">Lighthouse, C diliyle geliştirilmiş, düşük seviyeli sistemler için tasarlanmış bir kod kapsama (code coverage) aracıdır. Yazılımın test süreçlerinde hangi kod bloklarının çalıştırıldığını analiz ederek geliştiricilere hata ayıklama ve performans optimizasyonu konusunda veri sağlar.</p>
 <ul class="disc-meta"><li>★ 324</li><li>C</li><li>GitHub Trending · 2026-08-03</li></ul>

--- a/discover/likec4/index.html
+++ b/discover/likec4/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Likec4</span><span class="disc-momentum">🚀 +80 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Likec4</span><span class="disc-momentum">↑ +80 bugün</span></div>
 <h1 class="disc-title">Yazılım mimarinizi canlı diyagramlarla görselleştirin</h1>
 <p class="disc-lead">Likec4, yazılım mimarisini doğrudan kaynak kod üzerinden görselleştiren ve canlı diyagramlar oluşturulmasını sağlayan bir araçtır. Kod tabanıyla eş zamanlı güncellenen mimari şemalar (diagrams) aracılığıyla teknik dokümantasyonun sürekliliğini hedefler.</p>
 <ul class="disc-meta"><li>★ 5.328</li><li>TypeScript</li><li>GitHub Trending · 2026-07-23</li></ul>

--- a/discover/lingbot-map/index.html
+++ b/discover/lingbot-map/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Lingbot Map</span><span class="disc-momentum">🚀 +372 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Lingbot Map</span><span class="disc-momentum">↑ +372 bugün</span></div>
 <h1 class="disc-title">Akış verisinden üç boyutlu sahneler oluşturun</h1>
 <p class="disc-lead">Lingbot-map, akış halindeki verilerden sahneleri yeniden oluşturmak için tasarlanmış ileri beslemeli bir üç boyutlu temel modeldir (3D foundation model). Proje, Python diliyle geliştirilen mimarisi sayesinde karmaşık çevresel verileri işleyerek görselleştirme süreçlerini optimize eder.</p>
 <ul class="disc-meta"><li>★ 16.054</li><li>Python</li><li>GitHub Trending · 2026-06-29</li></ul>

--- a/discover/liteparse/index.html
+++ b/discover/liteparse/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Liteparse</span><span class="disc-momentum">🚀 Bir günde +929 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Liteparse</span><span class="disc-momentum">↑ Bir günde +929 yıldız</span></div>
       <h1 class="disc-title">Belgelerinizi Rust ile hızlıca ayrıştırın</h1>
       <p class="disc-lead"><strong>Liteparse</strong> (run-llama); belgeleri <strong>hızlı ve verimli</strong> bir şekilde ayrıştırmak için Rust ile yazılmış açık kaynak bir belge ayrıştırıcıdır. Karmaşık doküman yapılarını işlenebilir hale getirerek AI ve RAG süreçlerinde kolaylık sağlar.</p>
       <ul class="disc-meta"><li>★ 11.934</li><li>Rust</li><li>Apache-2.0</li><li>GitHub Trending · 30 May 2026</li></ul>

--- a/discover/llama-cpp/index.html
+++ b/discover/llama-cpp/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Llama.cpp</span><span class="disc-momentum">🚀 +158 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Llama.cpp</span><span class="disc-momentum">↑ +158 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ modellerini bilgisayarınızda çalıştırın</h1>
 <p class="disc-lead">Llama.cpp, büyük dil modellerinin (large language models) standart donanımlar üzerinde verimli bir şekilde çalıştırılmasını sağlayan C ve C++ tabanlı bir çıkarım (inference) kütüphanesidir. Yazılım, düşük bellek kullanımı ve yüksek performans odaklı yapısıyla yerel cihazlarda yapay zekâ modellerinin çalıştırılmasını kolaylaştırır.</p>
 <ul class="disc-meta"><li>★ 122.872</li><li>C++</li><li>GitHub Trending · 2026-06-08</li></ul>

--- a/discover/llmfit/index.html
+++ b/discover/llmfit/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Llmfit</span><span class="disc-momentum">🚀 +129 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Llmfit</span><span class="disc-momentum">↑ +129 bugün</span></div>
 <h1 class="disc-title">Donanımınıza uygun yapay zekâ modellerini bulun</h1>
 <p class="disc-lead">Rust diliyle geliştirilen llmfit, yüzlerce büyük dil modelini (large language model) ve sağlayıcıyı tarayarak donanımınızla uyumlu olanları tek bir komutla tespit etmenizi sağlıyor. Araç, yerel sistem kaynaklarına en uygun modelleri bulma sürecini otomatikleştiriyor.</p>
 <ul class="disc-meta"><li>★ 31.111</li><li>Rust</li><li>GitHub Trending · 2026-07-22</li></ul>

--- a/discover/lmcache/index.html
+++ b/discover/lmcache/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · LMCache</span><span class="disc-momentum">🚀 +28 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · LMCache</span><span class="disc-momentum">↑ +28 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ modellerinde KV önbelleği yönetimi</h1>
 <p class="disc-lead">LMCache, büyük dil modelleri (large language models) için anahtar-değer önbelleği (KV cache) yönetimini optimize ederek çıkarım hızını artıran bir katman sunuyor. Bellek kullanımını verimli hale getiren bu sistem, aynı bağlamı kullanan sorgularda hesaplama yükünü azaltmayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 11.038</li><li>Python</li><li>GitHub Trending · 2026-06-13</li></ul>

--- a/discover/lobehub/index.html
+++ b/discover/lobehub/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Lobehub</span><span class="disc-momentum">🚀 +71 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Lobehub</span><span class="disc-momentum">↑ +71 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları ile operasyon yönetimi</h1>
 <p class="disc-lead">LobeHub, yapay zekâ ajanlarını işe alma, zamanlama ve raporlama süreçleriyle yöneterek 7 gün 24 saat çalışan bir yapay zekâ ekibi operasyonu (AI team operations) oluşturmayı sağlıyor. Platform, farklı ajanları tek bir merkezden organize ederek iş akışlarını otomatize eden bir yönetici arayüzü sunuyor.</p>
 <ul class="disc-meta"><li>★ 81.117</li><li>TypeScript</li><li>GitHub Trending · 2026-07-17</li></ul>

--- a/discover/logto/index.html
+++ b/discover/logto/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Logto</span><span class="disc-momentum">🚀 +158 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Logto</span><span class="disc-momentum">↑ +158 bugün</span></div>
 <h1 class="disc-title">SaaS ve yapay zekâ uygulamaları için kimlik doğrulama</h1>
 <p class="disc-lead">Logto, SaaS ve yapay zekâ uygulamaları için Açık Kimlik Doğrulama (OIDC) ve OAuth 2.1 protokollerini temel alan bir kimlik doğrulama ve yetkilendirme altyapısı sunuyor. Çoklu kiracılık (multi-tenancy), tek oturum açma (SSO) ve rol tabanlı erişim denetimi (RBAC) gibi özellikleri TypeScript ile geliştirilmiş bir yapıda birleştiriyor.</p>
 <ul class="disc-meta"><li>★ 14.271</li><li>TypeScript</li><li>GitHub Trending · 2026-06-30</li></ul>

--- a/discover/loopx/index.html
+++ b/discover/loopx/index.html
@@ -57,7 +57,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Loopx</span><span class="disc-momentum">🚀 +326 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Loopx</span><span class="disc-momentum">↑ +326 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları için kalıcı hafıza</h1>
 <p class="disc-lead">Loopx, uzun süreli çalışan yapay zekâ ajan ekipleri için geliştirilmiş hafif bir durum çekirdeği (state kernel). Kodlama ajanları (Codex, Claude Code) ile uyumlu çalışarak görev takibi, kota yönetimi ve doğrulanabilir iş devri gibi süreçleri standartlaştırıyor.</p>
 <ul class="disc-meta"><li>★ 2.399</li><li>Python</li><li>GitHub Trending · 2026-08-06</li></ul>

--- a/discover/maigret/index.html
+++ b/discover/maigret/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Maigret</span><span class="disc-momentum">🚀 +318 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Maigret</span><span class="disc-momentum">↑ +318 bugün</span></div>
 <h1 class="disc-title">Kullanıcı adlarıyla dijital iz sürme</h1>
 <p class="disc-lead">Maigret, kullanıcı adlarını temel alarak 3000&#x27;den fazla internet sitesi üzerinde tarama yapıyor ve kişilere dair bir dosya (dossier) oluşturuyor. Python ile geliştirilen bu araç, açık kaynaklı istihbarat (OSINT) süreçlerinde dijital ayak izi takibini otomatize ediyor.</p>
 <ul class="disc-meta"><li>★ 36.075</li><li>Python</li><li>GitHub Trending · 2026-06-11</li></ul>

--- a/discover/marketingskills/index.html
+++ b/discover/marketingskills/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Marketingskills</span><span class="disc-momentum">🚀 +145 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Marketingskills</span><span class="disc-momentum">↑ +145 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanınıza pazarlama becerileri kazandırın</h1>
 <p class="disc-lead">Claude Code ve yapay zekâ ajanları için geliştirilen marketingskills kütüphanesi, dönüşüm oranı optimizasyonu (CRO), metin yazarlığı, arama motoru optimizasyonu (SEO), analitik ve büyüme mühendisliği gibi alanlarda özelleşmiş yetenekler sunuyor. Bu araç seti, yapay zekâ modellerinin pazarlama odaklı görevleri daha profesyonel ve veriye dayalı şekilde yürütmesini sağlıyor.</p>
 <ul class="disc-meta"><li>★ 42.728</li><li>JavaScript</li><li>GitHub Trending · 2026-07-06</li></ul>

--- a/discover/markitdown/index.html
+++ b/discover/markitdown/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MarkItDown</span><span class="disc-momentum">🚀 Bir günde +1.410 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MarkItDown</span><span class="disc-momentum">↑ Bir günde +1.410 yıldız</span></div>
       <h1 class="disc-title">Belgelerinizi yapay zekâya Hazırlayın</h1>
       <p class="disc-lead"><strong>MarkItDown</strong> (Microsoft); Word, PDF, PowerPoint, Excel ve daha fazlasını büyük dil modellerinin kolayca okuyabileceği <strong>temiz Markdown</strong> metnine çeviren hafif bir Python aracıdır. Belge içindeki başlıkları, listeleri ve tabloları koruyarak dönüştürür.</p>
       <ul class="disc-meta"><li>★ 170.726</li><li>Python</li><li>MIT</li><li>GitHub Trending · 29 May 2026</li></ul>

--- a/discover/masterdnsvpn/index.html
+++ b/discover/masterdnsvpn/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MasterDnsVPN</span><span class="disc-momentum">🚀 +354 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MasterDnsVPN</span><span class="disc-momentum">↑ +354 bugün</span></div>
 <h1 class="disc-title">DNS tünelleme ile sansür engellerini aşın</h1>
 <p class="disc-lead">MasterDnsVPN, sansür engellerini aşmak için geliştirilen ve düşük yükle çalışan bir alan adı sistemi tünelleme (DNS tunneling) sanal özel ağ (VPN) çözümüdür. Go diliyle yazılan araç, veri iletiminde yüksek paket kaybı kararlılığı ve çözümleyici yük dengeleme (resolver load balancing) özellikleri sunar.</p>
 <ul class="disc-meta"><li>★ 6.870</li><li>Go</li><li>GitHub Trending · 2026-06-11</li></ul>

--- a/discover/maths-cs-ai-compendium/index.html
+++ b/discover/maths-cs-ai-compendium/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Maths Cs AI Compendium</span><span class="disc-momentum">🚀 +112 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Maths Cs AI Compendium</span><span class="disc-momentum">↑ +112 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ve mühendislik için kapsamlı rehber</h1>
 <p class="disc-lead">Maths-cs-ai-compendium, yapay zekâ ve makine öğrenimi (machine learning) alanında uzmanlaşmak isteyen mühendisler için matematik, bilgisayar bilimleri ve yapay zekâ konularını kapsayan kapsamlı bir kaynak derlemesi sunuyor. Bu depo, teorik temelleri güçlendirmek ve araştırma mühendisliği becerilerini geliştirmek amacıyla yapılandırılmış bir çalışma rehberi görevi görüyor.</p>
 <ul class="disc-meta"><li>★ 7.220</li><li>TypeScript</li><li>GitHub Trending · 2026-07-15</li></ul>

--- a/discover/maven/index.html
+++ b/discover/maven/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Maven</span><span class="disc-momentum">🚀 +58 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Maven</span><span class="disc-momentum">↑ +58 bugün</span></div>
 <h1 class="disc-title">Java projeleri için proje yönetimi</h1>
 <p class="disc-lead">Apache Maven, Java tabanlı projelerde yazılım oluşturma süreçlerini yöneten bir proje yönetim ve anlama aracıdır (build automation tool). Yazılım geliştirme yaşam döngüsünü standartlaştırmak için proje nesne modeli (project object model) yapısını kullanır.</p>
 <ul class="disc-meta"><li>★ 5.292</li><li>Java</li><li>GitHub Trending · 2026-07-04</li></ul>

--- a/discover/mediacrawler/index.html
+++ b/discover/mediacrawler/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MediaCrawler</span><span class="disc-momentum">🚀 +398 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MediaCrawler</span><span class="disc-momentum">↑ +398 bugün</span></div>
 <h1 class="disc-title">Sosyal medya verilerini otomatik toplayın</h1>
 <p class="disc-lead">MediaCrawler, popüler Çin sosyal medya platformlarındaki gönderileri ve kullanıcı yorumlarını otomatik olarak veri madenciliği (web scraping) yöntemiyle topluyor. Python tabanlı bu araç, içerik analizi ve veri toplama süreçleri için geniş kapsamlı bir veri çekme (crawling) altyapısı sunuyor.</p>
 <ul class="disc-meta"><li>★ 59.631</li><li>Python</li><li>GitHub Trending · 2026-06-26</li></ul>

--- a/discover/meetily/index.html
+++ b/discover/meetily/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Meetily</span><span class="disc-momentum">🚀 +718 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Meetily</span><span class="disc-momentum">↑ +718 bugün</span></div>
 <h1 class="disc-title">Verilerinizi koruyan yerel yapay zekâ asistanı</h1>
 <p class="disc-lead">Meetily, toplantı kayıtlarını yerel olarak işleyen ve bulut bağlantısına ihtiyaç duymayan, açık kaynaklı bir toplantı asistanıdır. Rust diliyle geliştirilen uygulama, hızlı ses dökümü (transcription), konuşmacı ayrıştırma (speaker diarization) ve yerel dil modelleriyle özetleme yetenekleri sunar.</p>
 <ul class="disc-meta"><li>★ 27.968</li><li>Rust</li><li>GitHub Trending · 2026-07-05</li></ul>

--- a/discover/mempalace/index.html
+++ b/discover/mempalace/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Mempalace</span><span class="disc-momentum">🚀 +227 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Mempalace</span><span class="disc-momentum">↑ +227 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ modellerine bellek kazandırın</h1>
 <p class="disc-lead">MemPalace, yapay zekâ modelleri için açık kaynaklı bir bellek sistemi (memory system) sunuyor. Sistem, geniş dil modellerinin (large language models) bağlamsal hafıza performansını ölçümlemek ve geliştirmek amacıyla optimize edilmiş araçlar içeriyor.</p>
 <ul class="disc-meta"><li>★ 57.977</li><li>Python</li><li>GitHub Trending · 2026-06-06</li></ul>

--- a/discover/meshery/index.html
+++ b/discover/meshery/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Meshery</span><span class="disc-momentum">🚀 +45 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Meshery</span><span class="disc-momentum">↑ +45 bugün</span></div>
 <h1 class="disc-title">Bulut yerlisi altyapıları yönetin</h1>
 <p class="disc-lead">Meshery, bulut yerlisi (cloud native) altyapıların yönetimi için tasarlanmış bir hizmet ağı (service mesh) yönetim platformudur. Platform, karmaşık bulut ortamlarında yapılandırma, yaşam döngüsü yönetimi ve performans analizi süreçlerini tek bir merkezden yürütmeyi sağlar.</p>
 <ul class="disc-meta"><li>★ 11.427</li><li>TypeScript</li><li>GitHub Trending · 2026-06-15</li></ul>

--- a/discover/meshoptimizer/index.html
+++ b/discover/meshoptimizer/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Meshoptimizer</span><span class="disc-momentum">🚀 +91 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Meshoptimizer</span><span class="disc-momentum">↑ +91 bugün</span></div>
 <h1 class="disc-title">Üç boyutlu ağları optimize edin</h1>
 <p class="disc-lead">Meshoptimizer kütüphanesi, üç boyutlu ağ (mesh) verilerini optimize ederek dosya boyutlarını küçültüyor ve işleme (rendering) performansını artırıyor. C++ diliyle geliştirilen bu araç, grafik uygulamalarında bellek kullanımını iyileştirmek için geometrik verileri düzenliyor.</p>
 <ul class="disc-meta"><li>★ 8.177</li><li>C++</li><li>GitHub Trending · 2026-07-11</li></ul>

--- a/discover/mineru/index.html
+++ b/discover/mineru/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MinerU</span><span class="disc-momentum">🚀 +644 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MinerU</span><span class="disc-momentum">↑ +644 bugün</span></div>
 <h1 class="disc-title">Belgelerinizi yapay zekâ için dönüştürün</h1>
 <p class="disc-lead">MinerU, PDF ve Office gibi karmaşık belge formatlarını büyük dil modelleri (large language models) için uygun olan işaretleme dili (markdown) veya JSON formatına dönüştürüyor. Bu araç, yapılandırılmamış verileri ajan tabanlı iş akışlarında (agentic workflows) kullanılabilir hale getirmeyi amaçlıyor.</p>
 <ul class="disc-meta"><li>★ 76.547</li><li>Python</li><li>GitHub Trending · 2026-06-26</li></ul>

--- a/discover/mirofish/index.html
+++ b/discover/mirofish/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MiroFish</span><span class="disc-momentum">🚀 +320 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MiroFish</span><span class="disc-momentum">↑ +320 bugün</span></div>
 <h1 class="disc-title">Veri tahmininde sürü zekâsı motoru</h1>
 <p class="disc-lead">MiroFish, çeşitli veri türlerini tahmin etmek amacıyla geliştirilen basit ve evrensel bir sürü zekâsı motoru (swarm intelligence engine) sunuyor. Python tabanlı bu araç, karmaşık sistemlerdeki örüntüleri tanımlamak için kolektif hesaplama yöntemlerinden yararlanıyor.</p>
 <ul class="disc-meta"><li>★ 69.813</li><li>Python</li><li>GitHub Trending · 2026-06-06</li></ul>

--- a/discover/moneyprinterturbo/index.html
+++ b/discover/moneyprinterturbo/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MoneyPrinterTurbo</span><span class="disc-momentum">🚀 Bir günde +1.742 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MoneyPrinterTurbo</span><span class="disc-momentum">↑ Bir günde +1.742 yıldız</span></div>
       <h1 class="disc-title">Tek tuşla yapay zekâ videoları üretin</h1>
       <p class="disc-lead"><strong>MoneyPrinterTurbo</strong>, verdiğiniz bir konu veya anahtar kelimeden büyük dil modellerini kullanarak <strong>otomatik kısa videolar</strong> üretir. Metin, altyazı, arka plan müziği ve görselleri birleştirir. (İsim pazarlama amaçlıdır, bir 'para basma' makinesi değil, içerik üretim aracıdır.)</p>
       <figure class="disc-shot"><img src="/assets/discover/moneyprinterturbo.webp" width="1440" height="1629" loading="lazy" decoding="async" alt="MoneyPrinterTurbo arayüzünden bir görünüm"><figcaption>Görsel: MoneyPrinterTurbo (proje deposundan)</figcaption></figure>

--- a/discover/moonshine/index.html
+++ b/discover/moonshine/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Moonshine</span><span class="disc-momentum">🚀 +282 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Moonshine</span><span class="disc-momentum">↑ +282 bugün</span></div>
 <h1 class="disc-title">Gerçek zamanlı yapay zekâ ses araçları</h1>
 <p class="disc-lead">Moonshine, sesli arayüzler ve yapay zekâ ajanları için düşük gecikmeli konuşmayı metne dönüştürme (speech to text), niyet tanıma (intent recognition) ve metni sese dönüştürme (text to speech) yetenekleri sunuyor. C++ diliyle geliştirilen bu kütüphane, gerçek zamanlı ses işleme süreçlerini optimize etmeyi hedefliyor.</p>
 <ul class="disc-meta"><li>★ 10.579</li><li>C++</li><li>GitHub Trending · 2026-07-21</li></ul>

--- a/discover/moss-tts/index.html
+++ b/discover/moss-tts/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MOSS-TTS</span><span class="disc-momentum">🚀 Bir günde +71 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MOSS-TTS</span><span class="disc-momentum">↑ Bir günde +71 yıldız</span></div>
       <h1 class="disc-title">Doğal ve Akıcı Sesler Üretin</h1>
       <p class="disc-lead"><strong>MOSS-TTS</strong> (MOSI.AI ve OpenMOSS); yüksek sadakatli <strong>konuşma ve ses üretimi</strong> sağlayan açık kaynak bir model ailesidir. Uzun metinli konuşma sentezi, çoklu konuşmacı desteği ve gerçek zamanlı akış gibi senaryolar için çözümler sunar.</p>
       <figure class="disc-shot"><img src="/assets/discover/moss-tts.webp" width="1440" height="712" loading="lazy" decoding="async" alt="MOSS-TTS arayüzünden bir görünüm"><figcaption>Görsel: MOSS-TTS (proje deposundan)</figcaption></figure>

--- a/discover/mxc/index.html
+++ b/discover/mxc/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MXC</span><span class="disc-momentum">🚀 +64 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · MXC</span><span class="disc-momentum">↑ +64 bugün</span></div>
 <h1 class="disc-title">Rust ile politika tabanlı katmanlı sistem yalıtımı</h1>
 <p class="disc-lead">Microsoft tarafından geliştirilen MXC, Rust diliyle yazılmış politika tabanlı, katmanlı bir yalıtım ve kapsayıcılık (isolation and containment) çözümüdür. Sistem kaynaklarını güvenli bir şekilde sınırlandırmak ve uygulama güvenliğini artırmak amacıyla tasarlanmıştır.</p>
 <ul class="disc-meta"><li>★ 641</li><li>Rust</li><li>GitHub Trending · 2026-06-07</li></ul>

--- a/discover/nautilus-trader/index.html
+++ b/discover/nautilus-trader/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Nautilus Trader</span><span class="disc-momentum">🚀 +98 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Nautilus Trader</span><span class="disc-momentum">↑ +98 bugün</span></div>
 <h1 class="disc-title">Yüksek Performanslı Algoritmik İşlem Platformu</h1>
 <p class="disc-lead">Nautilus Trader, Rust diliyle geliştirilmiş, deterministik olay güdümlü mimariye (event-driven architecture) sahip bir alım satım motorudur (trading engine). Yüksek performanslı finansal sistemler için üretim seviyesinde (production-grade) altyapı çözümleri sunar.</p>
 <ul class="disc-meta"><li>★ 25.223</li><li>Rust</li><li>GitHub Trending · 2026-06-18</li></ul>

--- a/discover/next-ai-draw-io/index.html
+++ b/discover/next-ai-draw-io/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Next AI Draw IO</span><span class="disc-momentum">🚀 +81 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Next AI Draw IO</span><span class="disc-momentum">↑ +81 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile otomatik diyagram oluşturma</h1>
 <p class="disc-lead">Next.js tabanlı bu uygulama, diyagram oluşturma aracı draw.io ile üretken yapay zekâ (generative AI) yeteneklerini birleştiriyor. Kullanıcılar, doğal dil komutları aracılığıyla görsel şemalar oluşturabiliyor ve mevcut diyagramlarını yapay zekâ desteğiyle düzenleyebiliyor.</p>
 <ul class="disc-meta"><li>★ 33.999</li><li>TypeScript</li><li>GitHub Trending · 2026-07-12</li></ul>

--- a/discover/next-js/index.html
+++ b/discover/next-js/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Next.js</span><span class="disc-momentum">🚀 +191 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Next.js</span><span class="disc-momentum">↑ +191 bugün</span></div>
 <h1 class="disc-title">React ile hızlı web uygulamaları geliştirin</h1>
 <p class="disc-lead">Next.js, React tabanlı web uygulamaları geliştirmek için kullanılan bir çerçeve (framework) olarak sunucu taraflı oluşturma (server-side rendering) ve statik site üretimi gibi özellikler sağlıyor. Modern web projelerinde performans odaklı optimizasyonlar ve ölçeklenebilir altyapı çözümleri sunmasıyla geliştiriciler arasında yaygın bir tercih haline geliyor.</p>
 <ul class="disc-meta"><li>★ 141.328</li><li>JavaScript</li><li>GitHub Trending · 2026-07-11</li></ul>

--- a/discover/nginx/index.html
+++ b/discover/nginx/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Nginx</span><span class="disc-momentum">🚀 +20 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Nginx</span><span class="disc-momentum">↑ +20 bugün</span></div>
 <h1 class="disc-title">Yüksek performanslı web sunucusu ve ters vekil</h1>
 <p class="disc-lead">NGINX açık kaynak kod deposu, yüksek performanslı bir web sunucusu ve ters vekil sunucu (reverse proxy) olarak C diliyle geliştirilmeye devam ediyor. Yazılım, ağ trafiğini yönetmek ve içerik dağıtımını optimize etmek amacıyla geniş ölçekli altyapılarda standart bir çözüm sunuyor.</p>
 <ul class="disc-meta"><li>★ 31.312</li><li>C</li><li>GitHub Trending · 2026-06-07</li></ul>

--- a/discover/no-mistakes/index.html
+++ b/discover/no-mistakes/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · No Mistakes</span><span class="disc-momentum">🚀 +110 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · No Mistakes</span><span class="disc-momentum">↑ +110 bugün</span></div>
 <h1 class="disc-title">Hatalı kod gönderimlerini engelleyin</h1>
 <p class="disc-lead">Go diliyle geliştirilen no-mistakes, yazılım geliştiricilerin hatalı kod gönderimlerini (git push) engellemek için tasarlanmış bir komut satırı aracıdır. Yerel geliştirme ortamında çalışarak, kod tabanına istenmeyen değişikliklerin aktarılmasını önleyen bir güvenlik katmanı sağlar.</p>
 <ul class="disc-meta"><li>★ 7.424</li><li>Go</li><li>GitHub Trending · 2026-06-25</li></ul>

--- a/discover/node/index.html
+++ b/discover/node/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Node</span><span class="disc-momentum">🚀 +36 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Node</span><span class="disc-momentum">↑ +36 bugün</span></div>
 <h1 class="disc-title">JavaScript ile sunucu tarafı geliştirme</h1>
 <p class="disc-lead">Node.js, JavaScript kodunun tarayıcı dışında çalıştırılmasını sağlayan bir çalışma zamanı ortamı (runtime environment) sunuyor. V8 motorunu temel alan bu platform, sunucu tarafında ölçeklenebilir ağ uygulamaları geliştirmek için kullanılıyor.</p>
 <ul class="disc-meta"><li>★ 118.797</li><li>JavaScript</li><li>GitHub Trending · 2026-07-27</li></ul>

--- a/discover/nuxt/index.html
+++ b/discover/nuxt/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Nuxt</span><span class="disc-momentum">🚀 +16 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Nuxt</span><span class="disc-momentum">↑ +16 bugün</span></div>
 <h1 class="disc-title">Vue ile tam yığın web geliştirme</h1>
 <p class="disc-lead">Nuxt, Vue tabanlı uygulamalar geliştirmek için kullanılan tam yığın (full-stack) bir çerçevedir (framework). TypeScript desteğiyle sunulan bu araç, sunucu taraflı işleme (server-side rendering) ve statik site oluşturma süreçlerini optimize eder.</p>
 <ul class="disc-meta"><li>★ 60.726</li><li>TypeScript</li><li>GitHub Trending · 2026-07-12</li></ul>

--- a/discover/officecli/index.html
+++ b/discover/officecli/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OfficeCLI</span><span class="disc-momentum">🚀 +893 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OfficeCLI</span><span class="disc-momentum">↑ +893 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile ofis dosyalarını yönetin</h1>
 <p class="disc-lead">OfficeCLI, yapay zekâ ajanlarının Word, Excel ve PowerPoint dosyalarını doğrudan okumasına, düzenlemesine ve otomatize etmesine olanak tanıyan açık kaynaklı bir ofis paketi sunuyor. C# ile geliştirilen bu araç, herhangi bir ofis yazılımı kurulumuna ihtiyaç duymadan tek bir ikili dosya (binary) üzerinden işlem yapılmasına imkân veriyor.</p>
 <ul class="disc-meta"><li>★ 25.967</li><li>C#</li><li>GitHub Trending · 2026-07-08</li></ul>

--- a/discover/olmocr/index.html
+++ b/discover/olmocr/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Olmocr</span><span class="disc-momentum">🚀 +334 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Olmocr</span><span class="disc-momentum">↑ +334 bugün</span></div>
 <h1 class="disc-title">PDF belgelerini yapay zekâ için dönüştürün</h1>
 <p class="disc-lead">AllenAI tarafından geliştirilen olmocr, PDF belgelerini büyük dil modelleri (large language models) için uygun metin formatlarına dönüştüren bir araç takımıdır. Bu yazılım, karmaşık doküman yapılarının doğrusal bir biçimde işlenmesini sağlayarak veri seti hazırlama süreçlerini kolaylaştırır.</p>
 <ul class="disc-meta"><li>★ 19.259</li><li>Python</li><li>GitHub Trending · 2026-07-02</li></ul>

--- a/discover/omniroute/index.html
+++ b/discover/omniroute/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OmniRoute</span><span class="disc-momentum">🚀 +387 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OmniRoute</span><span class="disc-momentum">↑ +387 bugün</span></div>
 <h1 class="disc-title">Tüm yapay zekâ sağlayıcılarını birleştirin</h1>
 <p class="disc-lead">OmniRoute, 231&#x27;den fazla yapay zekâ sağlayıcısını tek bir uç noktada (endpoint) birleştirerek ücretsiz erişim imkânı sunan bir ağ geçididir (gateway). Gelişmiş sıkıştırma teknikleriyle jeton (token) kullanımını azaltırken, akıllı yedekleme ve çok modlu arayüz desteğiyle geliştirici araçlarını optimize eder.</p>
 <ul class="disc-meta"><li>★ 41.023</li><li>TypeScript</li><li>GitHub Trending · 2026-07-01</li></ul>

--- a/discover/ontology-playground/index.html
+++ b/discover/ontology-playground/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ontology-Playground</span><span class="disc-momentum">🚀 +464 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ontology-Playground</span><span class="disc-momentum">↑ +464 bugün</span></div>
 <h1 class="disc-title">Ontology-Playground ile yapay zekâ ontolojileri tasarlayın</h1>
 <p class="disc-lead">Microsoft tarafından geliştirilen Ontology-Playground, ontolojileri öğrenmek ve Microsoft Fabric IQ üzerinde görsel tasarımlar oluşturmak için kullanılan açık kaynaklı bir web uygulamasıdır. Tamamen statik yapıda çalışan bu araç, kullanıcıların ontoloji modellerini tasarlamasına, RDF/XML formatında dışa aktarmasına ve etkileşimli diyagramlar paylaşmasına olanak tanır.</p>
 <ul class="disc-meta"><li>★ 1.806</li><li>TypeScript</li><li>GitHub Trending · 2026-07-21</li></ul>

--- a/discover/open-code-review/index.html
+++ b/discover/open-code-review/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Open Code Review</span><span class="disc-momentum">🚀 +180 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Open Code Review</span><span class="disc-momentum">↑ +180 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ destekli hassas kod inceleme</h1>
 <p class="disc-lead">Alibaba tarafından geliştirilen açık kaynaklı kod inceleme aracı, deterministik işlem hatları (pipelines) ile büyük dil modeli (LLM) ajanlarını hibrit bir yapıda birleştiriyor. Yazılım güvenliği kuralları ve satır bazlı yorumlama yetenekleriyle donatılan araç, Go diliyle yazılmış olup OpenAI ve Anthropic uyumlu bir altyapı sunuyor.</p>
 <ul class="disc-meta"><li>★ 19.239</li><li>Go</li><li>GitHub Trending · 2026-07-24</li></ul>

--- a/discover/open-deep-research/index.html
+++ b/discover/open-deep-research/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Open Deep Research</span><span class="disc-momentum">🚀 +23 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Open Deep Research</span><span class="disc-momentum">↑ +23 bugün</span></div>
 <h1 class="disc-title">Otonom yapay zekâ ile derinlemesine araştırma</h1>
 <p class="disc-lead">LangChain tarafından geliştirilen open-deep-research, karmaşık soruları yanıtlamak için internet üzerinde çok adımlı araştırmalar yapan otonom bir sistemdir. Araştırma sürecini planlama, veri toplama ve sentezleme aşamalarıyla otomatize ederek derinlemesine analiz (deep research) süreçlerini kolaylaştırır.</p>
 <ul class="disc-meta"><li>★ 12.307</li><li>Python</li><li>GitHub Trending · 2026-07-22</li></ul>

--- a/discover/open-generative-ai/index.html
+++ b/discover/open-generative-ai/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Open-Generative-AI</span><span class="disc-momentum">🚀 +255 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Open-Generative-AI</span><span class="disc-momentum">↑ +255 bugün</span></div>
 <h1 class="disc-title">Kısıtlamasız yapay zekâ görsel ve video stüdyosu</h1>
 <p class="disc-lead">Open-Generative-AI, içerik filtrelemesi bulunmayan ve 200&#x27;den fazla görsel ile video oluşturma modelini (model) barındıran açık kaynaklı bir stüdyo platformudur. Kullanıcılar, MIT lisansıyla sunulan bu yazılımı kendi sunucularında (self-hosted) çalıştırarak görsel üretim süreçlerini özgürce yönetebilirler.</p>
 <ul class="disc-meta"><li>★ 25.418</li><li>JavaScript</li><li>GitHub Trending · 2026-06-28</li></ul>

--- a/discover/open-notebook/index.html
+++ b/discover/open-notebook/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Open Notebook</span><span class="disc-momentum">🚀 +212 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Open Notebook</span><span class="disc-momentum">↑ +212 bugün</span></div>
 <h1 class="disc-title">Kendi verilerinizle yapay zekâ asistanı</h1>
 <p class="disc-lead">Open-notebook, Google NotebookLM&#x27;in açık kaynaklı bir alternatifini sunarak kullanıcıların kendi verileri üzerinde özelleştirilebilir yapay zekâ destekli not analizi (AI-powered note analysis) yapmalarına olanak tanıyor. TypeScript ile geliştirilen bu proje, orijinal platforma kıyasla daha fazla esneklik ve genişletilmiş özellik seti sağlıyor.</p>
 <ul class="disc-meta"><li>★ 36.268</li><li>TypeScript</li><li>GitHub Trending · 2026-06-05</li></ul>

--- a/discover/open-seo/index.html
+++ b/discover/open-seo/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Open Seo</span><span class="disc-momentum">🚀 +57 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Open Seo</span><span class="disc-momentum">↑ +57 bugün</span></div>
 <h1 class="disc-title">Açık kaynaklı SEO veri ve analiz platformu</h1>
 <p class="disc-lead">Open SEO, Semrush ve Ahrefs gibi ücretli araçlara açık kaynaklı bir alternatif sunuyor. Arama motoru optimizasyonu (SEO) verilerini analiz etmek için geliştirilen bu yazılım, TypeScript tabanlı altyapısıyla süreçleri şeffaflaştırmayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 10.091</li><li>TypeScript</li><li>GitHub Trending · 2026-06-26</li></ul>

--- a/discover/openclaw-windows-node/index.html
+++ b/discover/openclaw-windows-node/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openclaw Windows Node</span><span class="disc-momentum">🚀 +411 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openclaw Windows Node</span><span class="disc-momentum">↑ +411 bugün</span></div>
 <h1 class="disc-title">Windows için yapay zekâ düğümü</h1>
 <p class="disc-lead">OpenClaw Windows düğümü (node), sistem tepsisi uygulaması, paylaşılan kütüphane ve PowerToys komut paleti uzantısı aracılığıyla Windows işletim sistemi üzerinde bütünleşik bir yönetim paketi sunuyor. C# diliyle geliştirilen bu araç, sistem kaynaklarına erişimi ve kullanıcı iş akışlarını standartlaştırmayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 2.018</li><li>C#</li><li>GitHub Trending · 2026-06-05</li></ul>

--- a/discover/opencode/index.html
+++ b/discover/opencode/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Opencode</span><span class="disc-momentum">🚀 +392 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Opencode</span><span class="disc-momentum">↑ +392 bugün</span></div>
 <h1 class="disc-title">Açık kaynaklı yapay zekâ kodlama ajanı</h1>
 <p class="disc-lead">OpenCode, yazılım geliştirme süreçlerini otomatikleştirmek için tasarlanmış açık kaynaklı bir kodlama ajanıdır (coding agent). TypeScript diliyle geliştirilen bu araç, yazılım projelerinde otonom görev yürütme yetenekleri sunar.</p>
 <ul class="disc-meta"><li>★ 193.974</li><li>TypeScript</li><li>GitHub Trending · 2026-06-28</li></ul>

--- a/discover/opencut/index.html
+++ b/discover/opencut/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OpenCut</span><span class="disc-momentum">🚀 +1.229 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OpenCut</span><span class="disc-momentum">↑ +1.229 bugün</span></div>
 <h1 class="disc-title">Açık kaynaklı video düzenleme platformu</h1>
 <p class="disc-lead">OpenCut, video düzenleme süreçleri için açık kaynaklı bir alternatif sunan TypeScript tabanlı bir uygulama geliştirme projesidir. CapCut benzeri bir kullanıcı deneyimi sağlamayı hedefleyen bu platform, video kurgu araçlarını erişilebilir kılmayı amaçlar.</p>
 <ul class="disc-meta"><li>★ 80.488</li><li>TypeScript</li><li>GitHub Trending · 2026-07-14</li></ul>

--- a/discover/opendataloader-pdf/index.html
+++ b/discover/opendataloader-pdf/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Opendataloader PDF</span><span class="disc-momentum">🚀 +570 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Opendataloader PDF</span><span class="disc-momentum">↑ +570 bugün</span></div>
 <h1 class="disc-title">PDF verilerini yapay zekâya hazırlayın</h1>
 <p class="disc-lead">OpenDataLoader PDF, yapay zekâ modelleri için veriyi hazır hale getiren açık kaynaklı bir PDF ayrıştırıcıdır (PDF parser). Java tabanlı bu proje, PDF belgelerinin erişilebilirliğini otomatikleştirerek veri işleme süreçlerini hızlandırır.</p>
 <ul class="disc-meta"><li>★ 28.095</li><li>Java</li><li>GitHub Trending · 2026-06-04</li></ul>

--- a/discover/openinterpreter/index.html
+++ b/discover/openinterpreter/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openinterpreter</span><span class="disc-momentum">🚀 +299 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openinterpreter</span><span class="disc-momentum">↑ +299 bugün</span></div>
 <h1 class="disc-title">Bilgisayarınızda kod çalıştıran yapay zekâ</h1>
 <p class="disc-lead">Open Interpreter, yerel bilgisayar ortamında kod çalıştırarak yazılım geliştirme süreçlerini otomatize eden bir kodlama ajanı (coding agent) sunuyor. Düşük maliyetli dil modelleriyle uyumlu çalışacak şekilde tasarlanan bu araç, karmaşık görevleri doğrudan terminal üzerinden yürütmeyi sağlıyor.</p>
 <ul class="disc-meta"><li>★ 67.509</li><li>Rust</li><li>GitHub Trending · 2026-07-16</li></ul>

--- a/discover/openmed/index.html
+++ b/discover/openmed/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openmed</span><span class="disc-momentum">🚀 +191 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openmed</span><span class="disc-momentum">↑ +191 bugün</span></div>
 <h1 class="disc-title">Sağlıkta Açık Kaynak yapay zekâ</h1>
 <p class="disc-lead">OpenMed, sağlık hizmetleri alanında kullanılan açık kaynaklı yapay zekâ (artificial intelligence) modellerini ve veri setlerini bir araya getiren bir platformdur. Tıp odaklı uygulamalar için geliştirilen bu Python tabanlı kütüphane, sağlık verilerinin işlenmesi süreçlerini standartlaştırmayı amaçlar.</p>
 <ul class="disc-meta"><li>★ 4.793</li><li>Python</li><li>GitHub Trending · 2026-06-10</li></ul>

--- a/discover/openmontage/index.html
+++ b/discover/openmontage/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OpenMontage</span><span class="disc-momentum">🚀 +98 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OpenMontage</span><span class="disc-momentum">↑ +98 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile profesyonel video üretimi</h1>
 <p class="disc-lead">OpenMontage, yapay zekâ kodlama asistanlarını tam kapsamlı bir video prodüksiyon stüdyosuna dönüştüren açık kaynaklı bir ajan tabanlı sistemdir (agentic system). Python tabanlı bu platform, 12 farklı işlem hattı (pipeline) ve 500&#x27;den fazla ajan yeteneği (agent skills) ile video üretim süreçlerini otomatize ediyor.</p>
 <ul class="disc-meta"><li>★ 44.651</li><li>Python</li><li>GitHub Trending · 2026-06-18</li></ul>

--- a/discover/openpilot/index.html
+++ b/discover/openpilot/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openpilot</span><span class="disc-momentum">🚀 +80 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openpilot</span><span class="disc-momentum">↑ +80 bugün</span></div>
 <h1 class="disc-title">Araçlar için açık kaynaklı yapay zekâ</h1>
 <p class="disc-lead">Comma AI tarafından geliştirilen openpilot, robotik sistemler için tasarlanmış açık kaynaklı bir işletim sistemidir. Yazılım, 300&#x27;den fazla araç modelinde sürücü destek sistemini (driver assistance system) yükselterek otonom sürüş yetenekleri kazandırıyor.</p>
 <ul class="disc-meta"><li>★ 63.294</li><li>Python</li><li>GitHub Trending · 2026-06-27</li></ul>

--- a/discover/openship/index.html
+++ b/discover/openship/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openship</span><span class="disc-momentum">🚀 +1.641 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openship</span><span class="disc-momentum">↑ +1.641 bugün</span></div>
 <h1 class="disc-title">Kendi sunucunuzda uygulama dağıtımı</h1>
 <p class="disc-lead">OpenShip, kullanıcıların kendi sunucularında barındırabildiği bir uygulama dağıtım platformu (deployment platform) sunuyor. TypeScript diliyle geliştirilen bu araç, bulut tabanlı altyapı hizmetlerine alternatif olarak kendi kendine barındırma (self-hosted) süreçlerini kolaylaştırıyor.</p>
 <ul class="disc-meta"><li>★ 10.135</li><li>TypeScript</li><li>GitHub Trending · 2026-07-21</li></ul>

--- a/discover/openspec/index.html
+++ b/discover/openspec/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OpenSpec</span><span class="disc-momentum">🚀 +177 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OpenSpec</span><span class="disc-momentum">↑ +177 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ projelerinde standart geliştirme</h1>
 <p class="disc-lead">OpenSpec, yapay zekâ kod asistanları için şartname odaklı geliştirme (spec-driven development) süreçlerini destekleyen bir TypeScript kütüphanesidir. Yazılım geliştirme aşamalarında teknik gereksinimlerin standartlaştırılmasını ve kod üretim süreçlerinin daha kontrollü ilerlemesini sağlar.</p>
 <ul class="disc-meta"><li>★ 63.990</li><li>TypeScript</li><li>GitHub Trending · 2026-06-28</li></ul>

--- a/discover/openstock/index.html
+++ b/discover/openstock/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OpenStock</span><span class="disc-momentum">🚀 Bir günde +128 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OpenStock</span><span class="disc-momentum">↑ Bir günde +128 yıldız</span></div>
       <h1 class="disc-title">Borsa Verilerini Ücretsiz Takip Edin</h1>
       <p class="disc-lead"><strong>OpenStock</strong>, pahalı borsa platformlarına karşı geliştirilmiş açık kaynaklı bir alternatiftir. Gerçek zamanlı fiyat takibi, <strong>kişiselleştirilmiş uyarılar</strong> ve şirket analizleri sunar. Herkes için erişilebilir ve sonsuza dek ücretsizdir.</p>
       <figure class="disc-shot"><img src="/assets/discover/openstock.webp" width="1440" height="764" loading="lazy" decoding="async" alt="OpenStock arayüzünden bir görünüm"><figcaption>Görsel: OpenStock (proje deposundan)</figcaption></figure>

--- a/discover/openwa/index.html
+++ b/discover/openwa/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OpenWA</span><span class="disc-momentum">🚀 +185 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · OpenWA</span><span class="disc-momentum">↑ +185 bugün</span></div>
 <h1 class="disc-title">WhatsApp için açık kaynaklı ağ geçidi</h1>
 <p class="disc-lead">OpenWA, WhatsApp mesajlaşma protokolü için ücretsiz ve açık kaynaklı bir ağ geçidi (API gateway) çözümü sunuyor. TypeScript diliyle geliştirilen bu araç, kullanıcıların kendi sunucularında (self-hosted) WhatsApp entegrasyonlarını yönetmelerine olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 12.466</li><li>TypeScript</li><li>GitHub Trending · 2026-06-17</li></ul>

--- a/discover/openwork/index.html
+++ b/discover/openwork/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openwork</span><span class="disc-momentum">🚀 +97 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Openwork</span><span class="disc-momentum">↑ +97 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ iş akışlarını paylaşın</h1>
 <p class="disc-lead">Openwork, Claude Cowork platformuna açık kaynaklı bir alternatif olarak geliştirilen ve opencode altyapısını kullanan bir yazılım projesidir. TypeScript diliyle yazılan bu araç, yazılım geliştirme süreçlerini otomatize etmeyi hedefleyen yapay zekâ destekli bir çalışma ortamı sunar.</p>
 <ul class="disc-meta"><li>★ 21.196</li><li>TypeScript</li><li>GitHub Trending · 2026-07-30</li></ul>

--- a/discover/optimizerduck/index.html
+++ b/discover/optimizerduck/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · optimizerDuck</span><span class="disc-momentum">🚀 +340 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · optimizerDuck</span><span class="disc-momentum">↑ +340 bugün</span></div>
 <h1 class="disc-title">Windows performansını ve gizliliğini artırın</h1>
 <p class="disc-lead">C# diliyle geliştirilen optimizerDuck, Windows işletim sistemlerinde performans artışı ve gizlilik odaklı yapılandırmalar sunan açık kaynaklı bir araçtır. Kullanıcıların sistem ayarlarını basitleştirmesini sağlayan bu yazılım, Windows optimizasyon süreçlerini tek bir arayüzde toplar.</p>
 <ul class="disc-meta"><li>★ 7.672</li><li>C#</li><li>GitHub Trending · 2026-06-16</li></ul>

--- a/discover/orca/index.html
+++ b/discover/orca/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Orca</span><span class="disc-momentum">🚀 +331 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Orca</span><span class="disc-momentum">↑ +331 bugün</span></div>
 <h1 class="disc-title">Birden fazla yapay zekâ ajanı yönetin</h1>
 <p class="disc-lead">Stablyai tarafından geliştirilen Orca, birden fazla yapay zekâ ajanını eş zamanlı yönetmeye olanak tanıyan bir ajan geliştirme ortamı (agent development environment) sunuyor. Kullanıcılar, kendi aboneliklerini kullanarak çeşitli kodlama ajanlarını hem masaüstü hem de mobil platformlarda çalıştırabiliyor.</p>
 <ul class="disc-meta"><li>★ 38.450</li><li>TypeScript</li><li>GitHub Trending · 2026-06-25</li></ul>

--- a/discover/ossie/index.html
+++ b/discover/ossie/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ossie</span><span class="disc-momentum">🚀 +60 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ossie</span><span class="disc-momentum">↑ +60 bugün</span></div>
 <h1 class="disc-title">Veri platformları için ortak anlamsal standart</h1>
 <p class="disc-lead">Apache Ossie, analitik, yapay zekâ ve iş zekâsı (BI) platformları arasında anlamsal üst veri (semantic metadata) değişimini standartlaştırmayı amaçlayan bir endüstri girişimidir. Bu proje, farklı platformlar arasında satıcıdan bağımsız, tek bir doğruluk kaynağı (single source of truth) oluşturarak veri entegrasyonunu kolaylaştırır.</p>
 <ul class="disc-meta"><li>★ 997</li><li>Python</li><li>GitHub Trending · 2026-07-17</li></ul>

--- a/discover/outlines/index.html
+++ b/discover/outlines/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Outlines</span><span class="disc-momentum">🚀 +65 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Outlines</span><span class="disc-momentum">↑ +65 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ çıktılarını yapılandırın</h1>
 <p class="disc-lead">Outlines kütüphanesi, büyük dil modellerinden gelen yanıtları önceden tanımlanmış şemalara göre yapılandırılmış çıktılar (structured outputs) halinde sunulmasını sağlıyor. Geliştiriciler, Python tabanlı bu araçla model çıktılarını düzenli ifadeler (regular expressions) veya bağlamsız dil bilgisi (context-free grammars) kurallarıyla kısıtlayarak veri bütünlüğünü koruyor.</p>
 <ul class="disc-meta"><li>★ 15.477</li><li>Python</li><li>GitHub Trending · 2026-07-22</li></ul>

--- a/discover/page-agent/index.html
+++ b/discover/page-agent/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Page Agent</span><span class="disc-momentum">🚀 +163 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Page Agent</span><span class="disc-momentum">↑ +163 bugün</span></div>
 <h1 class="disc-title">Doğal dil ile web arayüzlerini yönetin</h1>
 <p class="disc-lead">Alibaba tarafından geliştirilen page-agent, doğal dil komutlarıyla web arayüzlerini kontrol etmeye olanak tanıyan bir sayfa içi grafik kullanıcı arayüzü (graphical user interface) ajanıdır. TypeScript ile yazılan bu araç, web etkileşimlerini otomatize etmek için tarayıcı tabanlı bir kontrol mekanizması sunmaktadır.</p>
 <ul class="disc-meta"><li>★ 28.366</li><li>TypeScript</li><li>GitHub Trending · 2026-06-26</li></ul>

--- a/discover/palmier-pro/index.html
+++ b/discover/palmier-pro/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Palmier Pro</span><span class="disc-momentum">🚀 +756 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Palmier Pro</span><span class="disc-momentum">↑ +756 bugün</span></div>
 <h1 class="disc-title">MacOS için yapay zekâlı video düzenleyici</h1>
 <p class="disc-lead">Palmier Pro, macOS işletim sistemi üzerinde çalışan ve yapay zekâ destekli düzenleme araçları sunan bir video düzenleyici (video editor) olarak geliştirildi. Swift diliyle yazılan bu uygulama, yapay zekâ tabanlı iş akışlarını yerel sistem performansı ile birleştirmeyi amaçlıyor.</p>
 <ul class="disc-meta"><li>★ 13.118</li><li>Swift</li><li>GitHub Trending · 2026-06-20</li></ul>

--- a/discover/pdf-inspector/index.html
+++ b/discover/pdf-inspector/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · PDF Inspector</span><span class="disc-momentum">🚀 +1.699 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · PDF Inspector</span><span class="disc-momentum">↑ +1.699 bugün</span></div>
 <h1 class="disc-title">Hızlı ve Yerel PDF Metin İşleme</h1>
 <p class="disc-lead">Firecrawl tarafından geliştirilen PDF Inspector, PDF dosyalarını incelemek, sınıflandırmak ve metinlerini ayıklamak için tasarlanmış hızlı bir Rust kütüphanesidir. Taranmış belgeler ile metin tabanlı dosyaları ayırt ederek veri işleme süreçlerinde akıllı yönlendirme kararları alınmasını sağlar.</p>
 <ul class="disc-meta"><li>★ 11.746</li><li>Rust</li><li>GitHub Trending · 2026-08-04</li></ul>

--- a/discover/penpot/index.html
+++ b/discover/penpot/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Penpot</span><span class="disc-momentum">🚀 +70 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Penpot</span><span class="disc-momentum">↑ +70 bugün</span></div>
 <h1 class="disc-title">Tasarım ve yazılımı birleştiren platform</h1>
 <p class="disc-lead">Penpot, tasarımcılar ve yazılımcılar arasında iş birliğini güçlendiren açık kaynaklı bir tasarım aracıdır. Vektör tabanlı arayüzü sayesinde tasarım süreçlerini kodlama aşamasıyla bütünleşik bir şekilde yönetmeyi sağlar.</p>
 <ul class="disc-meta"><li>★ 57.989</li><li>Clojure</li><li>GitHub Trending · 2026-06-18</li></ul>

--- a/discover/pentagi/index.html
+++ b/discover/pentagi/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pentagi</span><span class="disc-momentum">🚀 +535 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pentagi</span><span class="disc-momentum">↑ +535 bugün</span></div>
 <h1 class="disc-title">Otonom sızma testi için yapay zekâ</h1>
 <p class="disc-lead">Go diliyle geliştirilen Pentagi, karmaşık sızma testlerini (penetration testing) gerçekleştirebilen tam otonom yapay zekâ ajanları (AI agents) sistemi sunuyor. Sistem, güvenlik açıklarını tespit etmek ve sömürmek için otonom iş akışlarını standartlaştırmayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 21.475</li><li>Go</li><li>GitHub Trending · 2026-07-10</li></ul>

--- a/discover/personal-ai-infrastructure/index.html
+++ b/discover/personal-ai-infrastructure/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Personal_AI_Infrastructure</span><span class="disc-momentum">🚀 +70 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Personal_AI_Infrastructure</span><span class="disc-momentum">↑ +70 bugün</span></div>
 <h1 class="disc-title">Kişisel yapay zekâ altyapınızı kurun</h1>
 <p class="disc-lead">Kişisel yapay zekâ altyapısı (Personal AI Infrastructure), insan yeteneklerini artırmak amacıyla tasarlanmış ajan tabanlı yapay zekâ (agentic AI) sistemleri oluşturmaya yönelik bir çerçeve sunuyor. TypeScript ile geliştirilen bu yapı, kullanıcıların kendi otonom iş akışlarını yönetmelerini sağlayan modüler bir mimariyi destekliyor.</p>
 <ul class="disc-meta"><li>★ 15.080</li><li>TypeScript</li><li>GitHub Trending · 2026-06-07</li></ul>

--- a/discover/pg-durable/index.html
+++ b/discover/pg-durable/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pg Durable</span><span class="disc-momentum">🚀 +316 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pg Durable</span><span class="disc-momentum">↑ +316 bugün</span></div>
 <h1 class="disc-title">PostgreSQL üzerinde dayanıklı süreç yönetimi</h1>
 <p class="disc-lead">Microsoft tarafından geliştirilen pg_durable, PostgreSQL üzerinde dayanıklı yürütme (durable execution) süreçlerini yönetmek için tasarlanmış bir kütüphanedir. Rust diliyle yazılan araç, karmaşık iş akışlarını veritabanı içerisinde hata toleranslı ve kalıcı bir şekilde çalıştırmayı sağlar.</p>
 <ul class="disc-meta"><li>★ 2.716</li><li>Rust</li><li>GitHub Trending · 2026-06-08</li></ul>

--- a/discover/pgrust/index.html
+++ b/discover/pgrust/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pgrust</span><span class="disc-momentum">🚀 +774 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pgrust</span><span class="disc-momentum">↑ +774 bugün</span></div>
 <h1 class="disc-title">Rust ile yeniden yazılan PostgreSQL</h1>
 <p class="disc-lead">PostgreSQL veritabanı yönetim sisteminin Rust programlama dili ile yeniden yazıldığı pgrust projesi, tüm regresyon testlerini başarıyla tamamlıyor. Bu çalışma, bellek güvenliği (memory safety) odaklı bir dille veritabanı mimarisini modernize etmeyi amaçlıyor.</p>
 <ul class="disc-meta"><li>★ 3.957</li><li>Rust</li><li>GitHub Trending · 2026-07-12</li></ul>

--- a/discover/photogimp/index.html
+++ b/discover/photogimp/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · PhotoGIMP</span><span class="disc-momentum">🚀 +1.125 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · PhotoGIMP</span><span class="disc-momentum">↑ +1.125 bugün</span></div>
 <h1 class="disc-title">GIMP arayüzünü Photoshop benzeri yapın</h1>
 <p class="disc-lead">PhotoGIMP, GIMP arayüzünü Photoshop kullanıcılarına tanıdık gelecek şekilde düzenleyen bir yama (patch) sunuyor. Bu araç, görsel düzenleme yazılımı (image editing software) geçiş sürecini kolaylaştırmak için kısayolları ve menü yerleşimlerini Photoshop standartlarına uyarlıyor.</p>
 <ul class="disc-meta"><li>★ 17.197</li><li>CSS</li><li>GitHub Trending · 2026-07-09</li></ul>

--- a/discover/pi-subagents/index.html
+++ b/discover/pi-subagents/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pi Subagents</span><span class="disc-momentum">🚀 Bir günde +69 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pi Subagents</span><span class="disc-momentum">↑ Bir günde +69 yıldız</span></div>
       <h1 class="disc-title">Yapay zekâ ile asenkron görev yönetimi</h1>
       <p class="disc-lead"><strong>pi-subagents</strong>, Pi platformu üzerinde <strong>asenkron alt-ajan delegasyonu</strong> süreçlerini yönetmek için geliştirilmiş bir TypeScript kütüphanesidir. Karmaşık iş yüklerini alt-ajanlara dağıtmayı kolaylaştırır.</p>
       <ul class="disc-meta"><li>★ 2.911</li><li>TypeScript</li><li>Lisans: yok</li><li>GitHub Trending · 1 Haziran 2026</li></ul>

--- a/discover/pi-web/index.html
+++ b/discover/pi-web/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pi Web</span><span class="disc-momentum">🚀 +298 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pi Web</span><span class="disc-momentum">↑ +298 bugün</span></div>
 <h1 class="disc-title">Pi kodlama ajanı için web arayüzü</h1>
 <p class="disc-lead">Pi-web, Pi kodlama ajanı için geliştirilmiş bir web tabanlı kullanıcı arayüzü (web UI) sunuyor. TypeScript diliyle yazılan bu araç, kodlama süreçlerini görsel bir arayüz üzerinden yönetmeyi mümkün kılıyor.</p>
 <ul class="disc-meta"><li>★ 3.485</li><li>TypeScript</li><li>GitHub Trending · 2026-07-22</li></ul>

--- a/discover/plane/index.html
+++ b/discover/plane/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Plane</span><span class="disc-momentum">🚀 +89 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Plane</span><span class="disc-momentum">↑ +89 bugün</span></div>
 <h1 class="disc-title">Açık kaynaklı proje yönetim platformu</h1>
 <p class="disc-lead">Plane, görev yönetimi, sprint planlama ve dokümantasyon süreçlerini bir araya getiren açık kaynaklı bir proje yönetim platformudur. Jira ve Linear gibi kurumsal araçlara alternatif olarak geliştirilen bu platform, ekiplerin iş akışlarını merkezi bir arayüz üzerinden düzenlemesine olanak tanır.</p>
 <ul class="disc-meta"><li>★ 55.364</li><li>TypeScript</li><li>GitHub Trending · 2026-06-18</li></ul>

--- a/discover/plugins/index.html
+++ b/discover/plugins/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Plugins</span><span class="disc-momentum">🚀 +49 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Plugins</span><span class="disc-momentum">↑ +49 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile güncel verilere erişin</h1>
 <p class="disc-lead">OpenAI eklentileri (plugins), dil modellerinin güncel verilere erişmesini ve üçüncü taraf uygulamalarla etkileşime girmesini sağlıyor. Bu yapı, yapay zekânın dış araçları kullanarak karmaşık görevleri yerine getirmesine olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 4.881</li><li>JavaScript</li><li>GitHub Trending · 2026-06-06</li></ul>

--- a/discover/pm-skills/index.html
+++ b/discover/pm-skills/index.html
@@ -58,7 +58,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pm Skills</span><span class="disc-momentum">🚀 +164 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pm Skills</span><span class="disc-momentum">↑ +164 bugün</span></div>
 <h1 class="disc-title">Ürün yönetimi için yapay zekâ yetenekleri</h1>
 <p class="disc-lead">PM Skills Marketplace, ürün yönetimi süreçleri için geliştirilmiş 100&#x27;den fazla otonom yetenek (agentic skills), komut ve eklenti sunuyor. Bu kaynak, keşif aşamasından büyüme evresine kadar tüm ürün yaşam döngüsü boyunca yapay zekâ destekli iş akışlarını standartlaştırmayı amaçlıyor.</p>
 <ul class="disc-meta"><li>★ 24.775</li><li>GitHub Trending · 2026-06-09</li></ul>

--- a/discover/pocket-tts/index.html
+++ b/discover/pocket-tts/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pocket TTS</span><span class="disc-momentum">🚀 +531 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pocket TTS</span><span class="disc-momentum">↑ +531 bugün</span></div>
 <h1 class="disc-title">CPU üzerinde çalışan hafif yapay zekâ ses sentezleyici</h1>
 <p class="disc-lead">Kyutai Labs tarafından geliştirilen Pocket-TTS, grafik işlem birimine ihtiyaç duymadan sadece merkezi işlem birimi (CPU) üzerinde çalışan hafif bir metinden sese dönüştürme (text-to-speech) modelidir. Düşük kaynak tüketimi sayesinde donanım kısıtlaması olan cihazlarda hızlı ve verimli ses sentezleme imkânı sunar.</p>
 <ul class="disc-meta"><li>★ 7.994</li><li>Python</li><li>GitHub Trending · 2026-07-08</li></ul>

--- a/discover/posthog/index.html
+++ b/discover/posthog/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Posthog</span><span class="disc-momentum">🚀 +77 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Posthog</span><span class="disc-momentum">↑ +77 bugün</span></div>
 <h1 class="disc-title">Ürün geliştirme için yapay zekâ gözlemlenebilirliği</h1>
 <p class="disc-lead">PostHog, ürün geliştirme süreçleri için yapay zekâ gözlemlenebilirliği (AI observability), analiz ve oturum tekrarı (session replay) gibi araçları bir araya getiren kapsamlı bir platformdur. Yazılım geliştiricilerin hata takibi, deney yönetimi ve kullanıcı verilerini analiz ederek otonom ürünler oluşturmasını sağlar.</p>
 <ul class="disc-meta"><li>★ 37.487</li><li>Python</li><li>GitHub Trending · 2026-07-17</li></ul>

--- a/discover/ppf-contact-solver/index.html
+++ b/discover/ppf-contact-solver/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · PPF Contact Solver</span><span class="disc-momentum">🚀 Bir günde +207 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · PPF Contact Solver</span><span class="disc-momentum">↑ Bir günde +207 yıldız</span></div>
       <h1 class="disc-title">Fizik Simülasyonlarında Temasları Yönetin</h1>
       <p class="disc-lead"><strong>PPF Contact Solver</strong>, ZOZO'nun fizik motoru olarak fizik tabanlı simülasyonlarda <strong>kumaş, katı ve ip</strong> arasındaki temasları çözümlemek için tasarlanmıştır. Farklı geometrilerin etkileşimini hesaplayarak simülasyonlarda fiziksel tutarlılığı artırır. Blender eklentisi sayesinde uzaktan da çalıştırılabilir.</p>
       <figure class="disc-shot"><img src="/assets/discover/ppf-contact-solver.webp" width="1440" height="483" loading="lazy" decoding="async" alt="PPF Contact Solver arayüzünden bir görünüm"><figcaption>Görsel: ppf-contact-solver · ZOZO (proje deposundan)</figcaption></figure>

--- a/discover/ppt-master/index.html
+++ b/discover/ppt-master/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ppt Master</span><span class="disc-momentum">🚀 +589 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Ppt Master</span><span class="disc-momentum">↑ +589 bugün</span></div>
 <h1 class="disc-title">Belgeleri düzenlenebilir sunumlara dönüştüren yapay zekâ</h1>
 <p class="disc-lead">PPT-Master, belgeleri doğrudan düzenlenebilir sunum dosyalarına (PPTX) dönüştüren yapay zekâ destekli bir araçtır. Sistem, metinleri yerel şekiller, animasyonlar ve sesli konuşmacı notları içeren özelleştirilebilir sunumlara çevirir.</p>
 <ul class="disc-meta"><li>★ 43.374</li><li>Python</li><li>GitHub Trending · 2026-06-28</li></ul>

--- a/discover/prefect/index.html
+++ b/discover/prefect/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Prefect</span><span class="disc-momentum">🚀 +66 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Prefect</span><span class="disc-momentum">↑ +66 bugün</span></div>
 <h1 class="disc-title">Python ile veri süreçlerini yönetin</h1>
 <p class="disc-lead">Prefect, Python tabanlı veri hatları oluşturmak için kullanılan bir iş akışı düzenleme çerçevesidir (workflow orchestration framework). Dayanıklı veri süreçleri geliştirmek amacıyla tasarlanan bu araç, karmaşık veri iş akışlarının yönetilmesini ve izlenmesini sağlar.</p>
 <ul class="disc-meta"><li>★ 23.532</li><li>Python</li><li>GitHub Trending · 2026-07-13</li></ul>

--- a/discover/prisma/index.html
+++ b/discover/prisma/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Prisma</span><span class="disc-momentum">🚀 +46 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Prisma</span><span class="disc-momentum">↑ +46 bugün</span></div>
 <h1 class="disc-title">Node.js projeleri için veritabanı yönetimi</h1>
 <p class="disc-lead">Prisma, Node.js ve TypeScript projeleri için veritabanı etkileşimlerini kolaylaştıran bir nesne ilişkisel eşleyici (ORM) aracıdır. Farklı veritabanı sistemlerini destekleyen yapısı, geliştiricilere tip güvenli (type-safe) veritabanı sorguları oluşturma imkânı tanır.</p>
 <ul class="disc-meta"><li>★ 47.540</li><li>TypeScript</li><li>GitHub Trending · 2026-07-09</li></ul>

--- a/discover/project-nomad/index.html
+++ b/discover/project-nomad/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Project N.O.M.A.D</span><span class="disc-momentum">🚀 Bir günde +473 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Project N.O.M.A.D</span><span class="disc-momentum">↑ Bir günde +473 yıldız</span></div>
       <h1 class="disc-title">İnternetsiz Hayatta Kalma Bilgisayarı</h1>
       <p class="disc-lead"><strong>Project N.O.M.A.D</strong>; internet bağlantısı gerektirmeyen, kritik araçlar, bilgi kaynakları ve yapay zekâ ile donatılmış <strong>kendi kendine yeten, çevrimdışı bir bilgisayar</strong> kurma projesidir. Acil durumlar ve internetin olmadığı senaryolar için özel olarak tasarlanmıştır.</p>
       <ul class="disc-meta"><li>★ 35.435</li><li>TypeScript</li><li>Apache-2.0</li><li>GitHub Trending · 30 May 2026</li></ul>

--- a/discover/protobuf/index.html
+++ b/discover/protobuf/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Protobuf</span><span class="disc-momentum">🚀 +11 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Protobuf</span><span class="disc-momentum">↑ +11 bugün</span></div>
 <h1 class="disc-title">Veri değişiminde hızlı ve yapılandırılmış format</h1>
 <p class="disc-lead">Google tarafından geliştirilen protokol tamponları (protocol buffers), yapılandırılmış verileri seri hale getirmek için kullanılan dilden bağımsız bir veri değişim formatıdır. Bu mekanizma, sistemler arası iletişimde verimli ve hızlı bir ikili (binary) veri aktarımı sağlar.</p>
 <ul class="disc-meta"><li>★ 71.674</li><li>C++</li><li>GitHub Trending · 2026-07-18</li></ul>

--- a/discover/pumpkin/index.html
+++ b/discover/pumpkin/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pumpkin</span><span class="disc-momentum">🚀 +108 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pumpkin</span><span class="disc-momentum">↑ +108 bugün</span></div>
 <h1 class="disc-title">Rust ile hızlı Minecraft sunucuları</h1>
 <p class="disc-lead">Rust programlama diliyle geliştirilen Pumpkin, Minecraft sunucularını daha hızlı ve verimli bir şekilde barındırmayı hedefleyen açık kaynaklı bir altyapı sunuyor. Bellek güvenliği ve yüksek performans odaklı yapısıyla sunucu yönetimi süreçlerini optimize etmeyi amaçlıyor.</p>
 <ul class="disc-meta"><li>★ 10.510</li><li>Rust</li><li>GitHub Trending · 2026-07-23</li></ul>

--- a/discover/pytest/index.html
+++ b/discover/pytest/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pytest</span><span class="disc-momentum">🚀 +8 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pytest</span><span class="disc-momentum">↑ +8 bugün</span></div>
 <h1 class="disc-title">Python projelerinde test süreçlerini hızlandırın</h1>
 <p class="disc-lead">Pytest, Python projelerinde küçük ölçekli birim testlerinden (unit testing) karmaşık işlevsel testlere kadar geniş bir yelpazeyi destekleyen bir test çerçevesidir (testing framework). Geliştiricilerin daha az kodla daha kapsamlı testler yazmasına olanak tanıyan yapısı sayesinde yazılım geliştirme süreçlerinde standart bir araç haline gelmiştir.</p>
 <ul class="disc-meta"><li>★ 14.382</li><li>Python</li><li>GitHub Trending · 2026-06-15</li></ul>

--- a/discover/pytorch/index.html
+++ b/discover/pytorch/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pytorch</span><span class="disc-momentum">🚀 +65 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Pytorch</span><span class="disc-momentum">↑ +65 bugün</span></div>
 <h1 class="disc-title">Esnek ve hızlı yapay zekâ kütüphanesi</h1>
 <p class="disc-lead">PyTorch, Python tabanlı tensör hesaplamaları ve dinamik sinir ağları (dynamic neural networks) için güçlü grafik işlem birimi (GPU) hızlandırması sunan bir makine öğrenmesi kütüphanesidir. Derin öğrenme modellerinin geliştirilmesi ve dağıtılması süreçlerinde geniş bir ekosistem desteği sağlar.</p>
 <ul class="disc-meta"><li>★ 102.131</li><li>Python</li><li>GitHub Trending · 2026-07-03</li></ul>

--- a/discover/reverse-skill/index.html
+++ b/discover/reverse-skill/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Reverse Skill</span><span class="disc-momentum">🚀 +335 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Reverse Skill</span><span class="disc-momentum">↑ +335 bugün</span></div>
 <h1 class="disc-title">Sızma testleri için yapay zekâ yönlendirme</h1>
 <p class="disc-lead">Reverse-skill, tersine mühendislik ve sızma testi süreçleri için yapay zekâ destekli bir yönlendirme paketi (routing pack) sunuyor. Araç zinciri önyükleme (toolchain bootstrapping) ve kendi kendine gelişen bilgi tabanı özellikleriyle Claude Code, Cursor ve Cline gibi kodlama araçlarıyla entegre çalışıyor.</p>
 <ul class="disc-meta"><li>★ 19.315</li><li>PowerShell</li><li>GitHub Trending · 2026-08-01</li></ul>

--- a/discover/rlm/index.html
+++ b/discover/rlm/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · RLM</span><span class="disc-momentum">🚀 +43 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · RLM</span><span class="disc-momentum">↑ +43 bugün</span></div>
 <h1 class="disc-title">Özyinelemeli yapay zekâ modelleri için altyapı</h1>
 <p class="disc-lead">Özyinelemeli dil modelleri (Recursive Language Models) için geliştirilen rlm, farklı çalışma ortamlarını (sandboxes) destekleyen tak-çalıştır bir çıkarım kütüphanesidir. Python tabanlı bu araç, karmaşık dil modeli süreçlerini standartlaştırarak farklı sistemlere entegre edilmesini kolaylaştırır.</p>
 <ul class="disc-meta"><li>★ 5.343</li><li>Python</li><li>GitHub Trending · 2026-06-18</li></ul>

--- a/discover/rocket-chat/index.html
+++ b/discover/rocket-chat/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Rocket.Chat</span><span class="disc-momentum">🚀 +22 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Rocket.Chat</span><span class="disc-momentum">↑ +22 bugün</span></div>
 <h1 class="disc-title">Güvenli ve özelleştirilebilir ekip iletişimi</h1>
 <p class="disc-lead">Rocket.Chat, görev kritik operasyonlar için tasarlanmış güvenli bir iletişim işletim sistemi (communications operating system) sunuyor. TypeScript diliyle geliştirilen platform, kurum içi mesajlaşma ve iş birliği süreçlerini merkezileştirmeyi hedefliyor.</p>
 <ul class="disc-meta"><li>★ 45.919</li><li>TypeScript</li><li>GitHub Trending · 2026-06-18</li></ul>

--- a/discover/romm/index.html
+++ b/discover/romm/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Romm</span><span class="disc-momentum">🚀 +239 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Romm</span><span class="disc-momentum">↑ +239 bugün</span></div>
 <h1 class="disc-title">Kendi oyun kütüphanenizi yönetin</h1>
 <p class="disc-lead">Romm, oyun dosyalarını (ROM) düzenlemek ve tarayıcı üzerinden doğrudan oynamak için tasarlanmış, kendi sunucunuzda barındırabileceğiniz bir oyun kütüphanesi yöneticisidir. Python diliyle geliştirilen bu araç, oyun koleksiyonlarını görsel bir arayüzle yönetme ve oynatma imkanı sunar.</p>
 <ul class="disc-meta"><li>★ 11.859</li><li>Python</li><li>GitHub Trending · 2026-07-04</li></ul>

--- a/discover/ruview/index.html
+++ b/discover/ruview/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · RuView</span><span class="disc-momentum">🚀 Bir günde +656 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · RuView</span><span class="disc-momentum">↑ Bir günde +656 yıldız</span></div>
       <h1 class="disc-title">WiFi Sinyalleriyle Mekansal Zeka Kazanın</h1>
       <p class="disc-lead"><strong>RuView</strong>, sıradan WiFi sinyallerini kullanarak <strong>kamera olmadan</strong> gerçek zamanlı mekânsal zekâ, hayati bulgu takibi ve varlık algılama işlemleri gerçekleştirir. Rust ile geliştirilmiş açık kaynak bir projedir.</p>
       <figure class="disc-shot"><img src="/assets/discover/ruview.webp" width="1440" height="1193" loading="lazy" decoding="async" alt="RuView arayüzünden bir görünüm"><figcaption>Görsel: RuView (proje deposundan)</figcaption></figure>

--- a/discover/scrapling/index.html
+++ b/discover/scrapling/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Scrapling</span><span class="disc-momentum">🚀 Bir günde +606 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Scrapling</span><span class="disc-momentum">↑ Bir günde +606 yıldız</span></div>
       <h1 class="disc-title">Esnek web kazıma ile verilerinizi çekin</h1>
       <p class="disc-lead"><strong>Scrapling</strong>, tek bir istekten geniş kapsamlı tarama işlerine kadar her ölçeği yönetebilen <strong>uyarlanabilir bir web kazıma (scraping) çerçevesidir</strong>. Sayfa yapısı değişse dahi yüksek uyum sağlamayı hedefler. Python tabanlıdır.</p>
       <ul class="disc-meta"><li>★ 72.180</li><li>Python</li><li>BSD-3-Clause</li><li>GitHub Trending · 1 Haziran 2026</li></ul>

--- a/discover/self-hosting-guide/index.html
+++ b/discover/self-hosting-guide/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Self-Hosting-Guide</span><span class="disc-momentum">🚀 +188 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Self-Hosting-Guide</span><span class="disc-momentum">↑ +188 bugün</span></div>
 <h1 class="disc-title">Kendi sunucunuzu yönetme rehberi</h1>
 <p class="disc-lead">Self-Hosting Guide, yerel ağlarda veya özel web sunucularında yazılım uygulamalarını barındırma ve yönetme süreçlerine dair kapsamlı bir rehber sunuyor. Bulut bilişim, büyük dil modelleri (large language models), otomasyon ve ağ yapılandırması gibi konularda teknik kaynaklar sağlıyor.</p>
 <ul class="disc-meta"><li>★ 21.324</li><li>Dockerfile</li><li>GitHub Trending · 2026-06-16</li></ul>

--- a/discover/sharpemu/index.html
+++ b/discover/sharpemu/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Sharpemu</span><span class="disc-momentum">🚀 +314 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Sharpemu</span><span class="disc-momentum">↑ +314 bugün</span></div>
 <h1 class="disc-title">Deneysel PlayStation 5 öykünücü projesi</h1>
 <p class="disc-lead">Sharpemu, C# diliyle geliştirilen deneysel bir PlayStation 5 öykünücü (emulator) projesidir. Konsol mimarisini yazılım tabanlı olarak taklit etmeyi hedefleyen bu çalışma, oyun konsolu öykünme teknolojileri üzerinde yürütülen teknik bir denemedir.</p>
 <ul class="disc-meta"><li>★ 1.379</li><li>C#</li><li>GitHub Trending · 2026-07-13</li></ul>

--- a/discover/sia/index.html
+++ b/discover/sia/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · SIA</span><span class="disc-momentum">🚀 +199 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · SIA</span><span class="disc-momentum">↑ +199 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ modellerini otonom test edin</h1>
 <p class="disc-lead">SIA, yapay zekâ modellerinin ve ajanların belirli kıyaslama görevlerindeki (benchmark tasks) performanslarını otonom şekilde artırmak için geliştirilen bir öz-iyileştiren yapay zekâ (self-improving AI) çerçevesidir. Python tabanlı bu sistem, yapay zekâ sistemlerinin kendi çıktılarını analiz ederek süreçlerini optimize etmesini sağlar.</p>
 <ul class="disc-meta"><li>★ 1.478</li><li>Python</li><li>GitHub Trending · 2026-06-12</li></ul>

--- a/discover/simplex-chat/index.html
+++ b/discover/simplex-chat/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Simplex Chat</span><span class="disc-momentum">🚀 +432 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Simplex Chat</span><span class="disc-momentum">↑ +432 bugün</span></div>
 <h1 class="disc-title">Kullanıcı tanımlayıcısı olmayan gizli mesajlaşma</h1>
 <p class="disc-lead">SimpleX, kullanıcı tanımlayıcıları (user identifiers) kullanmadan çalışan ilk mesajlaşma ağı olarak gizlilik odaklı bir iletişim altyapısı sunuyor. Haskell diliyle geliştirilen platform, merkeziyetsiz yapısı sayesinde kullanıcı verilerini tamamen anonim tutmayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 19.164</li><li>Haskell</li><li>GitHub Trending · 2026-06-27</li></ul>

--- a/discover/skills/index.html
+++ b/discover/skills/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Skills</span><span class="disc-momentum">🚀 +461 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Skills</span><span class="disc-momentum">↑ +461 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanlarını Google ile güçlendirin</h1>
 <p class="disc-lead">Google tarafından geliştirilen yetenekler (skills) kütüphanesi, yapay zekâ ajanlarının Google ürünleri ve teknolojileriyle etkileşim kurmasını sağlayan Python tabanlı araçlar sunuyor. Bu kaynak, ajanların belirli görevleri yerine getirmesi için gerekli işlevselliği standartlaştırılmış bir yapıda sağlıyor.</p>
 <ul class="disc-meta"><li>★ 15.389</li><li>Python</li><li>GitHub Trending · 2026-06-09</li></ul>

--- a/discover/skillspector/index.html
+++ b/discover/skillspector/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · SkillSpector</span><span class="disc-momentum">🚀 +319 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · SkillSpector</span><span class="disc-momentum">↑ +319 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ yeteneklerini güvenli kılın</h1>
 <p class="disc-lead">NVIDIA tarafından geliştirilen SkillSpector, yapay zekâ ajanlarına ait yetenek paketlerindeki (skills) güvenlik açıklarını ve kötü niyetli kalıpları tespit eden bir tarama aracıdır. Python tabanlı bu yazılım, ajan tabanlı sistemlerin geliştirilme sürecinde karşılaşılan güvenlik risklerini analiz etmeyi hedefler.</p>
 <ul class="disc-meta"><li>★ 14.260</li><li>Python</li><li>GitHub Trending · 2026-06-12</li></ul>

--- a/discover/smsforwarder/index.html
+++ b/discover/smsforwarder/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · SmsForwarder</span><span class="disc-momentum">🚀 +104 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · SmsForwarder</span><span class="disc-momentum">↑ +104 bugün</span></div>
 <h1 class="disc-title">Android mesajlarınızı farklı platformlara yönlendirin</h1>
 <p class="disc-lead">SmsForwarder, Android cihazlardaki kısa mesajları, çağrıları ve uygulama bildirimlerini belirlenen kurallar çerçevesinde farklı mesajlaşma platformlarına veya web kancalarına (webhook) yönlendiren bir araçtır. Kullanıcıların cihazlarını uzaktan yönetmesine ve pil durumu ile rehber gibi verilere erişmesine olanak tanıyan bu yazılım, Kotlin diliyle geliştirilmiştir.</p>
 <ul class="disc-meta"><li>★ 27.342</li><li>Kotlin</li><li>GitHub Trending · 2026-06-21</li></ul>

--- a/discover/snipe-it/index.html
+++ b/discover/snipe-it/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Snipe It</span><span class="disc-momentum">🚀 +164 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Snipe It</span><span class="disc-momentum">↑ +164 bugün</span></div>
 <h1 class="disc-title">Kurumsal varlık ve lisans yönetimi</h1>
 <p class="disc-lead">Snipe-IT, bilişim teknolojileri varlıklarını ve yazılım lisanslarını takip etmeye yarayan açık kaynaklı bir yönetim sistemidir. PHP diliyle geliştirilen bu platform, kurumların envanter kayıtlarını ve kullanım döngülerini dijital ortamda düzenlemesine olanak tanır.</p>
 <ul class="disc-meta"><li>★ 14.677</li><li>PHP</li><li>GitHub Trending · 2026-07-30</li></ul>

--- a/discover/social-auto-upload/index.html
+++ b/discover/social-auto-upload/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · social-auto-upload</span><span class="disc-momentum">🚀 Bir günde +106 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · social-auto-upload</span><span class="disc-momentum">↑ Bir günde +106 yıldız</span></div>
       <h1 class="disc-title">Videolarınızı Tüm Platformlara Otomatik Yükleyin</h1>
       <p class="disc-lead"><strong>social-auto-upload</strong>, videolarınızı <strong>TikTok, YouTube, Bilibili, Douyin ve Xiaohongshu</strong> gibi sosyal medya platformlarına otomatik olarak yükleyen bir Python aracıdır. Çok platformlu içerik dağıtım süreçlerinizi kolaylaştırır.</p>
       <ul class="disc-meta"><li>★ 13.937</li><li>Python</li><li>Lisans: yok</li><li>GitHub Trending · 30 May 2026</li></ul>

--- a/discover/spdlog/index.html
+++ b/discover/spdlog/index.html
@@ -57,7 +57,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Spdlog</span><span class="disc-momentum">🚀 +10 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Spdlog</span><span class="disc-momentum">↑ +10 bugün</span></div>
 <h1 class="disc-title">C++ projeleri için hızlı günlük kaydı</h1>
 <p class="disc-lead">spdlog, C++ programlama dili için geliştirilmiş çok hızlı bir günlük kaydı (logging) kütüphanesidir. Yazılım projelerinde hata ayıklama ve izleme süreçlerini hızlandırmak amacıyla yüksek performanslı çıktı yönetimi sunar.</p>
 <ul class="disc-meta"><li>★ 29.437</li><li>C++</li><li>GitHub Trending · 2026-08-05</li></ul>

--- a/discover/spec-kit/index.html
+++ b/discover/spec-kit/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Spec Kit</span><span class="disc-momentum">🚀 +321 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Spec Kit</span><span class="disc-momentum">↑ +321 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile şartname odaklı geliştirme</h1>
 <p class="disc-lead">GitHub tarafından yayınlanan spec-kit, şartname odaklı geliştirme (spec-driven development) süreçlerini başlatmak için gerekli araçları sunuyor. Python tabanlı bu kütüphane, yazılım geliştirme aşamasında tanımlanan teknik şartnamelerin kod süreçlerine entegrasyonunu kolaylaştırıyor.</p>
 <ul class="disc-meta"><li>★ 125.507</li><li>Python</li><li>GitHub Trending · 2026-06-05</li></ul>

--- a/discover/speech-to-speech/index.html
+++ b/discover/speech-to-speech/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Speech to Speech</span><span class="disc-momentum">🚀 +227 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Speech to Speech</span><span class="disc-momentum">↑ +227 bugün</span></div>
 <h1 class="disc-title">Açık kaynaklı yerel sesli ajanlar</h1>
 <p class="disc-lead">Hugging Face tarafından geliştirilen speech-to-speech kütüphanesi, açık kaynaklı modeller kullanarak yerel sesli ajanlar (voice agents) oluşturulmasına olanak tanıyor. Python tabanlı bu araç, geliştiricilerin cihaz üzerinde çalışan gerçek zamanlı sesli etkileşim sistemleri kurmasını sağlıyor.</p>
 <ul class="disc-meta"><li>★ 11.283</li><li>Python</li><li>GitHub Trending · 2026-07-29</li></ul>

--- a/discover/spiderfoot/index.html
+++ b/discover/spiderfoot/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Spiderfoot</span><span class="disc-momentum">🚀 +294 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Spiderfoot</span><span class="disc-momentum">↑ +294 bugün</span></div>
 <h1 class="disc-title">Açık kaynaklı istihbarat toplama aracı</h1>
 <p class="disc-lead">SpiderFoot, tehdit istihbaratı ve saldırı yüzeyi haritalama süreçleri için açık kaynaklı istihbarat (OSINT) toplama işlemlerini otomatize eden bir Python aracıdır. Çeşitli veri kaynaklarını entegre ederek dijital varlıklar üzerindeki güvenlik açıklarını tespit etmeyi sağlar.</p>
 <ul class="disc-meta"><li>★ 20.026</li><li>Python</li><li>GitHub Trending · 2026-06-22</li></ul>

--- a/discover/stable-worldmodel/index.html
+++ b/discover/stable-worldmodel/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · stable-worldmodel</span><span class="disc-momentum">🚀 Bir günde +319 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · stable-worldmodel</span><span class="disc-momentum">↑ Bir günde +319 yıldız</span></div>
       <h1 class="disc-title">Dünya Modeli Araştırmalarını Hızlandırın</h1>
       <p class="disc-lead"><strong>stable-worldmodel</strong>; 'dünya modelleri' (world models) üzerine yapılan araştırmaların <strong>tekrarlanabilir</strong> ve karşılaştırılabilir olmasını sağlayan bir platformdur. Özellikle araştırma ve değerlendirme süreçlerine odaklanır.</p>
       <ul class="disc-meta"><li>★ 2.080</li><li>Python</li><li>Lisans: kontrol et</li><li>GitHub Trending · 30 May 2026</li></ul>

--- a/discover/stirling-pdf/index.html
+++ b/discover/stirling-pdf/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Stirling-PDF</span><span class="disc-momentum">🚀 +547 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Stirling-PDF</span><span class="disc-momentum">↑ +547 bugün</span></div>
 <h1 class="disc-title">Kendi sunucunuzda kapsamlı PDF düzenleme</h1>
 <p class="disc-lead">Stirling-PDF, kullanıcıların PDF dosyaları üzerinde her cihazda düzenleme yapmasına olanak tanıyan açık kaynaklı bir belge işleme aracıdır. TypeScript ile geliştirilen bu uygulama, yerel sunucularda çalışarak doküman yönetimi süreçlerini merkezileştirir.</p>
 <ul class="disc-meta"><li>★ 88.578</li><li>TypeScript</li><li>GitHub Trending · 2026-06-23</li></ul>

--- a/discover/stitch-skills/index.html
+++ b/discover/stitch-skills/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Stitch Skills</span><span class="disc-momentum">🚀 +117 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Stitch Skills</span><span class="disc-momentum">↑ +117 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları için tasarım yetenekleri</h1>
 <p class="disc-lead">Google Labs tarafından geliştirilen Stitch Skills, Stitch MCP sunucusuyla uyumlu çalışmak üzere tasarlanmış bir ajan yetenekleri (agent skills) kütüphanesidir. Açık standartları takip eden bu kütüphane, Gemini CLI ve Cursor gibi kodlama ajanları (coding agents) için iş akışlarını standartlaştırmayı amaçlar.</p>
 <ul class="disc-meta"><li>★ 7.892</li><li>TypeScript</li><li>GitHub Trending · 2026-07-11</li></ul>

--- a/discover/stop-slop/index.html
+++ b/discover/stop-slop/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Stop Slop</span><span class="disc-momentum">🚀 Bir günde +547 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Stop Slop</span><span class="disc-momentum">↑ Bir günde +547 yıldız</span></div>
       <h1 class="disc-title">Yapay zekâ metinlerini doğallaştırın</h1>
       <p class="disc-lead">Yapay zekâ ile üretilen metinler genellikle tahmin edilebilir ifadeler, ritimler ve yapılar içerir. <strong>Stop Slop</strong>, Claude veya herhangi bir LLM'e bu kalıpları yakalayıp temizlemeyi öğreten bir beceri dosyasıdır. Bu sayede metinleriniz çok daha doğal ve insani bir tona kavuşur.</p>
       <figure class="disc-shot"><img src="/assets/discover/stop-slop.webp" width="1440" height="810" loading="lazy" decoding="async" alt="Stop Slop arayüzünden bir görünüm"><figcaption>Görsel: stop-slop (proje deposundan)</figcaption></figure>

--- a/discover/strix/index.html
+++ b/discover/strix/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Strix</span><span class="disc-momentum">🚀 +122 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Strix</span><span class="disc-momentum">↑ +122 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile otomatik güvenlik taraması</h1>
 <p class="disc-lead">Strix, uygulamalardaki güvenlik açıklarını tespit etmek ve gidermek için tasarlanmış açık kaynaklı bir yapay zekâ tabanlı güvenlik aracıdır (AI security tool). Python diliyle geliştirilen bu sistem, yazılım geliştirme süreçlerinde zafiyet tarama ve düzeltme işlemlerini otomatize eder.</p>
 <ul class="disc-meta"><li>★ 49.097</li><li>Python</li><li>GitHub Trending · 2026-06-29</li></ul>

--- a/discover/supabase/index.html
+++ b/discover/supabase/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Supabase</span><span class="disc-momentum">🚀 +169 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Supabase</span><span class="disc-momentum">↑ +169 bugün</span></div>
 <h1 class="disc-title">Açık kaynaklı Postgres geliştirme platformu</h1>
 <p class="disc-lead">Supabase, web, mobil ve yapay zekâ uygulamaları geliştirmek için Postgres veritabanı (Postgres database) altyapısı sunan bir geliştirme platformudur. Açık kaynaklı yapısıyla uygulama geliştirme süreçlerini hızlandırmak için gerekli olan veritabanı yönetimi ve arka uç (backend) hizmetlerini bir arada sağlar.</p>
 <ul class="disc-meta"><li>★ 107.399</li><li>TypeScript</li><li>GitHub Trending · 2026-07-04</li></ul>

--- a/discover/superfile/index.html
+++ b/discover/superfile/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Superfile</span><span class="disc-momentum">🚀 +338 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Superfile</span><span class="disc-momentum">↑ +338 bugün</span></div>
 <h1 class="disc-title">Terminalde modern dosya yönetimi</h1>
 <p class="disc-lead">Go diliyle geliştirilen superfile, terminal tabanlı dosya yöneticilerine modern ve görsel açıdan zengin bir arayüz kazandırıyor. Kullanıcılar, komut satırı üzerinde dosya işlemlerini daha estetik ve işlevsel bir deneyimle yönetebiliyor.</p>
 <ul class="disc-meta"><li>★ 22.119</li><li>Go</li><li>GitHub Trending · 2026-07-25</li></ul>

--- a/discover/supermemory/index.html
+++ b/discover/supermemory/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Supermemory</span><span class="disc-momentum">🚀 Bir günde +264 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Supermemory</span><span class="disc-momentum">↑ Bir günde +264 yıldız</span></div>
       <h1 class="disc-title">Yapay zekâ için akıllı bellek</h1>
       <p class="disc-lead"><strong>Supermemory</strong>, yapay zekâ çağı için tasarlanmış, yüksek <strong>ölçeklenebilir bir bellek motoru</strong> ve API sunar. Uygulamalarınıza kalıcı ve sorgulanabilir bir hafıza katmanı eklemenizi sağlar.</p>
       <figure class="disc-shot"><img src="/assets/discover/supermemory.webp" width="1440" height="954" loading="lazy" decoding="async" alt="Supermemory arayüzünden bir görünüm"><figcaption>Görsel: supermemory (proje deposundan)</figcaption></figure>

--- a/discover/superpowers/index.html
+++ b/discover/superpowers/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Superpowers</span><span class="disc-momentum">🚀 Bir günde +1.511 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Superpowers</span><span class="disc-momentum">↑ Bir günde +1.511 yıldız</span></div>
       <h1 class="disc-title">Kodlama Ajanları İçin Gelişmiş Metodoloji</h1>
       <p class="disc-lead"><strong>Superpowers</strong>, kodlama ajanlarınız için <strong>bileşik becerilerden</strong> oluşan kapsamlı bir yazılım geliştirme metodolojisidir. Ajan tabanlı iş akışlarını standartlaştırır. Claude Code, Codex CLI, Gemini CLI ve daha fazlasıyla birlikte çalışır.</p>
       <ul class="disc-meta"><li>★ 264.883</li><li>Shell</li><li>MIT</li><li>GitHub Trending · 28 May 2026</li></ul>

--- a/discover/supervision/index.html
+++ b/discover/supervision/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Supervision</span><span class="disc-momentum">🚀 +1.288 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Supervision</span><span class="disc-momentum">↑ +1.288 bugün</span></div>
 <h1 class="disc-title">Bilgisayarlı görü projeleri için araçlar</h1>
 <p class="disc-lead">Roboflow tarafından geliştirilen Supervision, bilgisayarlı görü (computer vision) projeleri için yeniden kullanılabilir yardımcı araçlar ve fonksiyonlar sunuyor. Python tabanlı bu kütüphane, nesne tespiti ve takibi gibi süreçlerdeki standart işlemleri kolaylaştırarak geliştirme iş akışlarını hızlandırıyor.</p>
 <ul class="disc-meta"><li>★ 49.033</li><li>Python</li><li>GitHub Trending · 2026-06-09</li></ul>

--- a/discover/system-design-101/index.html
+++ b/discover/system-design-101/index.html
@@ -58,7 +58,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · System Design 101</span><span class="disc-momentum">🚀 +250 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · System Design 101</span><span class="disc-momentum">↑ +250 bugün</span></div>
 <h1 class="disc-title">Görsellerle sistem tasarımı rehberi</h1>
 <p class="disc-lead">ByteByteGoHq tarafından hazırlanan system-design-101 deposu, karmaşık sistem mimarilerini görselleştirmeler ve sade bir dille açıklıyor. Yazılım mühendisliği mülakatlarına hazırlananlar için sistem tasarımı (system design) kavramlarını temelden ileri seviyeye taşıyan bir kaynak sunuyor.</p>
 <ul class="disc-meta"><li>★ 84.839</li><li>GitHub Trending · 2026-06-29</li></ul>

--- a/discover/system-design-primer/index.html
+++ b/discover/system-design-primer/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · System Design Primer</span><span class="disc-momentum">🚀 +237 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · System Design Primer</span><span class="disc-momentum">↑ +237 bugün</span></div>
 <h1 class="disc-title">Büyük ölçekli sistem tasarımı rehberi</h1>
 <p class="disc-lead">System Design Primer, büyük ölçekli yazılım sistemleri tasarlamak isteyenler için kapsamlı bir öğrenme kaynağı sunuyor. Teknik mülakatlara hazırlanan yazılımcılar için sistem tasarımı (system design) prensiplerini ve pratik çalışma kartlarını bir araya getiriyor.</p>
 <ul class="disc-meta"><li>★ 360.710</li><li>Python</li><li>GitHub Trending · 2026-08-04</li></ul>

--- a/discover/system-prompts-and-models-of-ai-tools/index.html
+++ b/discover/system-prompts-and-models-of-ai-tools/index.html
@@ -58,7 +58,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · System Prompts and Models of AI Tools</span><span class="disc-momentum">🚀 +79 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · System Prompts and Models of AI Tools</span><span class="disc-momentum">↑ +79 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ araçlarının perde arkası</h1>
 <p class="disc-lead">Popüler yapay zekâ araçlarının sistem yönergeleri (system prompts) ve kullanılan dil modelleri (AI models), geliştiricilerin incelemesi için tek bir kaynakta toplanıyor. Bu arşiv, güncel kodlama asistanlarının ve üretken yapay zekâ (generative AI) platformlarının arka planındaki yapılandırma stratejilerini şeffaf bir şekilde ortaya koyuyor.</p>
 <ul class="disc-meta"><li>★ 139.309</li><li>GitHub Trending · 2026-06-10</li></ul>

--- a/discover/system-prompts-leaks/index.html
+++ b/discover/system-prompts-leaks/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · System Prompts Leaks</span><span class="disc-momentum">🚀 +282 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · System Prompts Leaks</span><span class="disc-momentum">↑ +282 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ modellerinin gizli talimatları</h1>
 <p class="disc-lead">GitHub üzerinde paylaşılan system_prompts_leaks deposu, Anthropic, OpenAI, Google ve xAI gibi büyük teknoloji şirketlerinin yapay zekâ modellerine ait sistem istemlerini (system prompts) bir araya getiriyor. Bu derleme, popüler dil modellerinin arka planda çalışan yapılandırma talimatlarını ve kısıtlamalarını incelemek isteyen geliştiriciler için merkezi bir kaynak sunuyor.</p>
 <ul class="disc-meta"><li>★ 61.968</li><li>JavaScript</li><li>GitHub Trending · 2026-06-22</li></ul>

--- a/discover/t3code/index.html
+++ b/discover/t3code/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · T3code</span><span class="disc-momentum">🚀 +75 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · T3code</span><span class="disc-momentum">↑ +75 bugün</span></div>
 <h1 class="disc-title">Kodlama ajanları için web arayüzü</h1>
 <p class="disc-lead">T3Code, TypeScript tabanlı projelerde kod kalitesini artırmak ve standartlaştırmak için geliştirilen bir araç setidir. Geliştiricilere tip güvenliği (type safety) ve kod düzenleme süreçlerinde otomasyon desteği sağlar.</p>
 <ul class="disc-meta"><li>★ 16.312</li><li>TypeScript</li><li>GitHub Trending · 2026-07-13</li></ul>

--- a/discover/tailscale/index.html
+++ b/discover/tailscale/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Tailscale</span><span class="disc-momentum">🚀 +143 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Tailscale</span><span class="disc-momentum">↑ +143 bugün</span></div>
 <h1 class="disc-title">Cihazlar arası güvenli ağ bağlantısı</h1>
 <p class="disc-lead">Tailscale, WireGuard protokolünü iki faktörlü kimlik doğrulama (two-factor authentication) ile birleştirerek güvenli ağ bağlantıları kurmayı kolaylaştırıyor. Go diliyle geliştirilen bu araç, karmaşık ağ yapılandırmalarına ihtiyaç duymadan cihazlar arası şifreli iletişim sağlıyor.</p>
 <ul class="disc-meta"><li>★ 34.858</li><li>Go</li><li>GitHub Trending · 2026-07-11</li></ul>

--- a/discover/tailwindcss/index.html
+++ b/discover/tailwindcss/index.html
@@ -57,7 +57,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Tailwindcss</span><span class="disc-momentum">🚀 +52 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Tailwindcss</span><span class="disc-momentum">↑ +52 bugün</span></div>
 <h1 class="disc-title">Hızlı arayüz tasarımı için stil çatısı</h1>
 <p class="disc-lead">Tailwind CSS, hızlı kullanıcı arayüzü geliştirmeye odaklanan bir yardımcı program öncelikli (utility-first) stil sayfası çatısıdır (CSS framework). Hazır tasarım bileşenleri yerine düşük seviyeli sınıflar sunarak özgün arayüzlerin hızlıca oluşturulmasını sağlar.</p>
 <ul class="disc-meta"><li>★ 96.949</li><li>TypeScript</li><li>GitHub Trending · 2026-08-05</li></ul>

--- a/discover/taste-skill/index.html
+++ b/discover/taste-skill/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Taste Skill</span><span class="disc-momentum">🚀 Bir günde +1.440 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Taste Skill</span><span class="disc-momentum">↑ Bir günde +1.440 yıldız</span></div>
       <h1 class="disc-title">Yapay zekâ Tasarımlarını Profesyonelleştirin</h1>
       <p class="disc-lead">Yapay zekâ ajanları arayüz üretirken çoğu zaman şablon odaklı sonuçlar verir. <strong>Taste Skill</strong>, ajanlara daha etkili <strong>yerleşim, tipografi, hareket ve boşluk</strong> kullanımı öğreten taşınabilir bir beceri setidir. Bu sayede yapay zekâ ile oluşturulan arayüzler çok daha özgün ve profesyonel görünür.</p>
       <figure class="disc-shot"><img src="/assets/discover/taste-skill.webp" width="1440" height="950" loading="lazy" decoding="async" alt="Taste Skill arayüzünden bir görünüm"><figcaption>Görsel: taste-skill (proje deposundan)</figcaption></figure>

--- a/discover/tencentdb-agent-memory/index.html
+++ b/discover/tencentdb-agent-memory/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · TencentDB-Agent-Memory</span><span class="disc-momentum">🚀 +318 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · TencentDB-Agent-Memory</span><span class="disc-momentum">↑ +318 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanları için katmanlı bellek</h1>
 <p class="disc-lead">TencentDB Agent Memory, yapay zekâ ajanları için dört aşamalı bir süreçle tamamen yerel uzun süreli bellek (long-term memory) çözümü sunuyor. Dış kaynaklı uygulama programlama arayüzlerine (API) ihtiyaç duymadan veri saklama ve geri çağırma işlemlerini gerçekleştiriyor.</p>
 <ul class="disc-meta"><li>★ 15.363</li><li>TypeScript</li><li>GitHub Trending · 2026-07-09</li></ul>

--- a/discover/terax-ai/index.html
+++ b/discover/terax-ai/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Terax AI</span><span class="disc-momentum">🚀 +62 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Terax AI</span><span class="disc-momentum">↑ +62 bugün</span></div>
 <h1 class="disc-title">Terminal odaklı yapay zekâ geliştirme ortamı</h1>
 <p class="disc-lead">Terax-ai, terminal odaklı yapay zekâ yerel geliştirme ortamı (AI-native dev workspace) olarak 7 megabaytlık düşük boyutlu yapısıyla dikkat çekiyor. TypeScript ile geliştirilen bu araç, geliştiricilere terminal üzerinden doğrudan yapay zekâ destekli kodlama imkânı sunuyor.</p>
 <ul class="disc-meta"><li>★ 8.790</li><li>TypeScript</li><li>GitHub Trending · 2026-07-05</li></ul>

--- a/discover/terminal/index.html
+++ b/discover/terminal/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Terminal</span><span class="disc-momentum">🚀 +59 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Terminal</span><span class="disc-momentum">↑ +59 bugün</span></div>
 <h1 class="disc-title">Modern Windows komut satırı deneyimi</h1>
 <p class="disc-lead">Microsoft, Windows Terminal ve geleneksel Windows konsol ana bilgisayarını (console host) tek bir çatı altında birleştiriyor. C++ diliyle geliştirilen bu açık kaynaklı proje, komut satırı deneyimini modern arayüz ve özelleştirilebilir sekmelerle yeniden yapılandırıyor.</p>
 <ul class="disc-meta"><li>★ 104.442</li><li>C++</li><li>GitHub Trending · 2026-07-20</li></ul>

--- a/discover/terraform/index.html
+++ b/discover/terraform/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Terraform</span><span class="disc-momentum">🚀 +172 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Terraform</span><span class="disc-momentum">↑ +172 bugün</span></div>
 <h1 class="disc-title">Altyapınızı kod ile yönetin</h1>
 <p class="disc-lead">HashiCorp tarafından geliştirilen Terraform, altyapıyı kod olarak (infrastructure as code) tanımlayarak güvenli ve öngörülebilir şekilde oluşturulmasına olanak tanır. Go diliyle yazılan bu araç, uygulama programlama arayüzlerini (API) bildirimsel yapılandırma dosyalarına dönüştürerek ekiplerin altyapı süreçlerini sürüm kontrolü altında yönetmesini sağlar.</p>
 <ul class="disc-meta"><li>★ 49.375</li><li>Go</li><li>GitHub Trending · 2026-07-11</li></ul>

--- a/discover/teslamate/index.html
+++ b/discover/teslamate/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Teslamate</span><span class="disc-momentum">🚀 +33 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Teslamate</span><span class="disc-momentum">↑ +33 bugün</span></div>
 <h1 class="disc-title">Tesla verilerinizi kendi sunucunuzda izleyin</h1>
 <p class="disc-lead">Tesla araç sahipleri için geliştirilen Teslamate, verileri kendi sunucunuzda barındırmanıza olanak tanıyan bir veri kaydedici (data logger) uygulamasıdır. Elixir diliyle yazılan bu açık kaynaklı araç, sürüş geçmişi ve şarj verileri gibi detaylı istatistikleri görselleştirerek kullanıcıya sunar.</p>
 <ul class="disc-meta"><li>★ 8.798</li><li>Elixir</li><li>GitHub Trending · 2026-06-16</li></ul>

--- a/discover/text-to-cad/index.html
+++ b/discover/text-to-cad/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Text to Cad</span><span class="disc-momentum">🚀 +291 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Text to Cad</span><span class="disc-momentum">↑ +291 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile otomatik tasarım</h1>
 <p class="disc-lead">Metinden bilgisayar destekli tasarım (text-to-cad) araçları, robotik ve donanım tasarımı süreçlerini otomatikleştirmek için geliştirilen bir yetenek paketi (agent skills) koleksiyonudur. JavaScript tabanlı bu kütüphane, karmaşık mühendislik modellerinin doğal dil komutlarıyla oluşturulmasına olanak tanır.</p>
 <ul class="disc-meta"><li>★ 12.478</li><li>JavaScript</li><li>GitHub Trending · 2026-07-22</li></ul>

--- a/discover/timesfm/index.html
+++ b/discover/timesfm/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Timesfm</span><span class="disc-momentum">🚀 +606 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Timesfm</span><span class="disc-momentum">↑ +606 bugün</span></div>
 <h1 class="disc-title">Zaman serileri için yapay zekâ tahminleme</h1>
 <p class="disc-lead">Google Research tarafından geliştirilen Zaman Serisi Temel Modeli (Time Series Foundation Model), zaman serisi tahminleme işlemleri için önceden eğitilmiş bir yapı sunuyor. Model, farklı veri setleri üzerinde genel tahminleme yetenekleri sağlamak amacıyla tasarlanmıştır.</p>
 <ul class="disc-meta"><li>★ 27.185</li><li>Python</li><li>GitHub Trending · 2026-06-18</li></ul>

--- a/discover/tolaria/index.html
+++ b/discover/tolaria/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Tolaria</span><span class="disc-momentum">🚀 +245 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Tolaria</span><span class="disc-momentum">↑ +245 bugün</span></div>
 <h1 class="disc-title">Markdown bilgi tabanı masaüstü uygulaması</h1>
 <p class="disc-lead">Tolaria, Markdown tabanlı bilgi tabanlarını yönetmek için geliştirilen bir masaüstü uygulamasıdır. TypeScript ile yazılan bu araç, kişisel dokümantasyon ve not sistemlerini düzenli bir yapıda tutmayı kolaylaştırır.</p>
 <ul class="disc-meta"><li>★ 19.219</li><li>TypeScript</li><li>GitHub Trending · 2026-06-08</li></ul>

--- a/discover/topcoat/index.html
+++ b/discover/topcoat/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Topcoat</span><span class="disc-momentum">🚀 +371 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Topcoat</span><span class="disc-momentum">↑ +371 bugün</span></div>
 <h1 class="disc-title">Rust ile tam kapsamlı web uygulamaları</h1>
 <p class="disc-lead">Tokio ekibi tarafından geliştirilen Topcoat, Rust dilinde web uygulamaları oluşturmak için gerekli tüm araçları barındıran kapsamlı bir çatı (framework) sunuyor. Geliştiricilerin ihtiyaç duyduğu temel bileşenleri tek bir yapıda toplayarak uygulama geliştirme sürecini standartlaştırmayı hedefliyor.</p>
 <ul class="disc-meta"><li>★ 4.127</li><li>Rust</li><li>GitHub Trending · 2026-07-21</li></ul>

--- a/discover/tradingview-mcp/index.html
+++ b/discover/tradingview-mcp/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Tradingview MCP</span><span class="disc-momentum">🚀 +114 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Tradingview MCP</span><span class="disc-momentum">↑ +114 bugün</span></div>
 <h1 class="disc-title">TradingView için yapay zekâ entegrasyonu</h1>
 <p class="disc-lead">TradingView-mcp, Claude Code ile TradingView masaüstü uygulamasını birbirine bağlayarak grafik analiz süreçlerini otomatize etmeyi sağlıyor. Bu entegrasyon, kullanıcıların yapay zekâ destekli model bağlamı (Model Context Protocol) üzerinden teknik analiz iş akışlarını kişiselleştirmesine olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 4.930</li><li>JavaScript</li><li>GitHub Trending · 2026-07-22</li></ul>

--- a/discover/train-llm-from-scratch/index.html
+++ b/discover/train-llm-from-scratch/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Train LLM from Scratch</span><span class="disc-momentum">🚀 Bir günde +316 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Train LLM from Scratch</span><span class="disc-momentum">↑ Bir günde +316 yıldız</span></div>
       <h1 class="disc-title">Sıfırdan Kendi LLM Modelini Eğit</h1>
       <p class="disc-lead"><strong>train-llm-from-scratch</strong>, veri setini indirme aşamasından metin üretimine kadar bir <strong>büyük dil modelini sıfırdan eğitmenin</strong> sade ve adım adım yöntemini sunar. Öğrenme süreciniz için pratik bir kaynaktır.</p>
       <ul class="disc-meta"><li>★ 8.864</li><li>Jupyter Notebook</li><li>MIT</li><li>GitHub Trending · 30 May 2026</li></ul>

--- a/discover/transcribe-cpp/index.html
+++ b/discover/transcribe-cpp/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Transcribe.cpp</span><span class="disc-momentum">🚀 +395 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Transcribe.cpp</span><span class="disc-momentum">↑ +395 bugün</span></div>
 <h1 class="disc-title">Yerel sistemlerde hızlı konuşma dönüştürme</h1>
 <p class="disc-lead">Transcribe.cpp, 16&#x27;dan fazla model ailesini destekleyen ve C++ diliyle geliştirilen bir konuşmayı metne dönüştürme (speech-to-text) çıkarım (inference) kütüphanesidir. Ggml altyapısını kullanan bu araç, farklı ses işleme modellerinin yerel sistemlerde verimli bir şekilde çalıştırılmasını sağlar.</p>
 <ul class="disc-meta"><li>★ 1.673</li><li>C++</li><li>GitHub Trending · 2026-07-21</li></ul>

--- a/discover/trellis-2/index.html
+++ b/discover/trellis-2/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · TRELLIS.2</span><span class="disc-momentum">🚀 +107 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · TRELLIS.2</span><span class="disc-momentum">↑ +107 bugün</span></div>
 <h1 class="disc-title">Görsellerden yüksek kaliteli 3D modeller üretin</h1>
 <p class="disc-lead">Microsoft tarafından geliştirilen TRELLIS, metin veya görsel girdilerini üç boyutlu (3D) modellere dönüştüren bir yapısal gizli temsil (structured latent) mimarisi. Bu teknoloji, yüksek kaliteli 3D varlıkları hızlı ve kompakt bir şekilde oluşturmak için üretken yapay zekâ (generative AI) yöntemlerini kullanıyor.</p>
 <ul class="disc-meta"><li>★ 9.992</li><li>Python</li><li>GitHub Trending · 2026-08-02</li></ul>

--- a/discover/trivy/index.html
+++ b/discover/trivy/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Trivy</span><span class="disc-momentum">🚀 +24 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Trivy</span><span class="disc-momentum">↑ +24 bugün</span></div>
 <h1 class="disc-title">Konteyner ve bulut güvenlik tarayıcısı</h1>
 <p class="disc-lead">Trivy, konteynerler, Kubernetes kümeleri ve bulut altyapılarındaki güvenlik açıklarını, hatalı yapılandırmaları ve gizli anahtarları (secrets) tespit eden kapsamlı bir güvenlik tarama aracıdır. Yazılım malzeme listesi (SBOM) oluşturma yeteneğiyle geliştirme süreçlerinde güvenlik denetimlerini otomatize eder.</p>
 <ul class="disc-meta"><li>★ 35.511</li><li>Go</li><li>GitHub Trending · 2026-06-04</li></ul>

--- a/discover/tuicr/index.html
+++ b/discover/tuicr/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Tuicr</span><span class="disc-momentum">🚀 +190 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Tuicr</span><span class="disc-momentum">↑ +190 bugün</span></div>
 <h1 class="disc-title">Terminalde Vim ile kod inceleme</h1>
 <p class="disc-lead">Rust diliyle geliştirilen tuicr, Vim klavye kısayollarını destekleyen bir uçbirim kullanıcı arayüzü (terminal user interface) tabanlı kod inceleme (code review) aracıdır. Geliştiricilerin kod gözden geçirme süreçlerini doğrudan terminal üzerinden yönetmelerine olanak tanır.</p>
 <ul class="disc-meta"><li>★ 2.439</li><li>Rust</li><li>GitHub Trending · 2026-07-31</li></ul>

--- a/discover/turbovec/index.html
+++ b/discover/turbovec/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Turbovec</span><span class="disc-momentum">🚀 +1.554 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Turbovec</span><span class="disc-momentum">↑ +1.554 bugün</span></div>
 <h1 class="disc-title">Rust ile yüksek performanslı vektör dizini</h1>
 <p class="disc-lead">TurboQuant altyapısı üzerine inşa edilen turbovec, Rust diliyle geliştirilmiş yüksek performanslı bir vektör dizini (vector index) aracıdır. Python bağlamaları (bindings) sayesinde geliştiricilerin vektör tabanlı arama işlemlerini hızlı ve verimli bir şekilde gerçekleştirmesine olanak tanır.</p>
 <ul class="disc-meta"><li>★ 14.575</li><li>Python</li><li>GitHub Trending · 2026-06-08</li></ul>

--- a/discover/turso/index.html
+++ b/discover/turso/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Turso</span><span class="disc-momentum">🚀 +801 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Turso</span><span class="disc-momentum">↑ +801 bugün</span></div>
 <h1 class="disc-title">SQLite uyumlu süreç içi veritabanı</h1>
 <p class="disc-lead">Turso, SQLite ile uyumlu çalışan ve süreç içi (in-process) bir SQL veritabanı sunuyor. Rust diliyle geliştirilen bu sistem, uygulama süreçlerine entegre edilerek veri yönetimi süreçlerini basitleştiriyor.</p>
 <ul class="disc-meta"><li>★ 23.620</li><li>Rust</li><li>GitHub Trending · 2026-06-21</li></ul>

--- a/discover/twenty/index.html
+++ b/discover/twenty/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Twenty</span><span class="disc-momentum">🚀 Bir günde +237 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Twenty</span><span class="disc-momentum">↑ Bir günde +237 yıldız</span></div>
       <h1 class="disc-title">Modern ve Açık Kaynaklı CRM</h1>
       <p class="disc-lead"><strong>Twenty</strong>, teknik ekiplere iş süreçlerine göre özelleştirilebilir modern bir CRM kurma imkânı veren açık kaynaklı bir <strong>Salesforce alternatifidir</strong>. Yapay zekâ destekli iş akışlarına odaklanan bu sistemi kendi sunucunuzda barındırabilirsiniz.</p>
       <ul class="disc-meta"><li>★ 54.367</li><li>TypeScript</li><li>Lisans: özel</li><li>GitHub Trending · 26 May 2026</li></ul>

--- a/discover/typescript/index.html
+++ b/discover/typescript/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · TypeScript</span><span class="disc-momentum">🚀 +177 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · TypeScript</span><span class="disc-momentum">↑ +177 bugün</span></div>
 <h1 class="disc-title">JavaScript projeleri için hata denetimi</h1>
 <p class="disc-lead">JavaScript dilinin bir üst kümesi (superset) olan TypeScript, kodun derleme aşamasında hata denetimi yapılmasına olanak tanıyor. Statik tip tanımlama (static typing) özelliğiyle daha güvenilir ve ölçeklenebilir yazılım geliştirme süreçlerini destekliyor.</p>
 <ul class="disc-meta"><li>★ 110.042</li><li>TypeScript</li><li>GitHub Trending · 2026-07-11</li></ul>

--- a/discover/u3-sdk/index.html
+++ b/discover/u3-sdk/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · U3 SDK</span><span class="disc-momentum">🚀 +524 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · U3 SDK</span><span class="disc-momentum">↑ +524 bugün</span></div>
 <h1 class="disc-title">Unturned oyununu özelleştirin</h1>
 <p class="disc-lead">SmartlyDressedGames, açık dünya zombi hayatta kalma oyunu Unturned için geliştirilen U3-SDK yazılım geliştirme kitini (software development kit) açık kaynak olarak paylaştı. C# diliyle hazırlanan bu kaynak kodlar, topluluk üyelerinin oyun üzerinde özelleştirme ve geliştirme yapmasına olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 3.324</li><li>C#</li><li>GitHub Trending · 2026-07-10</li></ul>

--- a/discover/ui-skills/index.html
+++ b/discover/ui-skills/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · UI Skills</span><span class="disc-momentum">🚀 +178 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · UI Skills</span><span class="disc-momentum">↑ +178 bugün</span></div>
 <h1 class="disc-title">Tasarım mühendisleri için arayüz becerileri</h1>
 <p class="disc-lead">Tasarım mühendisleri için geliştirilen ui-skills, kullanıcı arayüzü (UI) geliştirme süreçlerinde ihtiyaç duyulan teknik becerileri ve yetkinlikleri bir araya getiriyor. TypeScript tabanlı bu kaynak, arayüz tasarımından kodlamaya geçiş yapan profesyoneller için bir yetkinlik haritası sunuyor.</p>
 <ul class="disc-meta"><li>★ 6.838</li><li>TypeScript</li><li>GitHub Trending · 2026-07-17</li></ul>

--- a/discover/ui-tars-desktop/index.html
+++ b/discover/ui-tars-desktop/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · UI-TARS-desktop</span><span class="disc-momentum">🚀 +150 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · UI-TARS-desktop</span><span class="disc-momentum">↑ +150 bugün</span></div>
 <h1 class="disc-title">Bilgisayarınızı yöneten yapay zekâ arayüzü</h1>
 <p class="disc-lead">ByteDance tarafından geliştirilen UI-TARS, çok modlu yapay zekâ modellerini (multimodal AI models) masaüstü arayüzleriyle entegre eden açık kaynaklı bir ajan altyapısıdır. Bu sistem, görsel verileri işleyerek bilgisayar üzerindeki görevleri otonom şekilde gerçekleştiren ajanların (AI agents) oluşturulmasını sağlar.</p>
 <ul class="disc-meta"><li>★ 38.404</li><li>TypeScript</li><li>GitHub Trending · 2026-06-18</li></ul>

--- a/discover/unciv/index.html
+++ b/discover/unciv/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Unciv</span><span class="disc-momentum">🚀 +24 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Unciv</span><span class="disc-momentum">↑ +24 bugün</span></div>
 <h1 class="disc-title">Hafif ve açık kaynaklı strateji oyunu</h1>
 <p class="disc-lead">Unciv, Civilization V oyununun açık kaynak kodlu bir masaüstü ve Android uyarlamasıdır. Kotlin diliyle geliştirilen proje, orijinal oyun mekaniklerini daha hafif bir altyapı üzerinde kullanıcılarla buluşturuyor.</p>
 <ul class="disc-meta"><li>★ 11.043</li><li>Kotlin</li><li>GitHub Trending · 2026-06-18</li></ul>

--- a/discover/understand-anything/index.html
+++ b/discover/understand-anything/index.html
@@ -58,7 +58,7 @@
 
       <div class="disc-top">
         <span class="disc-eyebrow">Keşif · GitHub · Understand Anything</span>
-        <span class="disc-momentum">🚀 Bir günde 4.721 yıldız</span>
+        <span class="disc-momentum">↑ Bir günde 4.721 yıldız</span>
       </div>
 
       <h1 class="disc-title">Kodlarınızı yapay zekâyla Sorgulayın</h1>

--- a/discover/unity-mcp/index.html
+++ b/discover/unity-mcp/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Unity MCP</span><span class="disc-momentum">🚀 +69 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Unity MCP</span><span class="disc-momentum">↑ +69 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile unity yönetimi</h1>
 <p class="disc-lead">Unity MCP, büyük dil modelleri (large language models) ile Unity düzenleyicisi arasında bir köprü kurarak varlık yönetimi, sahne kontrolü ve kod düzenleme süreçlerinin otomatize edilmesini sağlıyor. Model Sunucu Protokolü (Model Context Protocol) aracılığıyla çalışan bu araç, yapay zekâ asistanlarının oyun geliştirme iş akışlarına doğrudan müdahale etmesine imkân tanıyor.</p>
 <ul class="disc-meta"><li>★ 13.091</li><li>C#</li><li>GitHub Trending · 2026-07-05</li></ul>

--- a/discover/universal-android-debloater-next-generation/index.html
+++ b/discover/universal-android-debloater-next-generation/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Universal Android Debloater Next Generation</span><span class="disc-momentum">🚀 +146 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Universal Android Debloater Next Generation</span><span class="disc-momentum">↑ +146 bugün</span></div>
 <h1 class="disc-title">Android cihazınızdaki gereksiz uygulamaları temizleyin</h1>
 <p class="disc-lead">Universal Android Debloater Next Generation, kök dizin erişimi (root) gerektirmeyen Android cihazlardaki gereksiz uygulamaları kaldırmak için Rust diliyle geliştirilmiş çapraz platform bir grafik arayüzüdür. Araç, Android Hata Ayıklama Köprüsü (ADB) kullanarak cihazın gizlilik, güvenlik ve pil ömrü performansını iyileştirmeyi amaçlar.</p>
 <ul class="disc-meta"><li>★ 8.660</li><li>Rust</li><li>GitHub Trending · 2026-06-17</li></ul>

--- a/discover/veracrypt/index.html
+++ b/discover/veracrypt/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · VeraCrypt</span><span class="disc-momentum">🚀 +186 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · VeraCrypt</span><span class="disc-momentum">↑ +186 bugün</span></div>
 <h1 class="disc-title">Güçlü disk şifreleme aracı</h1>
 <p class="disc-lead">VeraCrypt, TrueCrypt temel alınarak geliştirilen ve güçlü güvenlik standartları sunan bir disk şifreleme (disk encryption) aracıdır. C diliyle yazılan bu açık kaynaklı yazılım, verilerin güvenliğini sağlamak için çeşitli şifreleme algoritmaları ve kimlik doğrulama yöntemleri kullanır.</p>
 <ul class="disc-meta"><li>★ 10.906</li><li>C</li><li>GitHub Trending · 2026-06-30</li></ul>

--- a/discover/vibe-trading/index.html
+++ b/discover/vibe-trading/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Vibe-Trading</span><span class="disc-momentum">🚀 +197 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Vibe-Trading</span><span class="disc-momentum">↑ +197 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile kişisel alım satım</h1>
 <p class="disc-lead">Vibe-Trading, finansal piyasalarda işlem yapmak amacıyla geliştirilmiş kişisel bir alım satım ajanı (trading agent) sunuyor. Proje, Python tabanlı yapısıyla kullanıcıların otomatik ticaret stratejilerini yönetmelerine olanak tanıyor.</p>
 <ul class="disc-meta"><li>★ 29.309</li><li>Python</li><li>GitHub Trending · 2026-06-04</li></ul>

--- a/discover/video-use/index.html
+++ b/discover/video-use/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Video Use</span><span class="disc-momentum">🚀 +196 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Video Use</span><span class="disc-momentum">↑ +196 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile otomatik video düzenleme</h1>
 <p class="disc-lead">Video-use kütüphanesi, kodlama ajanlarının (coding agents) video düzenleme süreçlerini otomatize etmesine olanak tanıyor. Python tabanlı bu araç, görsel düzenleme görevlerini yazılım komutları aracılığıyla yerine getirerek iş akışlarını hızlandırıyor.</p>
 <ul class="disc-meta"><li>★ 19.784</li><li>Python</li><li>GitHub Trending · 2026-06-29</li></ul>

--- a/discover/voice-pro/index.html
+++ b/discover/voice-pro/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Voice Pro</span><span class="disc-momentum">🚀 +58 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Voice Pro</span><span class="disc-momentum">↑ +58 bugün</span></div>
 <h1 class="disc-title">Metinden konuşmaya ve ses kopyalama</h1>
 <p class="disc-lead">Voice-pro, metinden konuşmaya dönüştürme (TTS) ve sıfır örnekli ses kopyalama (zero-shot voice cloning) araçlarını bir araya getiren açık kaynaklı bir arayüzdür. Kullanıcılar, web tabanlı arayüzü üzerinden ses ayrıştırma, çok dilli çeviri ve YouTube içeriklerini işleme gibi işlemleri tek bir platformda gerçekleştirebilir.</p>
 <ul class="disc-meta"><li>★ 11.965</li><li>Python</li><li>GitHub Trending · 2026-08-02</li></ul>

--- a/discover/voicebox/index.html
+++ b/discover/voicebox/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Voicebox</span><span class="disc-momentum">🚀 +145 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Voicebox</span><span class="disc-momentum">↑ +145 bugün</span></div>
 <h1 class="disc-title">Yerel ortamda çalışan yapay zekâ ses stüdyosu</h1>
 <p class="disc-lead">Voicebox, kullanıcıların ses kopyalama (voice cloning), dikte ve içerik oluşturma işlemlerini gerçekleştirmesine olanak tanıyan açık kaynaklı bir yapay zekâ ses stüdyosudur. TypeScript diliyle geliştirilen bu platform, ses işleme süreçlerini yerel ortamda yönetmek için kapsamlı araçlar sunar.</p>
 <ul class="disc-meta"><li>★ 48.096</li><li>TypeScript</li><li>GitHub Trending · 2026-06-21</li></ul>

--- a/discover/voxcpm/index.html
+++ b/discover/voxcpm/index.html
@@ -58,7 +58,7 @@
   <main id="main">
     <article class="disc">
       <a class="disc-back" href="/discover/">← Keşif</a>
-      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · VoxCPM</span><span class="disc-momentum">🚀 Bir günde +658 yıldız</span></div>
+      <div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · VoxCPM</span><span class="disc-momentum">↑ Bir günde +658 yıldız</span></div>
       <h1 class="disc-title">Belirteçsiz Çok Dilli Ses Tasarımı</h1>
       <p class="disc-lead"><strong>VoxCPM</strong>; çok dilli konuşma üretimi, yaratıcı <strong>ses tasarımı</strong> ve gerçekçi <strong>ses kopyalama (voice cloning)</strong> işlemleri için geliştirilmiş, belirteçsiz (tokenizer-free) açık kaynak bir TTS modelidir.</p>
       <ul class="disc-meta"><li>★ 34.774</li><li>Python</li><li>Apache-2.0</li><li>GitHub Trending · 30 May 2026</li></ul>

--- a/discover/vulnclaw/index.html
+++ b/discover/vulnclaw/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · VulnClaw</span><span class="disc-momentum">🚀 +129 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · VulnClaw</span><span class="disc-momentum">↑ +129 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile otomatik sızma testi</h1>
 <p class="disc-lead">VulnClaw, yapay zekâ ajanları (AI agents) ve model bağlam protokolü (Model Context Protocol) araç zincirini kullanarak sızma testi süreçlerini otomatize ediyor. Araç, doğal dil komutlarını işleyerek bilgi toplama, zafiyet tarama, istismar ve raporlama adımlarını uçtan uca gerçekleştiriyor.</p>
 <ul class="disc-meta"><li>★ 2.575</li><li>Python</li><li>GitHub Trending · 2026-06-30</li></ul>

--- a/discover/wand-enhancer/index.html
+++ b/discover/wand-enhancer/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Wand-Enhancer</span><span class="disc-momentum">🚀 +609 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Wand-Enhancer</span><span class="disc-momentum">↑ +609 bugün</span></div>
 <h1 class="disc-title">Wand uygulaması için arayüz özelleştirme</h1>
 <p class="disc-lead">Wand-Enhancer, WeMod uygulaması için kullanıcı deneyimini (user experience) geliştiren ve birlikte çalışabilirliği (interoperability) artıran bir C# tabanlı eklentidir. Uygulamanın işlevselliğini genişleterek kullanıcıların araçlar üzerindeki kontrolünü optimize eder.</p>
 <ul class="disc-meta"><li>★ 14.159</li><li>C#</li><li>GitHub Trending · 2026-07-13</li></ul>

--- a/discover/webpack/index.html
+++ b/discover/webpack/index.html
@@ -57,7 +57,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Webpack</span><span class="disc-momentum">🚀 +10 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Webpack</span><span class="disc-momentum">↑ +10 bugün</span></div>
 <h1 class="disc-title">Web projeleri için modül paketleyici</h1>
 <p class="disc-lead">Webpack, JavaScript ve diğer web varlıklarını tarayıcıda çalışacak şekilde bir araya getiren bir paketleyici (bundler). Modülleri yönetilebilir parçalara ayıran kod bölme (code splitting) özelliği sayesinde uygulamaların ihtiyaç duyulduğunda yüklenmesini sağlar.</p>
 <ul class="disc-meta"><li>★ 65.985</li><li>JavaScript</li><li>GitHub Trending · 2026-08-05</li></ul>

--- a/discover/website-downloader/index.html
+++ b/discover/website-downloader/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Website-downloader</span><span class="disc-momentum">🚀 +140 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Website-downloader</span><span class="disc-momentum">↑ +140 bugün</span></div>
 <h1 class="disc-title">Web sitelerini yerel diske indirin</h1>
 <p class="disc-lead">AhmadIbrahiim tarafından geliştirilen Website-downloader, Node.js kullanarak bir web sitesinin tüm kaynak kodlarını ve varlıklarını (assets) yerel bilgisayara indirmeye olanak tanıyor. Araç, JavaScript dosyaları, stil sayfaları ve görseller dahil olmak üzere sitenin tamamını arşivlemek için kullanılıyor.</p>
 <ul class="disc-meta"><li>★ 4.223</li><li>HTML</li><li>GitHub Trending · 2026-07-08</li></ul>

--- a/discover/whichllm/index.html
+++ b/discover/whichllm/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Whichllm</span><span class="disc-momentum">🚀 +143 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Whichllm</span><span class="disc-momentum">↑ +143 bugün</span></div>
 <h1 class="disc-title">Donanımınıza En Uygun yapay zekâ Modelini Bulun</h1>
 <p class="disc-lead">Whichllm, donanımınız üzerinde en yüksek performansı gösteren yerel büyük dil modellerini (large language models) belirlemenizi sağlayan bir araçtır. Parametre sayısından ziyade güncel kıyaslama testlerine (benchmarks) odaklanan bu Python tabanlı yazılım, tek komutla en uygun modeli seçmenize olanak tanır.</p>
 <ul class="disc-meta"><li>★ 6.101</li><li>Python</li><li>GitHub Trending · 2026-06-09</li></ul>

--- a/discover/whisper/index.html
+++ b/discover/whisper/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Whisper</span><span class="disc-momentum">🚀 +150 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Whisper</span><span class="disc-momentum">↑ +150 bugün</span></div>
 <h1 class="disc-title">Sesleri yapay zekâ ile yazıya dökün</h1>
 <p class="disc-lead">OpenAI tarafından geliştirilen Whisper, geniş ölçekli zayıf denetimli öğrenme (weak supervision) yöntemiyle eğitilmiş bir konuşma tanıma (speech recognition) modelidir. Çok dilli ses verilerini metne dönüştürme ve çeviri yapma süreçlerinde yüksek doğruluk oranları sunar.</p>
 <ul class="disc-meta"><li>★ 106.452</li><li>Python</li><li>GitHub Trending · 2026-06-07</li></ul>

--- a/discover/wigolo/index.html
+++ b/discover/wigolo/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Wigolo</span><span class="disc-momentum">🚀 +203 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Wigolo</span><span class="disc-momentum">↑ +203 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ajanınıza yerel web yetenekleri</h1>
 <p class="disc-lead">Wigolo, yapay zekâ kodlama ajanları için yerel öncelikli (local-first) arama, veri çekme ve tarama yetenekleri sunan bir araçtır. Model bağlamı protokolü (MCP) üzerinden çalışan bu sistem, bulut bağımlılığı olmadan ve API anahtarı gerektirmeden ücretsiz araştırma imkânı sağlar.</p>
 <ul class="disc-meta"><li>★ 4.069</li><li>TypeScript</li><li>GitHub Trending · 2026-07-19</li></ul>

--- a/discover/worldmonitor/index.html
+++ b/discover/worldmonitor/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Worldmonitor</span><span class="disc-momentum">🚀 +156 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Worldmonitor</span><span class="disc-momentum">↑ +156 bugün</span></div>
 <h1 class="disc-title">Gerçek zamanlı küresel istihbarat paneli</h1>
 <p class="disc-lead">Worldmonitor, yapay zekâ destekli haber derleme ve jeopolitik izleme özelliklerini tek bir arayüzde birleştiren gerçek zamanlı bir küresel istihbarat paneli (global intelligence dashboard) sunuyor. Altyapı takibi ve durum farkındalığı (situational awareness) sağlayan bu araç, karmaşık veri akışlarını görselleştirerek analiz süreçlerini kolaylaştırıyor.</p>
 <ul class="disc-meta"><li>★ 78.032</li><li>TypeScript</li><li>GitHub Trending · 2026-06-20</li></ul>

--- a/discover/wrenai/index.html
+++ b/discover/wrenai/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · WrenAI</span><span class="disc-momentum">🚀 +121 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · WrenAI</span><span class="disc-momentum">↑ +121 bugün</span></div>
 <h1 class="disc-title">Yapay zekâ ile otomatik iş zekâsı</h1>
 <p class="disc-lead">Canner tarafından geliştirilen WrenAI, doğal dili veritabanı sorgularına (text-to-SQL) dönüştürerek verileri otomatik olarak panellere ve grafiklere aktaran açık kaynaklı bir üretken iş zekası (generative BI) aracıdır. Platform, yirmiden fazla veri kaynağını destekleyen yönetilebilir bir bağlam katmanı üzerinden yapay zekâ ajanları için güvenilir veri analitiği süreçleri sunar.</p>
 <ul class="disc-meta"><li>★ 17.046</li><li>Python</li><li>GitHub Trending · 2026-07-20</li></ul>

--- a/discover/yaml-cpp/index.html
+++ b/discover/yaml-cpp/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · YAML Cpp</span><span class="disc-momentum">🚀 +69 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · YAML Cpp</span><span class="disc-momentum">↑ +69 bugün</span></div>
 <h1 class="disc-title">C++ projeleri için YAML yönetimi</h1>
 <p class="disc-lead">yaml-cpp, C++ programlama dili için YAML formatındaki verileri ayrıştıran (parser) ve oluşturan (emitter) bir kütüphanedir. Yazılım geliştiricilerin yapılandırma dosyalarını yönetmesine ve veri serileştirme (serialization) işlemlerini gerçekleştirmesine olanak tanır.</p>
 <ul class="disc-meta"><li>★ 6.113</li><li>C++</li><li>GitHub Trending · 2026-07-11</li></ul>

--- a/discover/yimmenuv2/index.html
+++ b/discover/yimmenuv2/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · YimMenuV2</span><span class="disc-momentum">🚀 +38 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · YimMenuV2</span><span class="disc-momentum">↑ +38 bugün</span></div>
 <h1 class="disc-title">Grand Theft Auto 5 için deneysel mod menüsü</h1>
 <p class="disc-lead">YimMenuV2, Grand Theft Auto 5: Enhanced sürümü için geliştirilen deneysel bir menü modifikasyonudur. C++ diliyle yazılan bu araç, oyun içerisinde çeşitli özelleştirmeler ve genişletilmiş işlevler (features) sunar.</p>
 <ul class="disc-meta"><li>★ 1.612</li><li>C++</li><li>GitHub Trending · 2026-07-16</li></ul>

--- a/discover/zapret-discord-youtube/index.html
+++ b/discover/zapret-discord-youtube/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Zapret Discord Youtube</span><span class="disc-momentum">🚀 +61 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Zapret Discord Youtube</span><span class="disc-momentum">↑ +61 bugün</span></div>
 <h1 class="disc-title">Kısıtlı platformlara erişim sağlayan araç</h1>
 <p class="disc-lead">Zapret-discord-youtube, ağ trafiğini şifreleyerek veya paket parçalama (packet fragmentation) yöntemlerini kullanarak kısıtlı platformlara erişim sağlamayı hedefleyen bir araçtır. Özellikle Discord ve YouTube gibi hizmetlere yönelik erişim engellerini aşmak amacıyla geliştirilmiştir.</p>
 <ul class="disc-meta"><li>★ 31.660</li><li>Batchfile</li><li>GitHub Trending · 2026-06-25</li></ul>

--- a/discover/zhangxuefeng-skill/index.html
+++ b/discover/zhangxuefeng-skill/index.html
@@ -58,7 +58,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Zhangxuefeng Skill</span><span class="disc-momentum">🚀 +89 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Zhangxuefeng Skill</span><span class="disc-momentum">↑ +89 bugün</span></div>
 <h1 class="disc-title">Kariyer ve üniversite tercihi rehberi</h1>
 <p class="disc-lead">Zhangxuefeng-skill, üniversite sınavı tercihleri, lisansüstü eğitim ve kariyer planlama süreçleri için yapılandırılmış bir bilişsel işletim sistemi (cognitive operating system) sunuyor. Nuwa.skill altyapısıyla oluşturulan bu proje, karmaşık karar verme süreçlerini pratik bir düşünce çerçevesi (thought framework) ile standartlaştırıyor.</p>
 <ul class="disc-meta"><li>★ 10.048</li><li>GitHub Trending · 2026-06-12</li></ul>

--- a/discover/zvec/index.html
+++ b/discover/zvec/index.html
@@ -59,7 +59,7 @@
 <main id="main">
 <article class="disc">
 <a class="disc-back" href="/discover/">← Keşif</a>
-<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Zvec</span><span class="disc-momentum">🚀 +156 bugün</span></div>
+<div class="disc-top"><span class="disc-eyebrow">Keşif · GitHub · Zvec</span><span class="disc-momentum">↑ +156 bugün</span></div>
 <h1 class="disc-title">Hızlı uygulama içi vektör veritabanı</h1>
 <p class="disc-lead">Alibaba tarafından geliştirilen zvec, C++ diliyle yazılmış hafif ve yüksek hızlı bir süreç içi vektör veritabanı (in-process vector database) çözümüdür. Uygulamaların vektör verilerini doğrudan bellek üzerinde işlemesine olanak tanıyarak sistem performansını artırmayı hedefler.</p>
 <ul class="disc-meta"><li>★ 15.356</li><li>C++</li><li>GitHub Trending · 2026-06-17</li></ul>

--- a/en/index.html
+++ b/en/index.html
@@ -414,7 +414,7 @@
           <div class="community-icon">🤝</div>
           <div class="community-content">
             <h3>Join the Team</h3>
-            <p>Believe in automated knowledge radars? Developer, designer, researcher, or creator — reach out and shape the product with us.</p>
+            <p>Believe in automated knowledge radars? Developer, designer, researcher, or creator · reach out and shape the product with us.</p>
             <span class="community-cta">hello@trescout.com →</span>
           </div>
         </a>

--- a/scripts/check-brand-typography.py
+++ b/scripts/check-brand-typography.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+Marka tipografi guard'ı (CI) · yayına giden sayfalarda iki kesin kural:
+
+  1. 🚀 YASAK · hype işareti (AGENTS.md marka bölümü).
+  2. Em dash (—) YASAK · Türkçede yok, yerine · , . : kullanılır.
+
+Neden gerekti: 2026-08-06 denetiminde 🚀 **361 keşif sayfasında** çıktı ·
+`discover-sync.py` momentum rozetine basıyordu ve kimse fark etmemişti.
+Kural dokümanda vardı, kontrol eden yoktu.
+
+Kod blokları hariç: `<pre>` ve `<code>` içindeki metin üçüncü taraf (README'den
+alınan kurulum komutları). Oradaki em dash'i düzeltmek komutu bozar · dokunulmaz.
+
+Kullanım: python3 scripts/check-brand-typography.py
+Çıkış kodu 1 → ihlal var (CI fail eder).
+"""
+import os, re, sys, glob
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+KOD = re.compile(r"<pre\b.*?</pre>|<code\b.*?</code>", re.S | re.I)
+YASAK = (("🚀", "hype işareti · marka kuralı"), ("—", "em dash · Türkçede yok, · kullanın"))
+
+
+def main():
+    ihlal = []
+    for p in sorted(glob.glob(os.path.join(ROOT, "**", "*.html"), recursive=True)):
+        rel = os.path.relpath(p, ROOT)
+        # Kod bloklarını boşlukla değiştir · satır numaraları kaymasın
+        metin = KOD.sub(lambda m: re.sub(r"[^\n]", " ", m.group(0)), open(p, encoding="utf-8").read())
+        for i, satir in enumerate(metin.splitlines(), 1):
+            for isaret, sebep in YASAK:
+                if isaret in satir:
+                    ihlal.append((rel, i, isaret, sebep, satir.strip()[:70]))
+
+    if ihlal:
+        print(f"✗ {len(ihlal)} marka tipografi ihlali:")
+        for rel, i, isaret, sebep, ornek in ihlal[:15]:
+            print(f"   {rel}:{i} · {isaret} ({sebep})\n     {ornek}")
+        if len(ihlal) > 15:
+            print(f"   … +{len(ihlal)-15} ihlal daha")
+        sys.exit(1)
+    print("✓ marka tipografisi temiz · 🚀 ve em dash yok")
+
+
+main()

--- a/scripts/discover-sync.py
+++ b/scripts/discover-sync.py
@@ -344,7 +344,8 @@ def build_page(e, rich=None):
     if rel:
         chips="".join(f'<a href="/dictionary/{r}/">{esc(EN_MAP.get(r,r))}</a>' for r in rel if r in EN_MAP)
         if chips: relsec=f'<section class="disc-sec"><h2>İlgili sözlük terimleri</h2><div class="disc-related">{chips}</div></section>'
-    mom=f'<span class="disc-momentum">🚀 {esc(momentum)}</span>' if momentum else ''
+    # ↑ · marka kuralı 🚀'yi yasaklıyor (hype). Aynı bilgiyi tipografik işaretle veriyoruz.
+    mom=f'<span class="disc-momentum">↑ {esc(momentum)}</span>' if momentum else ''
     rich_html=rich_sections(rich, e.get("cmds")) if rich else ''
     notu=(e.get("trescout_notu") or "").strip()   # elle yazılan editöryel yargı · README özetinden farkımız
     not_html=f'<aside class="disc-note"><p><strong>TreScout notu:</strong> {esc(notu)}</p></aside>\n      ' if notu else ''


### PR DESCRIPTION
Tasarım denetimini emoji kullanımına genişletince çıktı.

## Bulgu
Marka kuralımız 🚀'yi yasaklıyor (hype). Buna rağmen `discover-sync.py` momentum rozetine basıyordu:

```
<span class="disc-momentum">🚀 +91 bugün</span>
```

**361 keşif sayfasında yayındaydı.** Kural dokümanda vardı, kontrol eden yoktu · tam olarak bu hafta nav/footer/başlıkta yaşadığımız desen.

## Düzeltme
- Rozet `↑ +91 bugün` oldu · aynı bilgi, hype yok, accent rozetin içinde tipografik olarak da daha temiz duruyor.
- Üretici (`discover-sync.py`) ve yayındaki 361 sayfa birlikte güncellendi · katalog ↔ sayfa sapması olmasın.
- İngilizce sayfadaki tek em dash (`researcher, or creator — reach out`) `·` ile değiştirildi.

## Guard
`scripts/check-brand-typography.py` · iki kesin kuralı denetler: 🚀 ve em dash. `<pre>`/`<code>` içindekiler hariç · oradaki metin README'den alınan kurulum komutları (bugün 6 em dash orada, hepsi meşru; düzeltmek komutu bozardı).

Guard ailesi artık altı kontrol: CSP · nav · footer · logo · başlık · marka tipografisi.

## Denetimin geri kalanı
Emoji sayımı: keşif 1.897 (çoğu ★ ve 🤖 · "yapay zekâ ajanınıza" bilgi kutusu başlığı), landing 52, rapor sayfaları 2. 🤖 ve 📚 gibi işlevsel etiketlere dokunmadım · yasak olan yalnız hype işaretiydi.

## Doğrulama
Altı guard yeşil · sayfalarda 🚀 kalmadı, üreticide yalnız kuralı açıklayan yorumda geçiyor.

## AI Traceability
### Plan Agent
- Outputs used: tasarım denetimi (bu oturum)
- Tool: claude-code

### Skills Agent
- [ ] Kullanılmadı

### Türkçe İçerik
- [x] Yeni metin yok · işaret değişimi
- [x] Claude denetiminden geçti

### Manuel
- Hangi emojinin kural ihlali, hangisinin işlevsel etiket olduğu ayrımı