### PR TITLE
fix(claude-code): form mesajları sayfanın dilinde

### DIFF
--- a/api/subscribe.js
+++ b/api/subscribe.js
@@ -50,6 +50,38 @@ const DISPOSABLE_DOMAINS = new Set([
   'mailcatch.com', 'spamgourmet.com', 'dispostable.com',
 ]);
 
+/**
+ * Kullanıcıya dönen hata metinleri · sayfanın dili neyse o.
+ * İstemci `lang` gönderiyor (document.documentElement.lang). Gönderilmezse
+ * Türkçe · site Türkçe doğdu, varsayılan o.
+ */
+const MESAJ = {
+  tr: {
+    method: 'Method not allowed',
+    istek: 'İstek geçersiz',
+    limit: 'Çok fazla deneme · birkaç dakika sonra tekrar deneyin',
+    format: 'Geçersiz istek formatı',
+    onay: 'Aydınlatma Metni onayı gerekli',
+    eposta: 'Geçerli bir e-posta adresi girin',
+    gecici: 'Lütfen kalıcı bir e-posta adresi kullanın',
+    sunucu: 'Sunucu konfigürasyonu eksik',
+    kayit: 'Kayıt yapılamadı, lütfen tekrar deneyin',
+    baglanti: 'Bağlantı hatası, lütfen tekrar deneyin',
+  },
+  en: {
+    method: 'Method not allowed',
+    istek: 'Invalid request',
+    limit: 'Too many attempts · try again in a few minutes',
+    format: 'Invalid request format',
+    onay: 'Please accept the privacy notice to continue',
+    eposta: 'Enter a valid email address',
+    gecici: 'Please use a permanent email address',
+    sunucu: 'Server configuration is missing',
+    kayit: 'Could not sign you up, please try again',
+    baglanti: 'Connection error, please try again',
+  },
+};
+
 function jsonResponse(body, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
@@ -120,30 +152,46 @@ function clientIp(req) {
   return req.headers.get('x-real-ip') || '';
 }
 
+/**
+ * Sayfanın dili · Referer yolundan okunur (/en/... → İngilizce).
+ * Gövde daha ayrıştırılmadan da hata dönebiliyoruz (yöntem, origin, hız sınırı) ·
+ * bu yüzden dili başlıktan alıyoruz, gövdedeki `lang` alanına bağlamıyoruz.
+ */
+function dilSec(req) {
+  const ref = req.headers.get('referer') || '';
+  try {
+    return new URL(ref).pathname.startsWith('/en/') ? 'en' : 'tr';
+  } catch {
+    return 'tr';
+  }
+}
+
 export default async function handler(req) {
+  const M = MESAJ[dilSec(req)];
+
   if (req.method !== 'POST') {
-    return jsonResponse({ error: 'Method not allowed' }, 405);
+    return jsonResponse({ error: M.method }, 405);
   }
 
   // CSRF · origin check
   const origin = req.headers.get('origin');
   if (!isOriginAllowed(origin)) {
     console.warn('Blocked origin:', origin);
-    return jsonResponse({ error: 'İstek geçersiz' }, 403);
+    return jsonResponse({ error: M.istek }, 403);
   }
 
   // Rate limit · pahalı Resend çağrılarından önce
   const ip = clientIp(req);
   if (isRateLimited(ip, Date.now())) {
     console.warn('Rate limited:', ip);
-    return jsonResponse({ error: 'Çok fazla deneme · birkaç dakika sonra tekrar deneyin' }, 429);
+    return jsonResponse({ error: M.limit }, 429);
   }
 
   let body;
   try {
     body = await req.json();
   } catch {
-    return jsonResponse({ error: 'Geçersiz istek formatı' }, 400);
+    return jsonResponse({ error: M.format }, 400);
   }
 
   // Honeypot · bot filtresi · görünmez input, dolu gelirse bot
@@ -162,11 +210,11 @@ export default async function handler(req) {
   const consent = body.consent === true || body.consent === 'true';
 
   if (!consent) {
-    return jsonResponse({ error: 'Aydınlatma Metni onayı gerekli' }, 400);
+    return jsonResponse({ error: M.onay }, 400);
   }
 
   if (!email || email.length > MAX_EMAIL_LENGTH || !EMAIL_REGEX.test(email)) {
-    return jsonResponse({ error: 'Geçerli bir e-posta adresi girin' }, 400);
+    return jsonResponse({ error: M.eposta }, 400);
   }
 
   // Disposable email check
@@ -183,7 +231,7 @@ export default async function handler(req) {
 
   if (!apiKey || !audienceId) {
     console.error('Missing env vars: RESEND_API_KEY or RESEND_AUDIENCE_ID');
-    return jsonResponse({ error: 'Sunucu konfigürasyonu eksik' }, 500);
+    return jsonResponse({ error: M.sunucu }, 500);
   }
 
   try {
@@ -204,7 +252,7 @@ export default async function handler(req) {
       // 409 = contact zaten var · sorun değil, devam et
       const errText = await audienceRes.text();
       console.error('Resend audience add failed:', audienceRes.status, errText);
-      return jsonResponse({ error: 'Kayıt yapılamadı, lütfen tekrar deneyin' }, 502);
+      return jsonResponse({ error: M.kayit }, 502);
     }
 
     // 2. hello@'a bildirim e-postası
@@ -248,6 +296,6 @@ export default async function handler(req) {
     return jsonResponse({ ok: true, duplicate: isDuplicate });
   } catch (err) {
     console.error('Subscribe error:', err);
-    return jsonResponse({ error: 'Bağlantı hatası, lütfen tekrar deneyin' }, 502);
+    return jsonResponse({ error: M.baglanti }, 502);
   }
 }

--- a/assets/index.js
+++ b/assets/index.js
@@ -14,10 +14,30 @@
     (function () {
       var ENDPOINT = '/api/subscribe';
 
-      function showSuccess(form, isDuplicate) {
+      /* Sayfanın dili · /en/ altındaki sayfalarda İngilizce metin.
+     NOT: aynı sözlük assets/index.js içinde de var (anasayfa formu ayrı akış
+     kullanıyor · scroll-gate modal). Birini değiştirirken diğerine bakın. */
+  var EN = document.documentElement.lang === 'en';
+  var T = EN ? {
+    zaten: '<strong>You are already on the list.</strong> We will let you know when we go live.',
+    aldik: '<strong>Got it.</strong> We will let you know when we go live. Have a good week.',
+    onay: 'Please accept the privacy notice to continue.',
+    gonderiliyor: 'Sending...',
+    genel: 'Something went wrong. Please try again.',
+    baglanti: 'Connection error. Please try again.'
+  } : {
+    zaten: '<strong>Zaten listemizdesiniz.</strong> Yayında olduğumuzda size haber vereceğiz.',
+    aldik: '<strong>Aldık.</strong> Yayında olduğumuzda size haber vereceğiz. İyi haftalar.',
+    onay: 'Devam etmek için Aydınlatma Metni onayı gerekli.',
+    gonderiliyor: 'Gönderiliyor...',
+    genel: 'Bir şeyler ters gitti. Lütfen tekrar deneyin.',
+    baglanti: 'Bağlantı hatası. Lütfen tekrar deneyin.'
+  };
+
+  function showSuccess(form, isDuplicate) {
         var msg = isDuplicate
-          ? '<strong>Zaten listemizdesiniz.</strong> Yayında olduğumuzda size haber vereceğiz.'
-          : '<strong>Aldık.</strong> Yayında olduğumuzda size haber vereceğiz. İyi haftalar.';
+          ? T.zaten
+          : T.aldik;
         var div = document.createElement('div');
         div.className = 'form-success';
         div.setAttribute('role', 'status');
@@ -51,14 +71,14 @@
           }
           var consent = form.querySelector('input[name="consent"]');
           if (consent && !consent.checked) {
-            showError(form, 'Devam etmek için Aydınlatma Metni onayı gerekli.');
+            showError(form, T.onay);
             consent.focus();
             return;
           }
 
           var originalText = button.textContent;
           button.disabled = true;
-          button.textContent = 'Gönderiliyor...';
+          button.textContent = T.gonderiliyor;
 
           try {
             var honeypot = form.querySelector('input[name="website"]');
@@ -79,12 +99,12 @@
             } else {
               button.disabled = false;
               button.textContent = originalText;
-              showError(form, data.error || 'Bir şeyler ters gitti. Lütfen tekrar deneyin.');
+              showError(form, data.error || T.genel);
             }
           } catch (err) {
             button.disabled = false;
             button.textContent = originalText;
-            showError(form, 'Bağlantı hatası. Lütfen tekrar deneyin.');
+            showError(form, T.baglanti);
           }
         });
       }

--- a/assets/subscribe.js
+++ b/assets/subscribe.js
@@ -5,10 +5,31 @@
 (function () {
   var ENDPOINT = '/api/subscribe';
 
+  /* Sayfanın dili · /en/ altındaki sayfalarda İngilizce metin.
+     NOT: aynı sözlük assets/index.js içinde de var (anasayfa formu ayrı akış
+     kullanıyor · scroll-gate modal). Birini değiştirirken diğerine bakın. */
+  var EN = document.documentElement.lang === 'en';
+  var T = EN ? {
+    zaten: '<strong>You are already on the list.</strong> We will let you know when we go live.',
+    aldik: '<strong>Got it.</strong> We will let you know when we go live. Have a good week.',
+    onay: 'Please accept the privacy notice to continue.',
+    gonderiliyor: 'Sending...',
+    genel: 'Something went wrong. Please try again.',
+    baglanti: 'Connection error. Please try again.'
+  } : {
+    zaten: '<strong>Zaten listemizdesiniz.</strong> Yayında olduğumuzda size haber vereceğiz.',
+    aldik: '<strong>Aldık.</strong> Yayında olduğumuzda size haber vereceğiz. İyi haftalar.',
+    onay: 'Devam etmek için Aydınlatma Metni onayı gerekli.',
+    gonderiliyor: 'Gönderiliyor...',
+    genel: 'Bir şeyler ters gitti. Lütfen tekrar deneyin.',
+    baglanti: 'Bağlantı hatası. Lütfen tekrar deneyin.'
+  };
+
+
   function showSuccess(form, isDuplicate) {
     var msg = isDuplicate
-      ? '<strong>Zaten listemizdesiniz.</strong> Yayında olduğumuzda size haber vereceğiz.'
-      : '<strong>Aldık.</strong> Yayında olduğumuzda size haber vereceğiz. İyi haftalar.';
+      ? T.zaten
+      : T.aldik;
     var div = document.createElement('div');
     div.className = 'form-success';
     div.setAttribute('role', 'status');
@@ -42,14 +63,14 @@
       }
       var consent = form.querySelector('input[name="consent"]');
       if (consent && !consent.checked) {
-        showError(form, 'Devam etmek için Aydınlatma Metni onayı gerekli.');
+        showError(form, T.onay);
         consent.focus();
         return;
       }
 
       var originalText = button.textContent;
       button.disabled = true;
-      button.textContent = 'Gönderiliyor...';
+      button.textContent = T.gonderiliyor;
 
       try {
         var honeypot = form.querySelector('input[name="website"]');
@@ -73,12 +94,12 @@
         } else {
           button.disabled = false;
           button.textContent = originalText;
-          showError(form, data.error || 'Bir şeyler ters gitti. Lütfen tekrar deneyin.');
+          showError(form, data.error || T.genel);
         }
       } catch (err) {
         button.disabled = false;
         button.textContent = originalText;
-        showError(form, 'Bağlantı hatası. Lütfen tekrar deneyin.');
+        showError(form, T.baglanti);
       }
     });
   }


### PR DESCRIPTION
İlk organik kaydımız **İngilizce sözlük sayfasından** geldi · o kişi form gönderdiğinde şu mesajı gördü:

> **Aldık.** Yayında olduğumuzda size haber vereceğiz. İyi haftalar.

İngilizce bir sayfada, Türkçe. Aynı durum onay uyarısında, hata mesajlarında ve "Gönderiliyor..." metninde de vardı · hem `assets/subscribe.js` (tüm alt sayfalar) hem `assets/index.js` (anasayfa, İngilizcesi dahil).

## Düzeltme
- İki istemci betiği metinleri `document.documentElement.lang` değerine göre seçiyor.
- **Sunucu hataları da dile duyarlı** · dil `Referer` yolundan okunuyor (`/en/...`), çünkü yöntem / origin / hız-sınırı hataları gövde daha ayrıştırılmadan dönüyor.

Sayfa üretimine dokunulmadı · değişen yalnız iki paylaşılan betik ve uç nokta, 1800 sayfa yeniden basılmadı.

## Doğrulama (yerel sunucu, gerçek form gönderimi)
| sayfa | çıkan uyarı |
|---|---|
| `/en/dictionary/rag/` | "Please accept the privacy notice to continue." |
| `/en/` | "Please accept the privacy notice to continue." |
| `/dictionary/rag/` | "Devam etmek için Aydınlatma Metni onayı gerekli." |

Altı guard yeşil.

**Not:** İlk denememde sözlüğün Türkçe dalını da otomatik değiştirmiştim ve `T` kendini referans eder hâle gelmişti · tarayıcı konsolunda `TypeError` olarak yakalandı, düzeltildi. Bu yüzden doğrulamayı gerçek form gönderimiyle yaptım, koda bakarak değil.

## Karşılama e-postası
Kullanıcı kararı: **gönderilmeyecek.** Sayfadaki "Aldık" mesajı yeterli görüldü · bu PR o mesajı doğru dilde gösteriyor.

## AI Traceability
### Plan Agent
- Outputs used: ilk organik kayıt (kaynak: dictionary-en)
- Tool: claude-code

### Skills Agent
- [ ] Kullanılmadı

### Türkçe İçerik
- [x] Türkçe metinler değişmedi · İngilizce karşılıkları eklendi, Claude denetiminden geçti

### Manuel
- Sunucu tarafında dilin Referer'dan okunması kararı