### PR TITLE
feat(claude-code): kayıt bildirimine sayfa yolu ekle

### DIFF
--- a/api/subscribe.js
+++ b/api/subscribe.js
@@ -156,6 +156,9 @@ export default async function handler(req) {
 
   const email = (body.email || '').toString().trim().toLowerCase();
   const source = (body.source || 'unknown').toString().slice(0, 32);
+  // Kayıt hangi sayfadan geldi · data-source sayfa TİPİNİ veriyor (ör. tüm
+  // 488 İngilizce sözlük sayfası 'dictionary-en'), path tek girdiyi veriyor.
+  const path = (body.path || '').toString().slice(0, 120).replace(/[^\w\-/.]/g, '');
   const consent = body.consent === true || body.consent === 'true';
 
   if (!consent) {
@@ -223,6 +226,7 @@ export default async function handler(req) {
         text: [
           `E-posta: ${email}`,
           `Kaynak: ${source}`,
+          path ? `Sayfa: https://trescout.com${path}` : '',
           `Tarih: ${new Date().toISOString()}`,
           isDuplicate ? 'Not: Bu e-posta listede zaten kayıtlıydı.' : ''
         ].filter(Boolean).join('\n')

--- a/assets/subscribe.js
+++ b/assets/subscribe.js
@@ -59,6 +59,9 @@
           body: JSON.stringify({
             email: email,
             source: form.dataset.source || 'unknown',
+            // Sayfa yolu · data-source tüm sözlük sayfalarında aynı ("dictionary-en"),
+            // hangi girdinin kişiyi getirdiğini ancak bu satır gösteriyor.
+            path: location.pathname,
             consent: true,
             website: honeypot ? honeypot.value : ''
           })


### PR DESCRIPTION
İlk organik erken erişim kaydı **`dictionary-en`** kaynağıyla geldi (2026-08-06 23:30 UTC). Ama bu etiketi **488 İngilizce sözlük sayfasının hepsi** basıyor · kişiyi hangi terimin getirdiği görünmüyor.

Form artık `location.pathname` de gönderiyor; `hello@`'a düşen bildirimde tam adres yazıyor:

```
E-posta: ...
Kaynak: dictionary-en
Sayfa: https://trescout.com/en/dictionary/rag/
Tarih: ...
```

**Sayfa üretimine dokunmadım** · `data-source` olduğu gibi kaldı, 1800 sayfa yeniden basılmadı. Değişen yalnız paylaşılan `assets/subscribe.js` ve uç nokta. Yol sanitize ediliyor (`[^\w\-/.]` temizleniyor) ve 120 karakterle sınırlı.

## Neden değerli
İçerik şu an tek edinim kanalı. Hangi sayfanın kayıt getirdiğini bilmek, "notu olmayan 363 sayfa"dan hangisine öncelik vereceğimizi de söyler.

## AI Traceability
### Plan Agent
- Outputs used: ilk organik kayıt verisi
- Tool: claude-code

### Skills Agent
- [ ] Kullanılmadı

### Türkçe İçerik
- [x] Kullanıcı-yüzü metin değişmedi

### Manuel
- Sayfa yeniden basmadan çözme kararı