### PR TITLE
fix(claude-code): guard iş akışı her PR'da koşsun · paths filtresi kaldırıldı

### DIFF
--- a/.github/workflows/csp-inline-guard.yml
+++ b/.github/workflows/csp-inline-guard.yml
@@ -8,12 +8,15 @@ name: CSP Inline Guard
 # 5) Başlık tutarlılığı: keşif detay sayfasının H1'i katalogdaki headline ile aynı (alan bazlı taşımada sayfa geride kalmasın).
 # 6) Marka tipografisi: 🚀 ve em dash (—) yayına giden sayfalarda geçmesin (kod blokları hariç).
 
+# paths filtresi KALDIRILDI (2026-08-08). GitHub, bir PR'da 300'den fazla dosya
+# değiştiğinde paths filtresini güvenilir uygulamıyor · üretilen sayfalara dokunan
+# PR'lar (dil ekleme, arşiv basımı) tam da bu boyutta oluyor ve guard sessizce
+# ATLANIYORDU. Sessizce atlanan guard, olmayan guard'dan daha kötü: yeşil görünür.
+# Bedeli birkaç saniyelik koşu · guard 15 saniyede bitiyor.
 on:
   pull_request:
-    paths: ['**.html', 'assets/discover/catalog.json']
   push:
     branches: [main]
-    paths: ['**.html', 'assets/discover/catalog.json']
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## Sorun

`csp-inline-guard.yml` şu filtreyle koşuyordu:

```yaml
on:
  pull_request:
    paths: ['**.html', 'assets/discover/catalog.json']
```

GitHub, bir PR'da **300'den fazla dosya** değiştiğinde paths filtresini güvenilir uygulamıyor. Üretilen sayfalara dokunan PR'lar — dil ekleme, arşiv basımı, kabuk normalizasyonu — tam da bu boyutta oluyor.

landing#92'de bizzat yaşandı: 3113 dosya değişti, **yedi guard da sessizce atlandı**, PR yeşil göründü. Elle `workflow_dispatch` ile tetikleyip doğrulamak gerekti.

Sessizce atlanan guard, olmayan guard'dan daha kötü: yokluğu bilinir, sessizliği bilinmez.

## Değişiklik

Filtre kaldırıldı · guard her PR'da ve her main push'unda koşuyor. Sebebi dosyanın başına yazıldı.

Bedeli birkaç saniye: guard 15 saniyede bitiyor, ağ çağrısı yok, yalnız diskteki HTML'i tarıyor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)