### PR TITLE
feat(claude-code): saklama süresine 90 günlük pencere

### DIFF
--- a/en/privacy.html
+++ b/en/privacy.html
@@ -15,7 +15,7 @@
 <body>
   <div class="container">
     <h1>Privacy Notice</h1>
-    <p class="meta">Last updated: 2026-06-02</p>
+    <p class="meta">Last updated: 2026-08-07</p>
 
     <p>
       <strong>This English text is a summary provided for convenience.</strong> TreScout operates under Turkish
@@ -49,8 +49,9 @@
     <h2>4. How long we keep it</h2>
     <p>
       We keep your email address until the launch happens or until you ask us to delete it, whichever comes first.
-      If you join the TreScout product after launch, retention continues under the product terms; if you do not
-      join, your email is deleted from our systems.
+      If you join the TreScout product after launch, retention continues under the product terms. If you do not
+      join, your email is deleted from our systems <strong>within 90 days of launch</strong>; we send you a
+      reminder before deleting it.
     </p>
 
     <h2>5. Where your data is stored</h2>

--- a/privacy.html
+++ b/privacy.html
@@ -12,7 +12,7 @@
 <body>
   <div class="container">
     <h1>Aydınlatma Metni</h1>
-    <p class="meta">Son güncelleme: 2026-06-02</p>
+    <p class="meta">Son güncelleme: 2026-08-07</p>
 
     <p>
       TreScout olarak kişisel verilerinizin korunmasına önem veriyoruz. Bu metin, 6698 sayılı <strong>Kişisel Verilerin Korunması Kanunu (KVKK)</strong> kapsamında veri sorumlusu sıfatımızla sizi bilgilendirmek için hazırlanmıştır.
@@ -43,7 +43,7 @@
 
     <h2>4. Saklama süresi</h2>
     <p>
-      E-posta adresinizi lansman gerçekleşene kadar veya silme talebinize kadar saklarız (hangisi önce gerçekleşirse). Lansman sonrası TreScout ürününe katılırsanız ürün kullanım koşulları çerçevesinde saklama devam eder; katılmazsanız e-postanız sistemden silinir.
+      E-posta adresinizi lansman gerçekleşene kadar veya silme talebinize kadar saklarız (hangisi önce gerçekleşirse). Lansman sonrası TreScout ürününe katılırsanız ürün kullanım koşulları çerçevesinde saklama devam eder. Katılmazsanız e-postanız <strong>lansmandan sonraki 90 gün içinde</strong> sistemden silinir; silmeden önce size bir hatırlatma göndeririz.
     </p>
 
     <h2>5. Verilerinizi nerede tutuyoruz?</h2>


### PR DESCRIPTION
"Lansman sonrası ürüne katılmazsanız e-postanız silinir" cümlesi **ne zaman** sileceğimizi söylemiyordu. Belirsiz süre, tutulamayan söz demektir.

## Değişiklik
**Türkçe (§4):**
> Katılmazsanız e-postanız **lansmandan sonraki 90 gün içinde** sistemden silinir; silmeden önce size bir hatırlatma göndeririz.

**İngilizce (§4):** aynı ifade · "within 90 days of launch", "we send you a reminder before deleting it".

"Son güncelleme" tarihi 2026-08-07'ye çekildi · metin değiştiğinde tarih eskisinde kalırsa okur değişikliği fark edemez.

## Neden hatırlatma sözü de verdik
Silmeden önce haber vermek hem nazik hem işlevsel: kişi için son katılma şansı, bizim için de "sessizce sildik" durumuna düşmemek.

## Uygulama
Bu bir taahhüt, otomatik değil · adımı app runbook'una yazdım: [trescout/app#38](https://github.com/trescout/app/pull/38) (60. günde hatırlatma, 90. günde silme, silinen adedin `trescout/internal` envanterine işlenmesi).

Altı guard yeşil.

## AI Traceability
### Plan Agent
- Outputs used: kullanıcı kararı (90 gün)
- Tool: claude-code

### Skills Agent
- [ ] Kullanılmadı

### Türkçe İçerik
- [ ] Gemini'den geçmedi · hukuki metin, cümle Türkçe aslın daraltılmış hâli
- [x] Claude denetiminden geçti (em dash yok, "siz" dili, iki noktadan sonra büyük harf)

### Manuel
- 90 gün sayısı ve hatırlatma sözü kararı