### PR TITLE
fix(claude-code): bugünkü yayının hreflang'ini onar · 282 sayfa

### DIFF
--- a/en/reports/2026-05-26/index.html
+++ b/en/reports/2026-05-26/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-05-26/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-05-26/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-05-26/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-05-26/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-05-26/">
 <meta property="og:title" content="May 26, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for May 26, 2026 (Tuesday).">

--- a/en/reports/2026-05-27/index.html
+++ b/en/reports/2026-05-27/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-05-27/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-05-27/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-05-27/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-05-27/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-05-27/">
 <meta property="og:title" content="May 27, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for May 27, 2026 (Wednesday).">

--- a/en/reports/2026-05-28/index.html
+++ b/en/reports/2026-05-28/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-05-28/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-05-28/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-05-28/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-05-28/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-05-28/">
 <meta property="og:title" content="May 28, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for May 28, 2026 (Thursday).">

--- a/en/reports/2026-05-29/index.html
+++ b/en/reports/2026-05-29/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-05-29/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-05-29/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-05-29/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-05-29/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-05-29/">
 <meta property="og:title" content="May 29, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for May 29, 2026 (Friday).">

--- a/en/reports/2026-05-30/index.html
+++ b/en/reports/2026-05-30/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-05-30/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-05-30/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-05-30/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-05-30/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-05-30/">
 <meta property="og:title" content="May 30, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for May 30, 2026 (Saturday).">

--- a/en/reports/2026-05-31/index.html
+++ b/en/reports/2026-05-31/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-05-31/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-05-31/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-05-31/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-05-31/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-05-31/">
 <meta property="og:title" content="May 31, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for May 31, 2026 (Sunday).">

--- a/en/reports/2026-06-01/index.html
+++ b/en/reports/2026-06-01/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-01/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-01/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-01/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-01/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-01/">
 <meta property="og:title" content="June 1, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 1, 2026 (Monday).">

--- a/en/reports/2026-06-02/index.html
+++ b/en/reports/2026-06-02/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-02/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-02/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-02/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-02/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-02/">
 <meta property="og:title" content="June 2, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 2, 2026 (Tuesday).">

--- a/en/reports/2026-06-03/index.html
+++ b/en/reports/2026-06-03/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-03/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-03/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-03/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-03/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-03/">
 <meta property="og:title" content="June 3, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 3, 2026 (Wednesday).">

--- a/en/reports/2026-06-04/index.html
+++ b/en/reports/2026-06-04/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-04/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-04/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-04/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-04/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-04/">
 <meta property="og:title" content="June 4, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 4, 2026 (Thursday).">

--- a/en/reports/2026-06-05/index.html
+++ b/en/reports/2026-06-05/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-05/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-05/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-05/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-05/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-05/">
 <meta property="og:title" content="June 5, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 5, 2026 (Friday).">

--- a/en/reports/2026-06-06/index.html
+++ b/en/reports/2026-06-06/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-06/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-06/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-06/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-06/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-06/">
 <meta property="og:title" content="June 6, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 6, 2026 (Saturday).">

--- a/en/reports/2026-06-07/index.html
+++ b/en/reports/2026-06-07/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-07/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-07/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-07/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-07/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-07/">
 <meta property="og:title" content="June 7, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 7, 2026 (Sunday).">

--- a/en/reports/2026-06-08/index.html
+++ b/en/reports/2026-06-08/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-08/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-08/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-08/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-08/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-08/">
 <meta property="og:title" content="June 8, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 8, 2026 (Monday).">

--- a/en/reports/2026-06-09/index.html
+++ b/en/reports/2026-06-09/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-09/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-09/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-09/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-09/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-09/">
 <meta property="og:title" content="June 9, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 9, 2026 (Tuesday).">

--- a/en/reports/2026-06-10/index.html
+++ b/en/reports/2026-06-10/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-10/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-10/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-10/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-10/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-10/">
 <meta property="og:title" content="June 10, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 10, 2026 (Wednesday).">

--- a/en/reports/2026-06-11/index.html
+++ b/en/reports/2026-06-11/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-11/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-11/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-11/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-11/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-11/">
 <meta property="og:title" content="June 11, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 11, 2026 (Thursday).">

--- a/en/reports/2026-06-12/index.html
+++ b/en/reports/2026-06-12/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-12/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-12/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-12/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-12/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-12/">
 <meta property="og:title" content="June 12, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 12, 2026 (Friday).">

--- a/en/reports/2026-06-13/index.html
+++ b/en/reports/2026-06-13/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-13/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-13/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-13/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-13/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-13/">
 <meta property="og:title" content="June 13, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 13, 2026 (Saturday).">

--- a/en/reports/2026-06-14/index.html
+++ b/en/reports/2026-06-14/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-14/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-14/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-14/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-14/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-14/">
 <meta property="og:title" content="June 14, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 14, 2026 (Sunday).">

--- a/en/reports/2026-06-15/index.html
+++ b/en/reports/2026-06-15/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-15/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-15/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-15/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-15/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-15/">
 <meta property="og:title" content="June 15, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 15, 2026 (Monday).">

--- a/en/reports/2026-06-16/index.html
+++ b/en/reports/2026-06-16/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-16/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-16/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-16/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-16/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-16/">
 <meta property="og:title" content="June 16, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 16, 2026 (Tuesday).">

--- a/en/reports/2026-06-17/index.html
+++ b/en/reports/2026-06-17/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-17/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-17/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-17/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-17/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-17/">
 <meta property="og:title" content="June 17, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 17, 2026 (Wednesday).">

--- a/en/reports/2026-06-18/index.html
+++ b/en/reports/2026-06-18/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-18/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-18/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-18/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-18/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-18/">
 <meta property="og:title" content="June 18, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 18, 2026 (Thursday).">

--- a/en/reports/2026-06-19/index.html
+++ b/en/reports/2026-06-19/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-19/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-19/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-19/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-19/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-19/">
 <meta property="og:title" content="June 19, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 19, 2026 (Friday).">

--- a/en/reports/2026-06-20/index.html
+++ b/en/reports/2026-06-20/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-20/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-20/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-20/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-20/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-20/">
 <meta property="og:title" content="June 20, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 20, 2026 (Saturday).">

--- a/en/reports/2026-06-21/index.html
+++ b/en/reports/2026-06-21/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-21/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-21/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-21/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-21/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-21/">
 <meta property="og:title" content="June 21, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 21, 2026 (Sunday).">

--- a/en/reports/2026-06-22/index.html
+++ b/en/reports/2026-06-22/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-22/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-22/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-22/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-22/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-22/">
 <meta property="og:title" content="June 22, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 22, 2026 (Monday).">

--- a/en/reports/2026-06-23/index.html
+++ b/en/reports/2026-06-23/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-23/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-23/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-23/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-23/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-23/">
 <meta property="og:title" content="June 23, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 23, 2026 (Tuesday).">

--- a/en/reports/2026-06-24/index.html
+++ b/en/reports/2026-06-24/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-24/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-24/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-24/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-24/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-24/">
 <meta property="og:title" content="June 24, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 24, 2026 (Wednesday).">

--- a/en/reports/2026-06-25/index.html
+++ b/en/reports/2026-06-25/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-25/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-25/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-25/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-25/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-25/">
 <meta property="og:title" content="June 25, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 25, 2026 (Thursday).">

--- a/en/reports/2026-06-26/index.html
+++ b/en/reports/2026-06-26/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-26/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-26/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-26/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-26/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-26/">
 <meta property="og:title" content="June 26, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 26, 2026 (Friday).">

--- a/en/reports/2026-06-27/index.html
+++ b/en/reports/2026-06-27/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-27/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-27/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-27/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-27/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-27/">
 <meta property="og:title" content="June 27, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 27, 2026 (Saturday).">

--- a/en/reports/2026-06-28/index.html
+++ b/en/reports/2026-06-28/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-28/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-28/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-28/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-28/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-28/">
 <meta property="og:title" content="June 28, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 28, 2026 (Sunday).">

--- a/en/reports/2026-06-29/index.html
+++ b/en/reports/2026-06-29/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-29/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-29/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-29/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-29/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-29/">
 <meta property="og:title" content="June 29, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 29, 2026 (Monday).">

--- a/en/reports/2026-06-30/index.html
+++ b/en/reports/2026-06-30/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-06-30/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-30/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-30/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-30/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-30/">
 <meta property="og:title" content="June 30, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 30, 2026 (Tuesday).">

--- a/en/reports/2026-07-01/index.html
+++ b/en/reports/2026-07-01/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-01/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-01/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-01/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-01/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-01/">
 <meta property="og:title" content="July 1, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 1, 2026 (Wednesday).">

--- a/en/reports/2026-07-02/index.html
+++ b/en/reports/2026-07-02/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-02/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-02/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-02/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-02/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-02/">
 <meta property="og:title" content="July 2, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 2, 2026 (Thursday).">

--- a/en/reports/2026-07-03/index.html
+++ b/en/reports/2026-07-03/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-03/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-03/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-03/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-03/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-03/">
 <meta property="og:title" content="July 3, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 3, 2026 (Friday).">

--- a/en/reports/2026-07-04/index.html
+++ b/en/reports/2026-07-04/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-04/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-04/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-04/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-04/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-04/">
 <meta property="og:title" content="July 4, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 4, 2026 (Saturday).">

--- a/en/reports/2026-07-05/index.html
+++ b/en/reports/2026-07-05/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-05/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-05/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-05/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-05/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-05/">
 <meta property="og:title" content="July 5, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 5, 2026 (Sunday).">

--- a/en/reports/2026-07-06/index.html
+++ b/en/reports/2026-07-06/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-06/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-06/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-06/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-06/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-06/">
 <meta property="og:title" content="July 6, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 6, 2026 (Monday).">

--- a/en/reports/2026-07-07/index.html
+++ b/en/reports/2026-07-07/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-07/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-07/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-07/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-07/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-07/">
 <meta property="og:title" content="July 7, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 7, 2026 (Tuesday).">

--- a/en/reports/2026-07-08/index.html
+++ b/en/reports/2026-07-08/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-08/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-08/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-08/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-08/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-08/">
 <meta property="og:title" content="July 8, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 8, 2026 (Wednesday).">

--- a/en/reports/2026-07-09/index.html
+++ b/en/reports/2026-07-09/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-09/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-09/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-09/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-09/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-09/">
 <meta property="og:title" content="July 9, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 9, 2026 (Thursday).">

--- a/en/reports/2026-07-10/index.html
+++ b/en/reports/2026-07-10/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-10/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-10/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-10/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-10/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-10/">
 <meta property="og:title" content="July 10, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 10, 2026 (Friday).">

--- a/en/reports/2026-07-11/index.html
+++ b/en/reports/2026-07-11/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-11/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-11/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-11/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-11/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-11/">
 <meta property="og:title" content="July 11, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 11, 2026 (Saturday).">

--- a/en/reports/2026-07-12/index.html
+++ b/en/reports/2026-07-12/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-12/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-12/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-12/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-12/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-12/">
 <meta property="og:title" content="July 12, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 12, 2026 (Sunday).">

--- a/en/reports/2026-07-13/index.html
+++ b/en/reports/2026-07-13/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-13/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-13/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-13/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-13/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-13/">
 <meta property="og:title" content="July 13, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 13, 2026 (Monday).">

--- a/en/reports/2026-07-14/index.html
+++ b/en/reports/2026-07-14/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-14/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-14/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-14/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-14/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-14/">
 <meta property="og:title" content="July 14, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 14, 2026 (Tuesday).">

--- a/en/reports/2026-07-15/index.html
+++ b/en/reports/2026-07-15/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-15/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-15/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-15/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-15/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-15/">
 <meta property="og:title" content="July 15, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 15, 2026 (Wednesday).">

--- a/en/reports/2026-07-16/index.html
+++ b/en/reports/2026-07-16/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-16/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-16/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-16/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-16/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-16/">
 <meta property="og:title" content="July 16, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 16, 2026 (Thursday).">

--- a/en/reports/2026-07-17/index.html
+++ b/en/reports/2026-07-17/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-17/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-17/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-17/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-17/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-17/">
 <meta property="og:title" content="July 17, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 17, 2026 (Friday).">

--- a/en/reports/2026-07-18/index.html
+++ b/en/reports/2026-07-18/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-18/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-18/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-18/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-18/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-18/">
 <meta property="og:title" content="July 18, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 18, 2026 (Saturday).">

--- a/en/reports/2026-07-19/index.html
+++ b/en/reports/2026-07-19/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-19/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-19/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-19/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-19/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-19/">
 <meta property="og:title" content="July 19, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 19, 2026 (Sunday).">

--- a/en/reports/2026-07-20/index.html
+++ b/en/reports/2026-07-20/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-20/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-20/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-20/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-20/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-20/">
 <meta property="og:title" content="July 20, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 20, 2026 (Monday).">

--- a/en/reports/2026-07-21/index.html
+++ b/en/reports/2026-07-21/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-21/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-21/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-21/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-21/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-21/">
 <meta property="og:title" content="July 21, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 21, 2026 (Tuesday).">

--- a/en/reports/2026-07-22/index.html
+++ b/en/reports/2026-07-22/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-22/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-22/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-22/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-22/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-22/">
 <meta property="og:title" content="July 22, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 22, 2026 (Wednesday).">

--- a/en/reports/2026-07-23/index.html
+++ b/en/reports/2026-07-23/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-23/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-23/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-23/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-23/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-23/">
 <meta property="og:title" content="July 23, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 23, 2026 (Thursday).">

--- a/en/reports/2026-07-24/index.html
+++ b/en/reports/2026-07-24/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-24/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-24/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-24/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-24/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-24/">
 <meta property="og:title" content="July 24, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 24, 2026 (Friday).">

--- a/en/reports/2026-07-25/index.html
+++ b/en/reports/2026-07-25/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-25/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-25/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-25/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-25/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-25/">
 <meta property="og:title" content="July 25, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 25, 2026 (Saturday).">

--- a/en/reports/2026-07-26/index.html
+++ b/en/reports/2026-07-26/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-26/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-26/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-26/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-26/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-26/">
 <meta property="og:title" content="July 26, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 26, 2026 (Sunday).">

--- a/en/reports/2026-07-27/index.html
+++ b/en/reports/2026-07-27/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-27/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-27/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-27/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-27/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-27/">
 <meta property="og:title" content="July 27, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 27, 2026 (Monday).">

--- a/en/reports/2026-07-28/index.html
+++ b/en/reports/2026-07-28/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-28/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-28/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-28/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-28/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-28/">
 <meta property="og:title" content="July 28, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 28, 2026 (Tuesday).">

--- a/en/reports/2026-07-29/index.html
+++ b/en/reports/2026-07-29/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-29/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-29/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-29/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-29/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-29/">
 <meta property="og:title" content="July 29, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 29, 2026 (Wednesday).">

--- a/en/reports/2026-07-30/index.html
+++ b/en/reports/2026-07-30/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-30/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-30/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-30/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-30/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-30/">
 <meta property="og:title" content="July 30, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 30, 2026 (Thursday).">

--- a/en/reports/2026-07-31/index.html
+++ b/en/reports/2026-07-31/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-07-31/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-31/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-31/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-31/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-31/">
 <meta property="og:title" content="July 31, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 31, 2026 (Friday).">

--- a/en/reports/2026-08-01/index.html
+++ b/en/reports/2026-08-01/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-08-01/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-01/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-01/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-01/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-01/">
 <meta property="og:title" content="August 1, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 1, 2026 (Saturday).">

--- a/en/reports/2026-08-02/index.html
+++ b/en/reports/2026-08-02/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-08-02/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-02/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-02/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-02/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-02/">
 <meta property="og:title" content="August 2, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 2, 2026 (Sunday).">

--- a/en/reports/2026-08-03/index.html
+++ b/en/reports/2026-08-03/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-08-03/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-03/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-03/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-03/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-03/">
 <meta property="og:title" content="August 3, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 3, 2026 (Monday).">

--- a/en/reports/2026-08-04/index.html
+++ b/en/reports/2026-08-04/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-08-04/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-04/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-04/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-04/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-04/">
 <meta property="og:title" content="August 4, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 4, 2026 (Tuesday).">

--- a/en/reports/2026-08-05/index.html
+++ b/en/reports/2026-08-05/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-08-05/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-05/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-05/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-05/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-05/">
 <meta property="og:title" content="August 5, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 5, 2026 (Wednesday).">

--- a/en/reports/2026-08-06/index.html
+++ b/en/reports/2026-08-06/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-08-06/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-06/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-06/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-06/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-06/">
 <meta property="og:title" content="August 6, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 6, 2026 (Thursday).">

--- a/en/reports/2026-08-07/index.html
+++ b/en/reports/2026-08-07/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-08-07/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-07/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-07/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-07/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-07/">
 <meta property="og:title" content="August 7, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 7, 2026 (Friday).">

--- a/en/reports/2026-08-08/index.html
+++ b/en/reports/2026-08-08/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-08-08/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-08/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-08/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-08/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-08/">
 <meta property="og:title" content="August 8, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 8, 2026 (Saturday).">

--- a/en/reports/2026-08-09/index.html
+++ b/en/reports/2026-08-09/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-08-09/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-09/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-09/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-09/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-09/">
 <meta property="og:title" content="August 9, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 9, 2026 (Sunday).">

--- a/en/reports/2026-08-10/index.html
+++ b/en/reports/2026-08-10/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-08-10/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-10/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-10/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-10/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-10/">
 <meta property="og:title" content="August 10, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 10, 2026 (Monday).">

--- a/en/reports/2026-08-11/index.html
+++ b/en/reports/2026-08-11/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-08-11/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-11/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-11/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-11/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-11/">
 <meta property="og:title" content="August 11, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 11, 2026 (Tuesday).">

--- a/en/reports/2026-08-12/index.html
+++ b/en/reports/2026-08-12/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/2026-08-12/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-12/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-12/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-12/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-12/">
 <meta property="og:title" content="August 12, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 12, 2026 (Wednesday).">

--- a/en/reports/fresh/2026-06-15/index.html
+++ b/en/reports/fresh/2026-06-15/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-15/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-15/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-15/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-15/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-15/">
 <meta property="og:title" content="June 15, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 15, 2026 (Monday).">

--- a/en/reports/fresh/2026-06-16/index.html
+++ b/en/reports/fresh/2026-06-16/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-16/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-16/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-16/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-16/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-16/">
 <meta property="og:title" content="June 16, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 16, 2026 (Tuesday).">

--- a/en/reports/fresh/2026-06-17/index.html
+++ b/en/reports/fresh/2026-06-17/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-17/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-17/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-17/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-17/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-17/">
 <meta property="og:title" content="June 17, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 17, 2026 (Wednesday).">

--- a/en/reports/fresh/2026-06-18/index.html
+++ b/en/reports/fresh/2026-06-18/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-18/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-18/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-18/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-18/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-18/">
 <meta property="og:title" content="June 18, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 18, 2026 (Thursday).">

--- a/en/reports/fresh/2026-06-19/index.html
+++ b/en/reports/fresh/2026-06-19/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-19/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-19/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-19/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-19/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-19/">
 <meta property="og:title" content="June 19, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 19, 2026 (Friday).">

--- a/en/reports/fresh/2026-06-20/index.html
+++ b/en/reports/fresh/2026-06-20/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-20/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-20/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-20/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-20/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-20/">
 <meta property="og:title" content="June 20, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 20, 2026 (Saturday).">

--- a/en/reports/fresh/2026-06-21/index.html
+++ b/en/reports/fresh/2026-06-21/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-21/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-21/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-21/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-21/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-21/">
 <meta property="og:title" content="June 21, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 21, 2026 (Sunday).">

--- a/en/reports/fresh/2026-06-22/index.html
+++ b/en/reports/fresh/2026-06-22/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-22/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-22/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-22/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-22/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-22/">
 <meta property="og:title" content="June 22, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 22, 2026 (Monday).">

--- a/en/reports/fresh/2026-06-23/index.html
+++ b/en/reports/fresh/2026-06-23/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-23/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-23/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-23/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-23/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-23/">
 <meta property="og:title" content="June 23, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 23, 2026 (Tuesday).">

--- a/en/reports/fresh/2026-06-24/index.html
+++ b/en/reports/fresh/2026-06-24/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-24/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-24/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-24/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-24/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-24/">
 <meta property="og:title" content="June 24, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 24, 2026 (Wednesday).">

--- a/en/reports/fresh/2026-06-25/index.html
+++ b/en/reports/fresh/2026-06-25/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-25/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-25/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-25/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-25/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-25/">
 <meta property="og:title" content="June 25, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 25, 2026 (Thursday).">

--- a/en/reports/fresh/2026-06-26/index.html
+++ b/en/reports/fresh/2026-06-26/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-26/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-26/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-26/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-26/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-26/">
 <meta property="og:title" content="June 26, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 26, 2026 (Friday).">

--- a/en/reports/fresh/2026-06-27/index.html
+++ b/en/reports/fresh/2026-06-27/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-27/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-27/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-27/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-27/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-27/">
 <meta property="og:title" content="June 27, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 27, 2026 (Saturday).">

--- a/en/reports/fresh/2026-06-28/index.html
+++ b/en/reports/fresh/2026-06-28/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-28/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-28/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-28/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-28/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-28/">
 <meta property="og:title" content="June 28, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 28, 2026 (Sunday).">

--- a/en/reports/fresh/2026-06-29/index.html
+++ b/en/reports/fresh/2026-06-29/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-29/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-29/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-29/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-29/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-29/">
 <meta property="og:title" content="June 29, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 29, 2026 (Monday).">

--- a/en/reports/fresh/2026-06-30/index.html
+++ b/en/reports/fresh/2026-06-30/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-06-30/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-30/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-30/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-30/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-30/">
 <meta property="og:title" content="June 30, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for June 30, 2026 (Tuesday).">

--- a/en/reports/fresh/2026-07-01/index.html
+++ b/en/reports/fresh/2026-07-01/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-01/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-01/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-01/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-01/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-01/">
 <meta property="og:title" content="July 1, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 1, 2026 (Wednesday).">

--- a/en/reports/fresh/2026-07-02/index.html
+++ b/en/reports/fresh/2026-07-02/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-02/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-02/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-02/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-02/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-02/">
 <meta property="og:title" content="July 2, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 2, 2026 (Thursday).">

--- a/en/reports/fresh/2026-07-03/index.html
+++ b/en/reports/fresh/2026-07-03/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-03/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-03/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-03/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-03/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-03/">
 <meta property="og:title" content="July 3, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 3, 2026 (Friday).">

--- a/en/reports/fresh/2026-07-04/index.html
+++ b/en/reports/fresh/2026-07-04/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-04/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-04/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-04/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-04/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-04/">
 <meta property="og:title" content="July 4, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 4, 2026 (Saturday).">

--- a/en/reports/fresh/2026-07-05/index.html
+++ b/en/reports/fresh/2026-07-05/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-05/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-05/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-05/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-05/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-05/">
 <meta property="og:title" content="July 5, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 5, 2026 (Sunday).">

--- a/en/reports/fresh/2026-07-06/index.html
+++ b/en/reports/fresh/2026-07-06/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-06/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-06/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-06/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-06/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-06/">
 <meta property="og:title" content="July 6, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 6, 2026 (Monday).">

--- a/en/reports/fresh/2026-07-07/index.html
+++ b/en/reports/fresh/2026-07-07/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-07/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-07/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-07/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-07/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-07/">
 <meta property="og:title" content="July 7, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 7, 2026 (Tuesday).">

--- a/en/reports/fresh/2026-07-08/index.html
+++ b/en/reports/fresh/2026-07-08/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-08/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-08/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-08/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-08/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-08/">
 <meta property="og:title" content="July 8, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 8, 2026 (Wednesday).">

--- a/en/reports/fresh/2026-07-09/index.html
+++ b/en/reports/fresh/2026-07-09/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-09/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-09/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-09/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-09/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-09/">
 <meta property="og:title" content="July 9, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 9, 2026 (Thursday).">

--- a/en/reports/fresh/2026-07-10/index.html
+++ b/en/reports/fresh/2026-07-10/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-10/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-10/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-10/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-10/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-10/">
 <meta property="og:title" content="July 10, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 10, 2026 (Friday).">

--- a/en/reports/fresh/2026-07-11/index.html
+++ b/en/reports/fresh/2026-07-11/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-11/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-11/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-11/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-11/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-11/">
 <meta property="og:title" content="July 11, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 11, 2026 (Saturday).">

--- a/en/reports/fresh/2026-07-12/index.html
+++ b/en/reports/fresh/2026-07-12/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-12/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-12/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-12/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-12/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-12/">
 <meta property="og:title" content="July 12, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 12, 2026 (Sunday).">

--- a/en/reports/fresh/2026-07-13/index.html
+++ b/en/reports/fresh/2026-07-13/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-13/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-13/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-13/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-13/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-13/">
 <meta property="og:title" content="July 13, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 13, 2026 (Monday).">

--- a/en/reports/fresh/2026-07-14/index.html
+++ b/en/reports/fresh/2026-07-14/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-14/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-14/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-14/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-14/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-14/">
 <meta property="og:title" content="July 14, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 14, 2026 (Tuesday).">

--- a/en/reports/fresh/2026-07-15/index.html
+++ b/en/reports/fresh/2026-07-15/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-15/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-15/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-15/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-15/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-15/">
 <meta property="og:title" content="July 15, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 15, 2026 (Wednesday).">

--- a/en/reports/fresh/2026-07-16/index.html
+++ b/en/reports/fresh/2026-07-16/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-16/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-16/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-16/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-16/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-16/">
 <meta property="og:title" content="July 16, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 16, 2026 (Thursday).">

--- a/en/reports/fresh/2026-07-17/index.html
+++ b/en/reports/fresh/2026-07-17/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-17/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-17/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-17/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-17/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-17/">
 <meta property="og:title" content="July 17, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 17, 2026 (Friday).">

--- a/en/reports/fresh/2026-07-18/index.html
+++ b/en/reports/fresh/2026-07-18/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-18/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-18/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-18/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-18/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-18/">
 <meta property="og:title" content="July 18, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 18, 2026 (Saturday).">

--- a/en/reports/fresh/2026-07-19/index.html
+++ b/en/reports/fresh/2026-07-19/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-19/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-19/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-19/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-19/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-19/">
 <meta property="og:title" content="July 19, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 19, 2026 (Sunday).">

--- a/en/reports/fresh/2026-07-20/index.html
+++ b/en/reports/fresh/2026-07-20/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-20/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-20/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-20/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-20/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-20/">
 <meta property="og:title" content="July 20, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 20, 2026 (Monday).">

--- a/en/reports/fresh/2026-07-21/index.html
+++ b/en/reports/fresh/2026-07-21/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-21/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-21/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-21/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-21/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-21/">
 <meta property="og:title" content="July 21, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 21, 2026 (Tuesday).">

--- a/en/reports/fresh/2026-07-22/index.html
+++ b/en/reports/fresh/2026-07-22/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-22/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-22/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-22/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-22/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-22/">
 <meta property="og:title" content="July 22, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 22, 2026 (Wednesday).">

--- a/en/reports/fresh/2026-07-23/index.html
+++ b/en/reports/fresh/2026-07-23/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-23/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-23/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-23/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-23/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-23/">
 <meta property="og:title" content="July 23, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 23, 2026 (Thursday).">

--- a/en/reports/fresh/2026-07-24/index.html
+++ b/en/reports/fresh/2026-07-24/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-24/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-24/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-24/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-24/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-24/">
 <meta property="og:title" content="July 24, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 24, 2026 (Friday).">

--- a/en/reports/fresh/2026-07-25/index.html
+++ b/en/reports/fresh/2026-07-25/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-25/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-25/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-25/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-25/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-25/">
 <meta property="og:title" content="July 25, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 25, 2026 (Saturday).">

--- a/en/reports/fresh/2026-07-26/index.html
+++ b/en/reports/fresh/2026-07-26/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-26/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-26/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-26/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-26/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-26/">
 <meta property="og:title" content="July 26, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 26, 2026 (Sunday).">

--- a/en/reports/fresh/2026-07-27/index.html
+++ b/en/reports/fresh/2026-07-27/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-27/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-27/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-27/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-27/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-27/">
 <meta property="og:title" content="July 27, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 27, 2026 (Monday).">

--- a/en/reports/fresh/2026-07-28/index.html
+++ b/en/reports/fresh/2026-07-28/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-28/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-28/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-28/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-28/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-28/">
 <meta property="og:title" content="July 28, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 28, 2026 (Tuesday).">

--- a/en/reports/fresh/2026-07-29/index.html
+++ b/en/reports/fresh/2026-07-29/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-29/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-29/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-29/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-29/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-29/">
 <meta property="og:title" content="July 29, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 29, 2026 (Wednesday).">

--- a/en/reports/fresh/2026-07-30/index.html
+++ b/en/reports/fresh/2026-07-30/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-30/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-30/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-30/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-30/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-30/">
 <meta property="og:title" content="July 30, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 30, 2026 (Thursday).">

--- a/en/reports/fresh/2026-07-31/index.html
+++ b/en/reports/fresh/2026-07-31/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-07-31/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-31/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-31/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-31/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-31/">
 <meta property="og:title" content="July 31, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for July 31, 2026 (Friday).">

--- a/en/reports/fresh/2026-08-01/index.html
+++ b/en/reports/fresh/2026-08-01/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-08-01/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-01/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-01/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-01/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-01/">
 <meta property="og:title" content="August 1, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 1, 2026 (Saturday).">

--- a/en/reports/fresh/2026-08-02/index.html
+++ b/en/reports/fresh/2026-08-02/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-08-02/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-02/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-02/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-02/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-02/">
 <meta property="og:title" content="August 2, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 2, 2026 (Sunday).">

--- a/en/reports/fresh/2026-08-03/index.html
+++ b/en/reports/fresh/2026-08-03/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-08-03/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-03/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-03/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-03/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-03/">
 <meta property="og:title" content="August 3, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 3, 2026 (Monday).">

--- a/en/reports/fresh/2026-08-04/index.html
+++ b/en/reports/fresh/2026-08-04/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-08-04/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-04/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-04/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-04/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-04/">
 <meta property="og:title" content="August 4, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 4, 2026 (Tuesday).">

--- a/en/reports/fresh/2026-08-05/index.html
+++ b/en/reports/fresh/2026-08-05/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-08-05/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-05/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-05/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-05/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-05/">
 <meta property="og:title" content="August 5, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 5, 2026 (Wednesday).">

--- a/en/reports/fresh/2026-08-06/index.html
+++ b/en/reports/fresh/2026-08-06/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-08-06/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-06/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-06/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-06/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-06/">
 <meta property="og:title" content="August 6, 2026 (Thursday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 6, 2026 (Thursday).">

--- a/en/reports/fresh/2026-08-07/index.html
+++ b/en/reports/fresh/2026-08-07/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-08-07/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-07/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-07/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-07/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-07/">
 <meta property="og:title" content="August 7, 2026 (Friday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 7, 2026 (Friday).">

--- a/en/reports/fresh/2026-08-08/index.html
+++ b/en/reports/fresh/2026-08-08/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-08-08/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-08/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-08/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-08/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-08/">
 <meta property="og:title" content="August 8, 2026 (Saturday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 8, 2026 (Saturday).">

--- a/en/reports/fresh/2026-08-09/index.html
+++ b/en/reports/fresh/2026-08-09/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-08-09/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-09/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-09/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-09/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-09/">
 <meta property="og:title" content="August 9, 2026 (Sunday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 9, 2026 (Sunday).">

--- a/en/reports/fresh/2026-08-10/index.html
+++ b/en/reports/fresh/2026-08-10/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-08-10/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-10/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-10/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-10/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-10/">
 <meta property="og:title" content="August 10, 2026 (Monday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 10, 2026 (Monday).">

--- a/en/reports/fresh/2026-08-11/index.html
+++ b/en/reports/fresh/2026-08-11/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-08-11/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-11/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-11/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-11/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-11/">
 <meta property="og:title" content="August 11, 2026 (Tuesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 11, 2026 (Tuesday).">

--- a/en/reports/fresh/2026-08-12/index.html
+++ b/en/reports/fresh/2026-08-12/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/2026-08-12/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-12/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-12/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-12/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-12/">
 <meta property="og:title" content="August 12, 2026 (Wednesday) · TreScout Daily Report">
 <meta property="og:description" content="TreScout Daily Technology Intelligence Report for August 12, 2026 (Wednesday).">

--- a/en/reports/fresh/index.html
+++ b/en/reports/fresh/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/fresh/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/">
 <meta property="og:title" content="Fresh Only Reports Archive · TreScout">
 <meta property="og:description" content="TreScout fresh-only daily reports · nothing that was already covered.">

--- a/en/reports/index.html
+++ b/en/reports/index.html
@@ -9,6 +9,7 @@
 <link rel="canonical" href="https://trescout.com/en/reports/">
 <link rel="alternate" hreflang="tr" href="https://trescout.com/reports/">
 <link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/">
 <link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/">
 <meta property="og:title" content="Daily Technology Reports Archive · TreScout">
 <meta property="og:description" content="TreScout daily technology reports archive · Curated AI summaries of GitHub, Hacker News, and HuggingFace trends every day.">

--- a/reports/2026-05-26/index.html
+++ b/reports/2026-05-26/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün geliştirici ekosisteminde yapay zekâ mühendisliği (AI engineering) temelleri ile siber güvenlik odaklı eklentilerin (plugins) entegrasyonu öne çıkıyor. GitHub üzerindeki güncel projeler, karmaş…">
 <link rel="canonical" href="https://trescout.com/reports/2026-05-26/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-05-26/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-05-26/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-05-26/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-05-26/">
 <meta property="og:title" content="26 Mayıs 2026, Salı · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün geliştirici ekosisteminde yapay zekâ mühendisliği (AI engineering) temelleri ile siber güvenlik odaklı eklentilerin (plugins) entegrasyonu öne çıkıyor. GitHub üzerindeki güncel projeler, karmaş…">
 <meta property="og:url" content="https://trescout.com/reports/2026-05-26/">

--- a/reports/2026-05-27/index.html
+++ b/reports/2026-05-27/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün odak noktası, büyük dil modellerinin (large language models) yeteneklerini genişleten eklentiler ve siber güvenlik odaklı özelleştirilmiş mimarilerdir. GitHub üzerindeki güncel paylaşımlar, ö…">
 <link rel="canonical" href="https://trescout.com/reports/2026-05-27/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-05-27/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-05-27/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-05-27/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-05-27/">
 <meta property="og:title" content="27 Mayıs 2026, Çarşamba · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün odak noktası, büyük dil modellerinin (large language models) yeteneklerini genişleten eklentiler ve siber güvenlik odaklı özelleştirilmiş mimarilerdir. GitHub üzerindeki güncel paylaşımlar, ö…">
 <meta property="og:url" content="https://trescout.com/reports/2026-05-27/">

--- a/reports/2026-05-28/index.html
+++ b/reports/2026-05-28/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündemini otonom içerik üretimi (automated content generation) ve karmaşık dokümanları anlamlandırmaya yarayan analiz araçları oluşturuyor. GitHub üzerinde paylaşılan açık kaynaklı…">
 <link rel="canonical" href="https://trescout.com/reports/2026-05-28/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-05-28/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-05-28/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-05-28/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-05-28/">
 <meta property="og:title" content="28 Mayıs 2026, Perşembe · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündemini otonom içerik üretimi (automated content generation) ve karmaşık dokümanları anlamlandırmaya yarayan analiz araçları oluşturuyor. GitHub üzerinde paylaşılan açık kaynaklı…">
 <meta property="og:url" content="https://trescout.com/reports/2026-05-28/">

--- a/reports/2026-05-29/index.html
+++ b/reports/2026-05-29/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün yazılım dünyasında otomasyon araçları (automation tools) ve açık kaynaklı müşteri ilişkileri yönetimi (CRM) sistemleri üzerine yoğun bir ilgi gözlemleniyor. GitHub üzerindeki güncel veriler, öz…">
 <link rel="canonical" href="https://trescout.com/reports/2026-05-29/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-05-29/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-05-29/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-05-29/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-05-29/">
 <meta property="og:title" content="29 Mayıs 2026, Cuma · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün yazılım dünyasında otomasyon araçları (automation tools) ve açık kaynaklı müşteri ilişkileri yönetimi (CRM) sistemleri üzerine yoğun bir ilgi gözlemleniyor. GitHub üzerindeki güncel veriler, öz…">
 <meta property="og:url" content="https://trescout.com/reports/2026-05-29/">

--- a/reports/2026-05-30/index.html
+++ b/reports/2026-05-30/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün yazılım geliştirme süreçlerinde otomasyon (automation) ve dosya ayrıştırma (parsing) teknolojileri öne çıkıyor. Özellikle Microsoft&#39;un belge işleme aracı ve Anthropic&#39;in kodlama asistanı, geliş…">
 <link rel="canonical" href="https://trescout.com/reports/2026-05-30/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-05-30/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-05-30/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-05-30/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-05-30/">
 <meta property="og:title" content="30 Mayıs 2026, Cumartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün yazılım geliştirme süreçlerinde otomasyon (automation) ve dosya ayrıştırma (parsing) teknolojileri öne çıkıyor. Özellikle Microsoft&#39;un belge işleme aracı ve Anthropic&#39;in kodlama asistanı, geliş…">
 <meta property="og:url" content="https://trescout.com/reports/2026-05-30/">

--- a/reports/2026-05-31/index.html
+++ b/reports/2026-05-31/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündemi, geliştirici araçlarının (developer tools) otomasyon ve dosya işleme süreçlerini hızlandıran yeni nesil komut satırı arayüzlerine (CLI) odaklanıyor. Özellikle Anthropic ve M…">
 <link rel="canonical" href="https://trescout.com/reports/2026-05-31/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-05-31/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-05-31/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-05-31/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-05-31/">
 <meta property="og:title" content="31 Mayıs 2026, Pazar · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündemi, geliştirici araçlarının (developer tools) otomasyon ve dosya işleme süreçlerini hızlandıran yeni nesil komut satırı arayüzlerine (CLI) odaklanıyor. Özellikle Anthropic ve M…">
 <meta property="og:url" content="https://trescout.com/reports/2026-05-31/">

--- a/reports/2026-06-01/index.html
+++ b/reports/2026-06-01/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün geliştirici ekosisteminde veri dönüştürme araçları (data conversion tools) ve otomasyon odaklı içerik üretim sistemleri öne çıkıyor. Microsoft tarafından yayınlanan MarkItDown gibi kütüphaneler…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-01/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-01/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-01/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-01/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-01/">
 <meta property="og:title" content="1 Haziran 2026, Pazartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün geliştirici ekosisteminde veri dönüştürme araçları (data conversion tools) ve otomasyon odaklı içerik üretim sistemleri öne çıkıyor. Microsoft tarafından yayınlanan MarkItDown gibi kütüphaneler…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-01/">

--- a/reports/2026-06-02/index.html
+++ b/reports/2026-06-02/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündemini veri dönüştürme araçları (data conversion tools) ve otomasyon odaklı web arayüzleri domine ediyor. GitHub üzerindeki popülerlik verileri, geliştiricilerin özellikle dosya…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-02/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-02/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-02/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-02/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-02/">
 <meta property="og:title" content="2 Haziran 2026, Salı · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündemini veri dönüştürme araçları (data conversion tools) ve otomasyon odaklı web arayüzleri domine ediyor. GitHub üzerindeki popülerlik verileri, geliştiricilerin özellikle dosya…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-02/">

--- a/reports/2026-06-03/index.html
+++ b/reports/2026-06-03/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündeminde veri işleme (data processing) ve web kazıma (web scraping) araçlarının otomasyon süreçlerini hızlandırdığı görülüyor. Özellikle Microsoft tarafından yayınlanan MarkItDown…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-03/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-03/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-03/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-03/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-03/">
 <meta property="og:title" content="3 Haziran 2026, Çarşamba · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündeminde veri işleme (data processing) ve web kazıma (web scraping) araçlarının otomasyon süreçlerini hızlandırdığı görülüyor. Özellikle Microsoft tarafından yayınlanan MarkItDown…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-03/">

--- a/reports/2026-06-04/index.html
+++ b/reports/2026-06-04/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündemi, belge işleme (document processing) süreçlerini otomatize eden araçlar ile büyük dil modelleri (large language models) için geliştirilen otonom ajan mimarileri etrafında şek…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-04/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-04/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-04/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-04/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-04/">
 <meta property="og:title" content="4 Haziran 2026, Perşembe · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündemi, belge işleme (document processing) süreçlerini otomatize eden araçlar ile büyük dil modelleri (large language models) için geliştirilen otonom ajan mimarileri etrafında şek…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-04/">

--- a/reports/2026-06-05/index.html
+++ b/reports/2026-06-05/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün öne çıkan başlıklar otonom ajanlar (autonomous agents) ve görsel tanıma sistemleri üzerine yoğunlaşıyor. Özellikle NousResearch tarafından yayınlanan ajan mimarileri ve NVIDIA&#39;nın görüntü işlem…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-05/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-05/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-05/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-05/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-05/">
 <meta property="og:title" content="5 Haziran 2026, Cuma · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün öne çıkan başlıklar otonom ajanlar (autonomous agents) ve görsel tanıma sistemleri üzerine yoğunlaşıyor. Özellikle NousResearch tarafından yayınlanan ajan mimarileri ve NVIDIA&#39;nın görüntü işlem…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-05/">

--- a/reports/2026-06-06/index.html
+++ b/reports/2026-06-06/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım dünyasında bugün otonom ajanlar (autonomous agents) ve bu ajanların uygulama arayüzlerine entegrasyonu (integration) üzerine yoğun bir geliştirici aktivitesi gözlemleniyor. GitHub üzerindeki…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-06/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-06/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-06/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-06/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-06/">
 <meta property="og:title" content="6 Haziran 2026, Cumartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım dünyasında bugün otonom ajanlar (autonomous agents) ve bu ajanların uygulama arayüzlerine entegrasyonu (integration) üzerine yoğun bir geliştirici aktivitesi gözlemleniyor. GitHub üzerindeki…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-06/">

--- a/reports/2026-06-07/index.html
+++ b/reports/2026-06-07/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım dünyası bugün kişisel yapay zekâ altyapısı (personal AI infrastructure) ve otonom ajanların bellek yönetimi (memory management) üzerine odaklanıyor. GitHub üzerindeki açık kaynaklı araçlar, k…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-07/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-07/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-07/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-07/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-07/">
 <meta property="og:title" content="7 Haziran 2026, Pazar · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım dünyası bugün kişisel yapay zekâ altyapısı (personal AI infrastructure) ve otonom ajanların bellek yönetimi (memory management) üzerine odaklanıyor. GitHub üzerindeki açık kaynaklı araçlar, k…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-07/">

--- a/reports/2026-06-08/index.html
+++ b/reports/2026-06-08/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündemini otonom yetenek setleri (skill sets) ve açık kaynaklı ajan (agent) mimarileri domine ediyor. Özellikle NousResearch tarafından yayınlanan Hermes modeli, geliştiricilerin ke…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-08/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-08/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-08/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-08/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-08/">
 <meta property="og:title" content="8 Haziran 2026, Pazartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündemini otonom yetenek setleri (skill sets) ve açık kaynaklı ajan (agent) mimarileri domine ediyor. Özellikle NousResearch tarafından yayınlanan Hermes modeli, geliştiricilerin ke…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-08/">

--- a/reports/2026-06-09/index.html
+++ b/reports/2026-06-09/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yapay zekâ ekosistemi bugün kişisel altyapı (personal AI infrastructure) ve yetenek yönetimi (skill management) üzerine odaklanan araçlarla genişliyor. Daniel Miessler&#39;in paylaştığı mimari şemalar ve…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-09/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-09/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-09/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-09/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-09/">
 <meta property="og:title" content="9 Haziran 2026, Salı · TreScout Günlük Rapor">
 <meta property="og:description" content="Yapay zekâ ekosistemi bugün kişisel altyapı (personal AI infrastructure) ve yetenek yönetimi (skill management) üzerine odaklanan araçlarla genişliyor. Daniel Miessler&#39;in paylaştığı mimari şemalar ve…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-09/">

--- a/reports/2026-06-10/index.html
+++ b/reports/2026-06-10/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündemi, bilgisayarlı görü (computer vision) kütüphaneleri ile geliştirici verimliliğini artıran otonom ajan (autonomous agent) araçları etrafında şekilleniyor. Roboflow ve OpenCV g…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-10/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-10/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-10/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-10/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-10/">
 <meta property="og:title" content="10 Haziran 2026, Çarşamba · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündemi, bilgisayarlı görü (computer vision) kütüphaneleri ile geliştirici verimliliğini artıran otonom ajan (autonomous agent) araçları etrafında şekilleniyor. Roboflow ve OpenCV g…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-10/">

--- a/reports/2026-06-11/index.html
+++ b/reports/2026-06-11/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündemini yapay zekâ ajanları (AI agents) için geliştirilen yetenek setleri (skill sets) ve dijital iz sürme araçları oluşturuyor. GitHub üzerindeki güncel depolar, özellikle otonom…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-11/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-11/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-11/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-11/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-11/">
 <meta property="og:title" content="11 Haziran 2026, Perşembe · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündemini yapay zekâ ajanları (AI agents) için geliştirilen yetenek setleri (skill sets) ve dijital iz sürme araçları oluşturuyor. GitHub üzerindeki güncel depolar, özellikle otonom…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-11/">

--- a/reports/2026-06-12/index.html
+++ b/reports/2026-06-12/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündemini otonom yetenek (agent skills) kütüphaneleri ve veri işleme araçları oluşturuyor. Geliştiriciler, özellikle açık kaynaklı yapay zekâ modellerini spesifik görevlere odaklaya…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-12/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-12/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-12/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-12/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-12/">
 <meta property="og:title" content="12 Haziran 2026, Cuma · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündemini otonom yetenek (agent skills) kütüphaneleri ve veri işleme araçları oluşturuyor. Geliştiriciler, özellikle açık kaynaklı yapay zekâ modellerini spesifik görevlere odaklaya…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-12/">

--- a/reports/2026-06-13/index.html
+++ b/reports/2026-06-13/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım dünyasında bugün otonom yetenek paketleri (agent skills) ve açık kaynaklı medya yönetimi çözümleri ön plana çıkıyor. GitHub verileri, geliştiricilerin özellikle konteyner (container) izolasyo…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-13/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-13/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-13/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-13/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-13/">
 <meta property="og:title" content="13 Haziran 2026, Cumartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım dünyasında bugün otonom yetenek paketleri (agent skills) ve açık kaynaklı medya yönetimi çözümleri ön plana çıkıyor. GitHub verileri, geliştiricilerin özellikle konteyner (container) izolasyo…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-13/">

--- a/reports/2026-06-14/index.html
+++ b/reports/2026-06-14/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım dünyasında bugün otonom yetenek paketleri (agent skills) ve açık kaynaklı altyapı yönetimi üzerine odaklanan projeler ön planda. GitHub verileri, özellikle uygulama konteynerleri (container)…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-14/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-14/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-14/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-14/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-14/">
 <meta property="og:title" content="14 Haziran 2026, Pazar · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım dünyasında bugün otonom yetenek paketleri (agent skills) ve açık kaynaklı altyapı yönetimi üzerine odaklanan projeler ön planda. GitHub verileri, özellikle uygulama konteynerleri (container)…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-14/">

--- a/reports/2026-06-15/index.html
+++ b/reports/2026-06-15/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün yazılım gündeminde açık kaynaklı altyapı araçları ve test otomasyonu (test automation) kütüphaneleri belirgin bir ağırlığa sahip. GitHub verileri, geliştiricilerin özellikle performans odaklı…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-15/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-15/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-15/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-15/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-15/">
 <meta property="og:title" content="15 Haziran 2026, Pazartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün yazılım gündeminde açık kaynaklı altyapı araçları ve test otomasyonu (test automation) kütüphaneleri belirgin bir ağırlığa sahip. GitHub verileri, geliştiricilerin özellikle performans odaklı…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-15/">

--- a/reports/2026-06-16/index.html
+++ b/reports/2026-06-16/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündeminde açık kaynak kodlu veri yönetimi ve otonom etkileşim sistemleri (autonomous interaction systems) ön planda yer alıyor. GitHub verileri, özellikle bulut yerel (cloud-native…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-16/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-16/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-16/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-16/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-16/">
 <meta property="og:title" content="16 Haziran 2026, Salı · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündeminde açık kaynak kodlu veri yönetimi ve otonom etkileşim sistemleri (autonomous interaction systems) ön planda yer alıyor. GitHub verileri, özellikle bulut yerel (cloud-native…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-16/">

--- a/reports/2026-06-17/index.html
+++ b/reports/2026-06-17/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündeminde yazılım geliştirme araçları (development tools) ve otomasyon kütüphaneleri öne çıkıyor. GitHub verileri, özellikle hızlı derleyiciler (compilers) ve tarayıcı otomasyonu (…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-17/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-17/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-17/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-17/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-17/">
 <meta property="og:title" content="17 Haziran 2026, Çarşamba · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündeminde yazılım geliştirme araçları (development tools) ve otomasyon kütüphaneleri öne çıkıyor. GitHub verileri, özellikle hızlı derleyiciler (compilers) ve tarayıcı otomasyonu (…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-17/">

--- a/reports/2026-06-18/index.html
+++ b/reports/2026-06-18/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündeminde kod tabanı bellek yönetimi (codebase memory) ve merkeziyetsiz ağ protokolleri üzerine kurulu altyapı araçları öne çıkıyor. Google Research tarafından yayınlanan zaman ser…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-18/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-18/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-18/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-18/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-18/">
 <meta property="og:title" content="18 Haziran 2026, Perşembe · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündeminde kod tabanı bellek yönetimi (codebase memory) ve merkeziyetsiz ağ protokolleri üzerine kurulu altyapı araçları öne çıkıyor. Google Research tarafından yayınlanan zaman ser…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-18/">

--- a/reports/2026-06-19/index.html
+++ b/reports/2026-06-19/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Zaman serisi tahminleme modelleri (time series forecasting) ve merkeziyetsiz ağ protokolleri bugün geliştirici ekosisteminde öne çıkan temel odak noktalarıdır. Özellikle Google tarafından yayınlanan…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-19/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-19/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-19/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-19/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-19/">
 <meta property="og:title" content="19 Haziran 2026, Cuma · TreScout Günlük Rapor">
 <meta property="og:description" content="Zaman serisi tahminleme modelleri (time series forecasting) ve merkeziyetsiz ağ protokolleri bugün geliştirici ekosisteminde öne çıkan temel odak noktalarıdır. Özellikle Google tarafından yayınlanan…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-19/">

--- a/reports/2026-06-20/index.html
+++ b/reports/2026-06-20/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün geliştirici ekosisteminde kod tabanı belleği (codebase memory) ve otonom ajan (autonomous agent) mimarileri üzerine odaklanan araçlar öne çıkıyor. Google Research tarafından paylaşılan zaman se…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-20/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-20/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-20/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-20/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-20/">
 <meta property="og:title" content="20 Haziran 2026, Cumartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün geliştirici ekosisteminde kod tabanı belleği (codebase memory) ve otonom ajan (autonomous agent) mimarileri üzerine odaklanan araçlar öne çıkıyor. Google Research tarafından paylaşılan zaman se…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-20/">

--- a/reports/2026-06-21/index.html
+++ b/reports/2026-06-21/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündeminde açık kaynaklı arayüz tasarımı (UI design) ve veri yönetimi (data management) araçları öne çıkıyor. Özellikle model bağlamı (model context) ve zaman serisi tahminleme (tim…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-21/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-21/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-21/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-21/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-21/">
 <meta property="og:title" content="21 Haziran 2026, Pazar · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündeminde açık kaynaklı arayüz tasarımı (UI design) ve veri yönetimi (data management) araçları öne çıkıyor. Özellikle model bağlamı (model context) ve zaman serisi tahminleme (tim…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-21/">

--- a/reports/2026-06-22/index.html
+++ b/reports/2026-06-22/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün gündeminde açık kaynaklı tasarım araçları (open-source design tools) ve veri tabanı yönetimi (database management) çözümleri ön plana çıkıyor. GitHub üzerindeki güncel hareketlilik, özellikle…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-22/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-22/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-22/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-22/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-22/">
 <meta property="og:title" content="22 Haziran 2026, Pazartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün gündeminde açık kaynaklı tasarım araçları (open-source design tools) ve veri tabanı yönetimi (database management) çözümleri ön plana çıkıyor. GitHub üzerindeki güncel hareketlilik, özellikle…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-22/">

--- a/reports/2026-06-23/index.html
+++ b/reports/2026-06-23/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Açık kaynaklı görüntü işleme ve üretken ses modelleri bugün geliştirici ekosisteminde yoğun ilgi görüyor. Siber güvenlik odaklı yapay zekâ yetenekleri (skills) ve PDF yönetimi araçları da GitHub üzer…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-23/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-23/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-23/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-23/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-23/">
 <meta property="og:title" content="23 Haziran 2026, Salı · TreScout Günlük Rapor">
 <meta property="og:description" content="Açık kaynaklı görüntü işleme ve üretken ses modelleri bugün geliştirici ekosisteminde yoğun ilgi görüyor. Siber güvenlik odaklı yapay zekâ yetenekleri (skills) ve PDF yönetimi araçları da GitHub üzer…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-23/">

--- a/reports/2026-06-24/index.html
+++ b/reports/2026-06-24/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün yazılım dünyasında açık kaynaklı görsel kurgu araçları (open-source video editing) ve finansal analiz otomasyonları öne çıkan başlıklar arasında yer alıyor. Siber güvenlik yetkinliklerini geliş…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-24/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-24/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-24/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-24/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-24/">
 <meta property="og:title" content="24 Haziran 2026, Çarşamba · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün yazılım dünyasında açık kaynaklı görsel kurgu araçları (open-source video editing) ve finansal analiz otomasyonları öne çıkan başlıklar arasında yer alıyor. Siber güvenlik yetkinliklerini geliş…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-24/">

--- a/reports/2026-06-25/index.html
+++ b/reports/2026-06-25/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün yazılım dünyasında odak noktası, işe alım süreçlerini otomatize eden ajanlar (hiring agents) ve veri görselleştirme araçları üzerine yoğunlaşıyor. Özellikle Apple&#39;ın konteyner (container) mimar…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-25/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-25/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-25/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-25/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-25/">
 <meta property="og:title" content="25 Haziran 2026, Perşembe · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün yazılım dünyasında odak noktası, işe alım süreçlerini otomatize eden ajanlar (hiring agents) ve veri görselleştirme araçları üzerine yoğunlaşıyor. Özellikle Apple&#39;ın konteyner (container) mimar…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-25/">

--- a/reports/2026-06-26/index.html
+++ b/reports/2026-06-26/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım dünyasında bugün odak noktası, Apple tarafından paylaşılan konteyner (container) mimarileri ve açık kaynaklı yapay zekâ araçlarının geliştirme süreçlerine entegrasyonu üzerine yoğunlaşıyor. G…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-26/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-26/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-26/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-26/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-26/">
 <meta property="og:title" content="26 Haziran 2026, Cuma · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım dünyasında bugün odak noktası, Apple tarafından paylaşılan konteyner (container) mimarileri ve açık kaynaklı yapay zekâ araçlarının geliştirme süreçlerine entegrasyonu üzerine yoğunlaşıyor. G…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-26/">

--- a/reports/2026-06-27/index.html
+++ b/reports/2026-06-27/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündeminde merkeziyetsiz iletişim protokolleri (decentralized communication) ile otonom sürüş sistemleri (autonomous driving) arasındaki teknik verimlilik arayışı öne çıkıyor. GitHu…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-27/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-27/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-27/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-27/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-27/">
 <meta property="og:title" content="27 Haziran 2026, Cumartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündeminde merkeziyetsiz iletişim protokolleri (decentralized communication) ile otonom sürüş sistemleri (autonomous driving) arasındaki teknik verimlilik arayışı öne çıkıyor. GitHu…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-27/">

--- a/reports/2026-06-28/index.html
+++ b/reports/2026-06-28/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündemini uçtan uca şifreli mesajlaşma (end-to-end encrypted messaging) protokolleri ile açık kaynak kodlu kişisel bulut (personal cloud) çözümleri oluşturuyor. GitHub üzerindeki ge…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-28/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-28/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-28/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-28/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-28/">
 <meta property="og:title" content="28 Haziran 2026, Pazar · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündemini uçtan uca şifreli mesajlaşma (end-to-end encrypted messaging) protokolleri ile açık kaynak kodlu kişisel bulut (personal cloud) çözümleri oluşturuyor. GitHub üzerindeki ge…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-28/">

--- a/reports/2026-06-29/index.html
+++ b/reports/2026-06-29/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündeminde merkeziyetsiz iletişim protokolleri ve otonom sürüş sistemleri (autonomous driving systems) gibi teknik derinliği yüksek projeler öne çıkıyor. Geliştirici kaynakları (dev…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-29/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-29/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-29/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-29/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-29/">
 <meta property="og:title" content="29 Haziran 2026, Pazartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündeminde merkeziyetsiz iletişim protokolleri ve otonom sürüş sistemleri (autonomous driving systems) gibi teknik derinliği yüksek projeler öne çıkıyor. Geliştirici kaynakları (dev…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-29/">

--- a/reports/2026-06-30/index.html
+++ b/reports/2026-06-30/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündemi merkeziyetsiz iletişim protokolleri (decentralized communication protocols) ile otonom sürüş sistemleri (autonomous driving systems) arasındaki dengeye odaklanıyor. GitHub v…">
 <link rel="canonical" href="https://trescout.com/reports/2026-06-30/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-06-30/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-06-30/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-06-30/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-06-30/">
 <meta property="og:title" content="30 Haziran 2026, Salı · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündemi merkeziyetsiz iletişim protokolleri (decentralized communication protocols) ile otonom sürüş sistemleri (autonomous driving systems) arasındaki dengeye odaklanıyor. GitHub v…">
 <meta property="og:url" content="https://trescout.com/reports/2026-06-30/">

--- a/reports/2026-07-01/index.html
+++ b/reports/2026-07-01/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün yazılım dünyasında otonom ajanlar (autonomous agents) ve tarayıcı tabanlı etkileşim (browser-based interaction) yetenekleri üzerine odaklanan projeler öne çıkıyor. GitHub üzerindeki veriseti ve…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-01/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-01/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-01/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-01/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-01/">
 <meta property="og:title" content="1 Temmuz 2026, Çarşamba · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün yazılım dünyasında otonom ajanlar (autonomous agents) ve tarayıcı tabanlı etkileşim (browser-based interaction) yetenekleri üzerine odaklanan projeler öne çıkıyor. GitHub üzerindeki veriseti ve…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-01/">

--- a/reports/2026-07-02/index.html
+++ b/reports/2026-07-02/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Otonom ajanlar (autonomous agents) ve karar destek sistemleri bugün geliştirici ekosisteminde merkezi bir konuma yerleşti. GitHub üzerindeki güncel projeler, veri seti yönetimi (dataset management) v…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-02/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-02/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-02/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-02/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-02/">
 <meta property="og:title" content="2 Temmuz 2026, Perşembe · TreScout Günlük Rapor">
 <meta property="og:description" content="Otonom ajanlar (autonomous agents) ve karar destek sistemleri bugün geliştirici ekosisteminde merkezi bir konuma yerleşti. GitHub üzerindeki güncel projeler, veri seti yönetimi (dataset management) v…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-02/">

--- a/reports/2026-07-03/index.html
+++ b/reports/2026-07-03/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündeminde otonom yazılım ajanları (autonomous agents) ve bu sistemlerin geliştirilmesine yönelik altyapı araçları öne çıkıyor. GitHub verileri, özellikle karmaşık görev yönetimi ve…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-03/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-03/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-03/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-03/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-03/">
 <meta property="og:title" content="3 Temmuz 2026, Cuma · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündeminde otonom yazılım ajanları (autonomous agents) ve bu sistemlerin geliştirilmesine yönelik altyapı araçları öne çıkıyor. GitHub verileri, özellikle karmaşık görev yönetimi ve…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-03/">

--- a/reports/2026-07-04/index.html
+++ b/reports/2026-07-04/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım dünyasında bugün geliştirici araçları (developer tools) ve yapay zekâ destekli kodlama asistanları arasındaki entegrasyon protokolleri ön plana çıkıyor. Özellikle Chrome DevTools tarafındaki…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-04/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-04/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-04/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-04/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-04/">
 <meta property="og:title" content="4 Temmuz 2026, Cumartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım dünyasında bugün geliştirici araçları (developer tools) ve yapay zekâ destekli kodlama asistanları arasındaki entegrasyon protokolleri ön plana çıkıyor. Özellikle Chrome DevTools tarafındaki…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-04/">

--- a/reports/2026-07-05/index.html
+++ b/reports/2026-07-05/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım geliştirme süreçlerinde yapay zekâ ajanları (AI agents) ve tarayıcı tabanlı otomasyon araçları bugün baskın bir ivme yakaladı. Özellikle geliştirici araçları (developer tools) ile bütünleşik…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-05/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-05/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-05/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-05/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-05/">
 <meta property="og:title" content="5 Temmuz 2026, Pazar · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım geliştirme süreçlerinde yapay zekâ ajanları (AI agents) ve tarayıcı tabanlı otomasyon araçları bugün baskın bir ivme yakaladı. Özellikle geliştirici araçları (developer tools) ile bütünleşik…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-05/">

--- a/reports/2026-07-06/index.html
+++ b/reports/2026-07-06/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün gündemi, büyük dil modellerine yetenek (skill) kazandıran entegrasyonlar ve sistem talimatlarının (system prompts) güvenlik açıklarına odaklanıyor. GitHub üzerindeki güncel depolar, geliştiri…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-06/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-06/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-06/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-06/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-06/">
 <meta property="og:title" content="6 Temmuz 2026, Pazartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün gündemi, büyük dil modellerine yetenek (skill) kazandıran entegrasyonlar ve sistem talimatlarının (system prompts) güvenlik açıklarına odaklanıyor. GitHub üzerindeki güncel depolar, geliştiri…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-06/">

--- a/reports/2026-07-07/index.html
+++ b/reports/2026-07-07/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yapay zekâ sistemlerinde yetenek paketleri (skills) ve istem sızıntıları (prompt leaks) bugün geliştirici ekosisteminin merkezinde yer alıyor. GitHub üzerindeki açık kaynaklı projeler, özellikle Clau…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-07/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-07/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-07/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-07/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-07/">
 <meta property="og:title" content="7 Temmuz 2026, Salı · TreScout Günlük Rapor">
 <meta property="og:description" content="Yapay zekâ sistemlerinde yetenek paketleri (skills) ve istem sızıntıları (prompt leaks) bugün geliştirici ekosisteminin merkezinde yer alıyor. GitHub üzerindeki açık kaynaklı projeler, özellikle Clau…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-07/">

--- a/reports/2026-07-08/index.html
+++ b/reports/2026-07-08/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündemini otonom yetenek setleri (agent skills) ve sistem komutlarının (system prompts) güvenliği üzerine kurulu bir yapı belirliyor. Özellikle açık kaynaklı iş arama otomasyonları…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-08/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-08/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-08/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-08/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-08/">
 <meta property="og:title" content="8 Temmuz 2026, Çarşamba · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündemini otonom yetenek setleri (agent skills) ve sistem komutlarının (system prompts) güvenliği üzerine kurulu bir yapı belirliyor. Özellikle açık kaynaklı iş arama otomasyonları…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-08/">

--- a/reports/2026-07-09/index.html
+++ b/reports/2026-07-09/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yapay zekâ tabanlı iş arama ve otonom ajanların yetenek setleri (agent skills) bugün geliştirici ekosisteminin merkezinde yer alıyor. Özellikle veri tabanı bellek mimarileri (database memory architec…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-09/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-09/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-09/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-09/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-09/">
 <meta property="og:title" content="9 Temmuz 2026, Perşembe · TreScout Günlük Rapor">
 <meta property="og:description" content="Yapay zekâ tabanlı iş arama ve otonom ajanların yetenek setleri (agent skills) bugün geliştirici ekosisteminin merkezinde yer alıyor. Özellikle veri tabanı bellek mimarileri (database memory architec…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-09/">

--- a/reports/2026-07-10/index.html
+++ b/reports/2026-07-10/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım geliştirme dünyasında bugün odak noktası, yapay zekâ ajanlarının (AI agents) yeteneklerini genişleten araçlar ve bu sistemlerin masaüstü etkileşimlerini yöneten protokoller (MCP) üzerine yoğu…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-10/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-10/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-10/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-10/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-10/">
 <meta property="og:title" content="10 Temmuz 2026, Cuma · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım geliştirme dünyasında bugün odak noktası, yapay zekâ ajanlarının (AI agents) yeteneklerini genişleten araçlar ve bu sistemlerin masaüstü etkileşimlerini yöneten protokoller (MCP) üzerine yoğu…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-10/">

--- a/reports/2026-07-11/index.html
+++ b/reports/2026-07-11/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündeminde otonom yazılım ajanları (AI agents) için geliştirilen yetenek setleri ve sistem seviyesindeki performans odaklı araçlar öne çıkıyor. GitHub üzerindeki güncel veriler, gel…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-11/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-11/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-11/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-11/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-11/">
 <meta property="og:title" content="11 Temmuz 2026, Cumartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündeminde otonom yazılım ajanları (AI agents) için geliştirilen yetenek setleri ve sistem seviyesindeki performans odaklı araçlar öne çıkıyor. GitHub üzerindeki güncel veriler, gel…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-11/">

--- a/reports/2026-07-12/index.html
+++ b/reports/2026-07-12/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün yazılım dünyasında C++ ekosistemindeki test kütüphaneleri (testing frameworks) ve düşük seviyeli bellek optimizasyon araçları öne çıkıyor. Google kaynaklı kod becerileri (code skills) ve altyap…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-12/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-12/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-12/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-12/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-12/">
 <meta property="og:title" content="12 Temmuz 2026, Pazar · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün yazılım dünyasında C++ ekosistemindeki test kütüphaneleri (testing frameworks) ve düşük seviyeli bellek optimizasyon araçları öne çıkıyor. Google kaynaklı kod becerileri (code skills) ve altyap…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-12/">

--- a/reports/2026-07-13/index.html
+++ b/reports/2026-07-13/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün geliştirici ekosisteminde komut satırı güvenliği (command line security) ve MCP (Model Context Protocol) entegrasyonları üzerinden otonom sistemlerin yönetimi öne çıkıyor. GitHub üzerindeki gün…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-13/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-13/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-13/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-13/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-13/">
 <meta property="og:title" content="13 Temmuz 2026, Pazartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün geliştirici ekosisteminde komut satırı güvenliği (command line security) ve MCP (Model Context Protocol) entegrasyonları üzerinden otonom sistemlerin yönetimi öne çıkıyor. GitHub üzerindeki gün…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-13/">

--- a/reports/2026-07-14/index.html
+++ b/reports/2026-07-14/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım dünyasında bugün açık kaynaklı video düzenleme araçları ve büyük dil modelleri (large language models) tabanlı uygulamalar geliştirme eğilimi öne çıkıyor. GitHub üzerinde paylaşılan sistem te…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-14/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-14/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-14/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-14/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-14/">
 <meta property="og:title" content="14 Temmuz 2026, Salı · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım dünyasında bugün açık kaynaklı video düzenleme araçları ve büyük dil modelleri (large language models) tabanlı uygulamalar geliştirme eğilimi öne çıkıyor. GitHub üzerinde paylaşılan sistem te…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-14/">

--- a/reports/2026-07-15/index.html
+++ b/reports/2026-07-15/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündeminde bağımsız geliştiricilerin açık kaynaklı yapay zeka uygulamaları (AI apps) ve finansal piyasalara yönelik otonom model mimarileri öne çıkıyor. GitHub üzerindeki popüler de…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-15/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-15/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-15/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-15/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-15/">
 <meta property="og:title" content="15 Temmuz 2026, Çarşamba · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündeminde bağımsız geliştiricilerin açık kaynaklı yapay zeka uygulamaları (AI apps) ve finansal piyasalara yönelik otonom model mimarileri öne çıkıyor. GitHub üzerindeki popüler de…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-15/">

--- a/reports/2026-07-16/index.html
+++ b/reports/2026-07-16/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün yazılım dünyasında açık kaynaklı video düzenleme araçları (open-source video editing tools) ile ticaret stratejilerini optimize eden algoritmik modeller ön plana çıkıyor. GitHub verileri, geliş…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-16/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-16/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-16/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-16/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-16/">
 <meta property="og:title" content="16 Temmuz 2026, Perşembe · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün yazılım dünyasında açık kaynaklı video düzenleme araçları (open-source video editing tools) ile ticaret stratejilerini optimize eden algoritmik modeller ön plana çıkıyor. GitHub verileri, geliş…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-16/">

--- a/reports/2026-07-17/index.html
+++ b/reports/2026-07-17/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün açık kaynak dünyasında yerel modellerin (local models) yürütülmesi ve kullanıcı etkileşimli analiz araçları ön planda yer alıyor. Özellikle kod yorumlayıcılar (code interpreters) ve veri analit…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-17/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-17/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-17/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-17/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-17/">
 <meta property="og:title" content="17 Temmuz 2026, Cuma · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün açık kaynak dünyasında yerel modellerin (local models) yürütülmesi ve kullanıcı etkileşimli analiz araçları ön planda yer alıyor. Özellikle kod yorumlayıcılar (code interpreters) ve veri analit…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-17/">

--- a/reports/2026-07-18/index.html
+++ b/reports/2026-07-18/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım geliştirme süreçlerinde kendi araçlarını inşa etme (build your own x) eğilimi ile yapay zekâ destekli kodlama asistanları (coding assistants) bugün ön planda. GitHub üzerindeki güncel veriler…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-18/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-18/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-18/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-18/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-18/">
 <meta property="og:title" content="18 Temmuz 2026, Cumartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım geliştirme süreçlerinde kendi araçlarını inşa etme (build your own x) eğilimi ile yapay zekâ destekli kodlama asistanları (coding assistants) bugün ön planda. GitHub üzerindeki güncel veriler…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-18/">

--- a/reports/2026-07-19/index.html
+++ b/reports/2026-07-19/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün geliştirici araçları ve yapay zekâ mühendisliği (AI engineering) pratikleri üzerine yoğunlaşan bir hareketlilik gözlemleniyor. GitHub üzerinde açık kaynaklı veri analitiği (analytics) ve kod in…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-19/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-19/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-19/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-19/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-19/">
 <meta property="og:title" content="19 Temmuz 2026, Pazar · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün geliştirici araçları ve yapay zekâ mühendisliği (AI engineering) pratikleri üzerine yoğunlaşan bir hareketlilik gözlemleniyor. GitHub üzerinde açık kaynaklı veri analitiği (analytics) ve kod in…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-19/">

--- a/reports/2026-07-20/index.html
+++ b/reports/2026-07-20/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım geliştirme süreçlerinde otonom ajan (autonomous agent) mimarileri ve kod inceleme (code review) otomasyonları bugün geliştirici topluluğunun ana odak noktasını oluşturuyor. GitHub üzerindeki…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-20/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-20/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-20/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-20/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-20/">
 <meta property="og:title" content="20 Temmuz 2026, Pazartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım geliştirme süreçlerinde otonom ajan (autonomous agent) mimarileri ve kod inceleme (code review) otomasyonları bugün geliştirici topluluğunun ana odak noktasını oluşturuyor. GitHub üzerindeki…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-20/">

--- a/reports/2026-07-21/index.html
+++ b/reports/2026-07-21/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım geliştirme süreçlerinde kod inceleme (code review) otomasyonu ve yapay zekâ destekli otonom ajan (autonomous agent) mimarileri bugün geliştirici ekosisteminin merkezinde yer alıyor. GitHub ve…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-21/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-21/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-21/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-21/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-21/">
 <meta property="og:title" content="21 Temmuz 2026, Salı · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım geliştirme süreçlerinde kod inceleme (code review) otomasyonu ve yapay zekâ destekli otonom ajan (autonomous agent) mimarileri bugün geliştirici ekosisteminin merkezinde yer alıyor. GitHub ve…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-21/">

--- a/reports/2026-07-22/index.html
+++ b/reports/2026-07-22/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım dünyasında bugün otonom ajan (autonomous agent) mimarileri ve kod analizi süreçlerini otomatize eden araçlar ön plana çıkıyor. GitHub üzerinde paylaşılan açık kaynaklı projeler, özellikle kar…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-22/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-22/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-22/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-22/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-22/">
 <meta property="og:title" content="22 Temmuz 2026, Çarşamba · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım dünyasında bugün otonom ajan (autonomous agent) mimarileri ve kod analizi süreçlerini otomatize eden araçlar ön plana çıkıyor. GitHub üzerinde paylaşılan açık kaynaklı projeler, özellikle kar…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-22/">

--- a/reports/2026-07-23/index.html
+++ b/reports/2026-07-23/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün yazılım dünyasında sistem izleme (monitoring) ve veri aktarımı (data transfer) araçları öne çıkarken, mimari görselleştirme (architecture visualization) projeleri dikkat çekiyor. GitHub üzerind…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-23/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-23/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-23/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-23/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-23/">
 <meta property="og:title" content="23 Temmuz 2026, Perşembe · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün yazılım dünyasında sistem izleme (monitoring) ve veri aktarımı (data transfer) araçları öne çıkarken, mimari görselleştirme (architecture visualization) projeleri dikkat çekiyor. GitHub üzerind…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-23/">

--- a/reports/2026-07-24/index.html
+++ b/reports/2026-07-24/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Günün odak noktası sistem izleme (monitoring) ve otonom görev yönetimi araçları üzerine yoğunlaşıyor. GitHub verileri, özellikle altyapı takibi (infrastructure monitoring) ve yazılım geliştirme süreç…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-24/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-24/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-24/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-24/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-24/">
 <meta property="og:title" content="24 Temmuz 2026, Cuma · TreScout Günlük Rapor">
 <meta property="og:description" content="Günün odak noktası sistem izleme (monitoring) ve otonom görev yönetimi araçları üzerine yoğunlaşıyor. GitHub verileri, özellikle altyapı takibi (infrastructure monitoring) ve yazılım geliştirme süreç…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-24/">

--- a/reports/2026-07-25/index.html
+++ b/reports/2026-07-25/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün odak noktası, otonom ajanların (autonomous agents) yetenek setlerini genişleten ve sistem izleme (monitoring) süreçlerini otomatize eden araçlar üzerinde yoğunlaşıyor. GitHub verileri, özelli…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-25/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-25/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-25/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-25/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-25/">
 <meta property="og:title" content="25 Temmuz 2026, Cumartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün odak noktası, otonom ajanların (autonomous agents) yetenek setlerini genişleten ve sistem izleme (monitoring) süreçlerini otomatize eden araçlar üzerinde yoğunlaşıyor. GitHub verileri, özelli…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-25/">

--- a/reports/2026-07-26/index.html
+++ b/reports/2026-07-26/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün gündemi, yazılım geliştirme süreçlerini hızlandıran kod inceleme (code review) araçları ve yapay zekâ modellerine yetenek kazandıran entegrasyon kütüphaneleri üzerine kurulu. GitHub üzerinde…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-26/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-26/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-26/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-26/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-26/">
 <meta property="og:title" content="26 Temmuz 2026, Pazar · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün gündemi, yazılım geliştirme süreçlerini hızlandıran kod inceleme (code review) araçları ve yapay zekâ modellerine yetenek kazandıran entegrasyon kütüphaneleri üzerine kurulu. GitHub üzerinde…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-26/">

--- a/reports/2026-07-27/index.html
+++ b/reports/2026-07-27/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündeminde merkeziyetsiz iletişim protokolleri (decentralized communication protocols) ve terminal tabanlı dosya yönetimi (terminal-based file management) araçları öne çıkıyor. Geli…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-27/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-27/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-27/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-27/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-27/">
 <meta property="og:title" content="27 Temmuz 2026, Pazartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündeminde merkeziyetsiz iletişim protokolleri (decentralized communication protocols) ve terminal tabanlı dosya yönetimi (terminal-based file management) araçları öne çıkıyor. Geli…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-27/">

--- a/reports/2026-07-28/index.html
+++ b/reports/2026-07-28/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündemi merkeziyetsiz iletişim protokolleri ve ağ sansürünü aşmaya odaklanan araçlar (censorship circumvention tools) etrafında şekilleniyor. Açık kaynaklı dosya yöneticileri ve ver…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-28/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-28/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-28/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-28/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-28/">
 <meta property="og:title" content="28 Temmuz 2026, Salı · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündemi merkeziyetsiz iletişim protokolleri ve ağ sansürünü aşmaya odaklanan araçlar (censorship circumvention tools) etrafında şekilleniyor. Açık kaynaklı dosya yöneticileri ve ver…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-28/">

--- a/reports/2026-07-29/index.html
+++ b/reports/2026-07-29/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün teknoloji gündeminde yapay zekâ geliştirme araçları (AI development tools) ve sürekli entegrasyon sistemleri (CI/CD systems) ön planda yer alıyor. Andrew Ng tarafından paylaşılan çoklu model…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-29/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-29/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-29/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-29/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-29/">
 <meta property="og:title" content="29 Temmuz 2026, Çarşamba · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün teknoloji gündeminde yapay zekâ geliştirme araçları (AI development tools) ve sürekli entegrasyon sistemleri (CI/CD systems) ön planda yer alıyor. Andrew Ng tarafından paylaşılan çoklu model…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-29/">

--- a/reports/2026-07-30/index.html
+++ b/reports/2026-07-30/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Coğrafi veri işleme kütüphaneleri ve ses tabanlı etkileşim modelleri, açık kaynak dünyasında geliştirici odaklı araçların merkezine yerleşti. Özellikle konuşmadan konuşmaya (speech-to-speech) çeviri…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-30/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-30/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-30/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-30/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-30/">
 <meta property="og:title" content="30 Temmuz 2026, Perşembe · TreScout Günlük Rapor">
 <meta property="og:description" content="Coğrafi veri işleme kütüphaneleri ve ses tabanlı etkileşim modelleri, açık kaynak dünyasında geliştirici odaklı araçların merkezine yerleşti. Özellikle konuşmadan konuşmaya (speech-to-speech) çeviri…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-30/">

--- a/reports/2026-07-31/index.html
+++ b/reports/2026-07-31/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün yazılım dünyasında ses tabanlı etkileşim (speech-to-speech) modelleri ve sistematik ticaret (systematic trading) kütüphaneleri geliştiricilerin odak noktasında yer alıyor. GitHub verileri, özel…">
 <link rel="canonical" href="https://trescout.com/reports/2026-07-31/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-07-31/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-07-31/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-07-31/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-07-31/">
 <meta property="og:title" content="31 Temmuz 2026, Cuma · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün yazılım dünyasında ses tabanlı etkileşim (speech-to-speech) modelleri ve sistematik ticaret (systematic trading) kütüphaneleri geliştiricilerin odak noktasında yer alıyor. GitHub verileri, özel…">
 <meta property="og:url" content="https://trescout.com/reports/2026-07-31/">

--- a/reports/2026-08-01/index.html
+++ b/reports/2026-08-01/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım geliştirme süreçlerinde otomasyon yetenekleri (skill) ve sistemli ticaret (systematic trading) stratejileri bugün geliştirici topluluğunun ana gündemini oluşturuyor. Microsoft tarafından payl…">
 <link rel="canonical" href="https://trescout.com/reports/2026-08-01/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-01/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-01/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-01/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-01/">
 <meta property="og:title" content="1 Ağustos 2026, Cumartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım geliştirme süreçlerinde otomasyon yetenekleri (skill) ve sistemli ticaret (systematic trading) stratejileri bugün geliştirici topluluğunun ana gündemini oluşturuyor. Microsoft tarafından payl…">
 <meta property="og:url" content="https://trescout.com/reports/2026-08-01/">

--- a/reports/2026-08-02/index.html
+++ b/reports/2026-08-02/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün teknoloji gündeminde yapay zekâ modellerindeki token sıkıştırma (token compression) teknikleri ve yazılım geliştirme metodolojileri öne çıkıyor. DeepSeek ve Kimi gibi yeni nesil dil modelleri (…">
 <link rel="canonical" href="https://trescout.com/reports/2026-08-02/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-02/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-02/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-02/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-02/">
 <meta property="og:title" content="2 Ağustos 2026, Pazar · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün teknoloji gündeminde yapay zekâ modellerindeki token sıkıştırma (token compression) teknikleri ve yazılım geliştirme metodolojileri öne çıkıyor. DeepSeek ve Kimi gibi yeni nesil dil modelleri (…">
 <meta property="og:url" content="https://trescout.com/reports/2026-08-02/">

--- a/reports/2026-08-03/index.html
+++ b/reports/2026-08-03/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün yazılım geliştirme süreçlerinde hız odaklı modellerin (speed-oriented models) zekâ kapasitesinin önüne geçtiği ve veri yapılarındaki güvenilirlik sorunlarının tartışıldığı bir gün. Özellikle De…">
 <link rel="canonical" href="https://trescout.com/reports/2026-08-03/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-03/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-03/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-03/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-03/">
 <meta property="og:title" content="3 Ağustos 2026, Pazartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün yazılım geliştirme süreçlerinde hız odaklı modellerin (speed-oriented models) zekâ kapasitesinin önüne geçtiği ve veri yapılarındaki güvenilirlik sorunlarının tartışıldığı bir gün. Özellikle De…">
 <meta property="og:url" content="https://trescout.com/reports/2026-08-03/">

--- a/reports/2026-08-04/index.html
+++ b/reports/2026-08-04/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün geliştirici araçlarının açık kaynak (open source) olması gerektiği tartışmaları ile yüksek performanslı dil modellerinin (LLMs) uzmanlık seviyesini ödüllendiren yeni mimariler öne çıkıyor. GitH…">
 <link rel="canonical" href="https://trescout.com/reports/2026-08-04/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-04/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-04/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-04/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-04/">
 <meta property="og:title" content="4 Ağustos 2026, Salı · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün geliştirici araçlarının açık kaynak (open source) olması gerektiği tartışmaları ile yüksek performanslı dil modellerinin (LLMs) uzmanlık seviyesini ödüllendiren yeni mimariler öne çıkıyor. GitH…">
 <meta property="og:url" content="https://trescout.com/reports/2026-08-04/">

--- a/reports/2026-08-05/index.html
+++ b/reports/2026-08-05/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yapay zeka ajanlarının (AI agents) bellek yönetimi ve kişisel veri güvenliği bugün teknik tartışmaların merkezinde yer alıyor. DeepSeek ve MiniMax gibi modellerin yeni sürümleri, çok modlu (multimoda…">
 <link rel="canonical" href="https://trescout.com/reports/2026-08-05/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-05/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-05/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-05/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-05/">
 <meta property="og:title" content="5 Ağustos 2026, Çarşamba · TreScout Günlük Rapor">
 <meta property="og:description" content="Yapay zeka ajanlarının (AI agents) bellek yönetimi ve kişisel veri güvenliği bugün teknik tartışmaların merkezinde yer alıyor. DeepSeek ve MiniMax gibi modellerin yeni sürümleri, çok modlu (multimoda…">
 <meta property="og:url" content="https://trescout.com/reports/2026-08-05/">

--- a/reports/2026-08-06/index.html
+++ b/reports/2026-08-06/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yapay zekâ ekosisteminde otonom ajanlar (autonomous agents) arası güvenlik testleri ve yeni nesil dil modelleri (large language models) bugün teknoloji gündeminin merkezinde yer alıyor. Google DeepMi…">
 <link rel="canonical" href="https://trescout.com/reports/2026-08-06/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-06/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-06/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-06/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-06/">
 <meta property="og:title" content="6 Ağustos 2026, Perşembe · TreScout Günlük Rapor">
 <meta property="og:description" content="Yapay zekâ ekosisteminde otonom ajanlar (autonomous agents) arası güvenlik testleri ve yeni nesil dil modelleri (large language models) bugün teknoloji gündeminin merkezinde yer alıyor. Google DeepMi…">
 <meta property="og:url" content="https://trescout.com/reports/2026-08-06/">

--- a/reports/2026-08-07/index.html
+++ b/reports/2026-08-07/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yapay zekâ ekosisteminde bugün odak noktası, donanım seviyesinde çıkarım (inference) performansını artırmak ve ajan yeteneklerini (agent skills) standart bir çerçeveye oturtmak üzerine kurulu. AMD&#39;ni…">
 <link rel="canonical" href="https://trescout.com/reports/2026-08-07/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-07/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-07/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-07/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-07/">
 <meta property="og:title" content="7 Ağustos 2026, Cuma · TreScout Günlük Rapor">
 <meta property="og:description" content="Yapay zekâ ekosisteminde bugün odak noktası, donanım seviyesinde çıkarım (inference) performansını artırmak ve ajan yeteneklerini (agent skills) standart bir çerçeveye oturtmak üzerine kurulu. AMD&#39;ni…">
 <meta property="og:url" content="https://trescout.com/reports/2026-08-07/">

--- a/reports/2026-08-08/index.html
+++ b/reports/2026-08-08/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yapay zeka ajanları (AI agents) için geliştirilen beceri setleri (skills) ve DeepSeek V4 Flash gibi yeni nesil dil modelleri bugün teknoloji gündemini domine ediyor. Meta&#39;nın çocukların ruh sağlığı ü…">
 <link rel="canonical" href="https://trescout.com/reports/2026-08-08/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-08/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-08/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-08/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-08/">
 <meta property="og:title" content="8 Ağustos 2026, Cumartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Yapay zeka ajanları (AI agents) için geliştirilen beceri setleri (skills) ve DeepSeek V4 Flash gibi yeni nesil dil modelleri bugün teknoloji gündemini domine ediyor. Meta&#39;nın çocukların ruh sağlığı ü…">
 <meta property="og:url" content="https://trescout.com/reports/2026-08-08/">

--- a/reports/2026-08-09/index.html
+++ b/reports/2026-08-09/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yapay zeka ajanlarının yetenek setleri (agent skills) ve robotik öğrenme süreçleri üzerine yoğunlaşan teknik mimariler bugün geliştirici topluluğunun ana gündemini oluşturuyor. Nixpkgs çekirdek ekibi…">
 <link rel="canonical" href="https://trescout.com/reports/2026-08-09/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-09/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-09/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-09/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-09/">
 <meta property="og:title" content="9 Ağustos 2026, Pazar · TreScout Günlük Rapor">
 <meta property="og:description" content="Yapay zeka ajanlarının yetenek setleri (agent skills) ve robotik öğrenme süreçleri üzerine yoğunlaşan teknik mimariler bugün geliştirici topluluğunun ana gündemini oluşturuyor. Nixpkgs çekirdek ekibi…">
 <meta property="og:url" content="https://trescout.com/reports/2026-08-09/">

--- a/reports/2026-08-10/index.html
+++ b/reports/2026-08-10/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yapay zeka ajanlarının (AI agents) yetenekleri ve kişilik evrimi üzerine yapılan akademik çalışmalar, modellerin karmaşık kavramları anlama kapasitesini (cross-concept understanding) merkeze alıyor.…">
 <link rel="canonical" href="https://trescout.com/reports/2026-08-10/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-10/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-10/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-10/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-10/">
 <meta property="og:title" content="10 Ağustos 2026, Pazartesi · TreScout Günlük Rapor">
 <meta property="og:description" content="Yapay zeka ajanlarının (AI agents) yetenekleri ve kişilik evrimi üzerine yapılan akademik çalışmalar, modellerin karmaşık kavramları anlama kapasitesini (cross-concept understanding) merkeze alıyor.…">
 <meta property="og:url" content="https://trescout.com/reports/2026-08-10/">

--- a/reports/2026-08-11/index.html
+++ b/reports/2026-08-11/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugünün gündemi yerel çalışma süreçlerine odaklanan yüksek kapasiteli modeller ve açık kaynaklı yapay zekâ (open-source AI) stratejileri etrafında şekilleniyor. Özellikle bellek yönetimi (memory mana…">
 <link rel="canonical" href="https://trescout.com/reports/2026-08-11/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-11/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-11/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-11/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-11/">
 <meta property="og:title" content="11 Ağustos 2026, Salı · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugünün gündemi yerel çalışma süreçlerine odaklanan yüksek kapasiteli modeller ve açık kaynaklı yapay zekâ (open-source AI) stratejileri etrafında şekilleniyor. Özellikle bellek yönetimi (memory mana…">
 <meta property="og:url" content="https://trescout.com/reports/2026-08-11/">

--- a/reports/2026-08-12/index.html
+++ b/reports/2026-08-12/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bugün odak noktası otonom ajanlar (autonomous agents) ve bu modellerin muhakeme süreçlerini (reasoning traces) hedef alan güvenlik açıklarının teknik analizi üzerine kurulu. Akademik literatürde veri…">
 <link rel="canonical" href="https://trescout.com/reports/2026-08-12/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-12/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-12/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/2026-08-12/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-12/">
 <meta property="og:title" content="12 Ağustos 2026, Çarşamba · TreScout Günlük Rapor">
 <meta property="og:description" content="Bugün odak noktası otonom ajanlar (autonomous agents) ve bu modellerin muhakeme süreçlerini (reasoning traces) hedef alan güvenlik açıklarının teknik analizi üzerine kurulu. Akademik literatürde veri…">
 <meta property="og:url" content="https://trescout.com/reports/2026-08-12/">

--- a/reports/2026-08-13/index.html
+++ b/reports/2026-08-13/index.html
@@ -7,6 +7,9 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Yazılım geliştirme dünyasında bugün hem SQLite veritabanı hataları gibi köklü altyapı sorunları hem de otonom yazılım evrimi (autonomous software evolution) üzerine odaklanan yeni akademik çalışmalar…">
 <link rel="canonical" href="https://trescout.com/reports/2026-08-13/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/2026-08-13/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/2026-08-13/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/2026-08-13/">
 <meta property="og:title" content="13 Ağustos 2026, Perşembe · TreScout Günlük Rapor">
 <meta property="og:description" content="Yazılım geliştirme dünyasında bugün hem SQLite veritabanı hataları gibi köklü altyapı sorunları hem de otonom yazılım evrimi (autonomous software evolution) üzerine odaklanan yeni akademik çalışmalar…">
 <meta property="og:url" content="https://trescout.com/reports/2026-08-13/">

--- a/reports/index.html
+++ b/reports/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="TreScout günlük teknoloji raporları arşivi · GitHub, Hacker News ve HuggingFace trendlerinin Türkçe özetleri, her gün.">
 <link rel="canonical" href="https://trescout.com/reports/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/">
 <meta property="og:title" content="Rapor Arşivi · TreScout">
 <meta property="og:description" content="TreScout günlük teknoloji raporları arşivi · GitHub, Hacker News ve HuggingFace trendlerinin Türkçe özetleri, her gün.">
 <meta property="og:url" content="https://trescout.com/reports/">

--- a/reports/tekrarsiz/2026-06-15/index.html
+++ b/reports/tekrarsiz/2026-06-15/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-15/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-15/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-15/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-15/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-15/">
 <meta property="og:title" content="15 Haziran 2026, Pazartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-15/">

--- a/reports/tekrarsiz/2026-06-16/index.html
+++ b/reports/tekrarsiz/2026-06-16/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-16/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-16/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-16/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-16/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-16/">
 <meta property="og:title" content="16 Haziran 2026, Salı · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-16/">

--- a/reports/tekrarsiz/2026-06-17/index.html
+++ b/reports/tekrarsiz/2026-06-17/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-17/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-17/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-17/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-17/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-17/">
 <meta property="og:title" content="17 Haziran 2026, Çarşamba · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-17/">

--- a/reports/tekrarsiz/2026-06-18/index.html
+++ b/reports/tekrarsiz/2026-06-18/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-18/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-18/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-18/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-18/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-18/">
 <meta property="og:title" content="18 Haziran 2026, Perşembe · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-18/">

--- a/reports/tekrarsiz/2026-06-19/index.html
+++ b/reports/tekrarsiz/2026-06-19/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-19/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-19/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-19/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-19/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-19/">
 <meta property="og:title" content="19 Haziran 2026, Cuma · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-19/">

--- a/reports/tekrarsiz/2026-06-20/index.html
+++ b/reports/tekrarsiz/2026-06-20/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-20/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-20/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-20/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-20/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-20/">
 <meta property="og:title" content="20 Haziran 2026, Cumartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-20/">

--- a/reports/tekrarsiz/2026-06-21/index.html
+++ b/reports/tekrarsiz/2026-06-21/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-21/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-21/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-21/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-21/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-21/">
 <meta property="og:title" content="21 Haziran 2026, Pazar · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-21/">

--- a/reports/tekrarsiz/2026-06-22/index.html
+++ b/reports/tekrarsiz/2026-06-22/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-22/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-22/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-22/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-22/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-22/">
 <meta property="og:title" content="22 Haziran 2026, Pazartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-22/">

--- a/reports/tekrarsiz/2026-06-23/index.html
+++ b/reports/tekrarsiz/2026-06-23/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-23/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-23/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-23/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-23/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-23/">
 <meta property="og:title" content="23 Haziran 2026, Salı · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-23/">

--- a/reports/tekrarsiz/2026-06-24/index.html
+++ b/reports/tekrarsiz/2026-06-24/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-24/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-24/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-24/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-24/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-24/">
 <meta property="og:title" content="24 Haziran 2026, Çarşamba · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-24/">

--- a/reports/tekrarsiz/2026-06-25/index.html
+++ b/reports/tekrarsiz/2026-06-25/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-25/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-25/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-25/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-25/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-25/">
 <meta property="og:title" content="25 Haziran 2026, Perşembe · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-25/">

--- a/reports/tekrarsiz/2026-06-26/index.html
+++ b/reports/tekrarsiz/2026-06-26/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-26/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-26/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-26/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-26/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-26/">
 <meta property="og:title" content="26 Haziran 2026, Cuma · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-26/">

--- a/reports/tekrarsiz/2026-06-27/index.html
+++ b/reports/tekrarsiz/2026-06-27/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-27/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-27/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-27/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-27/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-27/">
 <meta property="og:title" content="27 Haziran 2026, Cumartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-27/">

--- a/reports/tekrarsiz/2026-06-28/index.html
+++ b/reports/tekrarsiz/2026-06-28/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-28/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-28/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-28/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-28/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-28/">
 <meta property="og:title" content="28 Haziran 2026, Pazar · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-28/">

--- a/reports/tekrarsiz/2026-06-29/index.html
+++ b/reports/tekrarsiz/2026-06-29/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-29/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-29/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-29/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-29/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-29/">
 <meta property="og:title" content="29 Haziran 2026, Pazartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-29/">

--- a/reports/tekrarsiz/2026-06-30/index.html
+++ b/reports/tekrarsiz/2026-06-30/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-06-30/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-06-30/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-06-30/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-06-30/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-06-30/">
 <meta property="og:title" content="30 Haziran 2026, Salı · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-06-30/">

--- a/reports/tekrarsiz/2026-07-01/index.html
+++ b/reports/tekrarsiz/2026-07-01/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-01/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-01/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-01/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-01/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-01/">
 <meta property="og:title" content="1 Temmuz 2026, Çarşamba · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-01/">

--- a/reports/tekrarsiz/2026-07-02/index.html
+++ b/reports/tekrarsiz/2026-07-02/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-02/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-02/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-02/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-02/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-02/">
 <meta property="og:title" content="2 Temmuz 2026, Perşembe · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-02/">

--- a/reports/tekrarsiz/2026-07-03/index.html
+++ b/reports/tekrarsiz/2026-07-03/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-03/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-03/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-03/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-03/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-03/">
 <meta property="og:title" content="3 Temmuz 2026, Cuma · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-03/">

--- a/reports/tekrarsiz/2026-07-04/index.html
+++ b/reports/tekrarsiz/2026-07-04/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-04/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-04/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-04/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-04/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-04/">
 <meta property="og:title" content="4 Temmuz 2026, Cumartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-04/">

--- a/reports/tekrarsiz/2026-07-05/index.html
+++ b/reports/tekrarsiz/2026-07-05/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-05/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-05/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-05/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-05/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-05/">
 <meta property="og:title" content="5 Temmuz 2026, Pazar · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-05/">

--- a/reports/tekrarsiz/2026-07-06/index.html
+++ b/reports/tekrarsiz/2026-07-06/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-06/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-06/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-06/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-06/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-06/">
 <meta property="og:title" content="6 Temmuz 2026, Pazartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-06/">

--- a/reports/tekrarsiz/2026-07-07/index.html
+++ b/reports/tekrarsiz/2026-07-07/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-07/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-07/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-07/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-07/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-07/">
 <meta property="og:title" content="7 Temmuz 2026, Salı · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-07/">

--- a/reports/tekrarsiz/2026-07-08/index.html
+++ b/reports/tekrarsiz/2026-07-08/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-08/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-08/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-08/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-08/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-08/">
 <meta property="og:title" content="8 Temmuz 2026, Çarşamba · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-08/">

--- a/reports/tekrarsiz/2026-07-09/index.html
+++ b/reports/tekrarsiz/2026-07-09/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-09/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-09/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-09/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-09/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-09/">
 <meta property="og:title" content="9 Temmuz 2026, Perşembe · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-09/">

--- a/reports/tekrarsiz/2026-07-10/index.html
+++ b/reports/tekrarsiz/2026-07-10/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-10/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-10/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-10/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-10/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-10/">
 <meta property="og:title" content="10 Temmuz 2026, Cuma · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-10/">

--- a/reports/tekrarsiz/2026-07-11/index.html
+++ b/reports/tekrarsiz/2026-07-11/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-11/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-11/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-11/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-11/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-11/">
 <meta property="og:title" content="11 Temmuz 2026, Cumartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-11/">

--- a/reports/tekrarsiz/2026-07-12/index.html
+++ b/reports/tekrarsiz/2026-07-12/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-12/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-12/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-12/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-12/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-12/">
 <meta property="og:title" content="12 Temmuz 2026, Pazar · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-12/">

--- a/reports/tekrarsiz/2026-07-13/index.html
+++ b/reports/tekrarsiz/2026-07-13/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-13/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-13/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-13/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-13/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-13/">
 <meta property="og:title" content="13 Temmuz 2026, Pazartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-13/">

--- a/reports/tekrarsiz/2026-07-14/index.html
+++ b/reports/tekrarsiz/2026-07-14/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-14/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-14/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-14/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-14/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-14/">
 <meta property="og:title" content="14 Temmuz 2026, Salı · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-14/">

--- a/reports/tekrarsiz/2026-07-15/index.html
+++ b/reports/tekrarsiz/2026-07-15/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-15/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-15/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-15/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-15/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-15/">
 <meta property="og:title" content="15 Temmuz 2026, Çarşamba · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-15/">

--- a/reports/tekrarsiz/2026-07-16/index.html
+++ b/reports/tekrarsiz/2026-07-16/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-16/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-16/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-16/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-16/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-16/">
 <meta property="og:title" content="16 Temmuz 2026, Perşembe · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-16/">

--- a/reports/tekrarsiz/2026-07-17/index.html
+++ b/reports/tekrarsiz/2026-07-17/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-17/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-17/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-17/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-17/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-17/">
 <meta property="og:title" content="17 Temmuz 2026, Cuma · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-17/">

--- a/reports/tekrarsiz/2026-07-18/index.html
+++ b/reports/tekrarsiz/2026-07-18/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-18/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-18/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-18/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-18/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-18/">
 <meta property="og:title" content="18 Temmuz 2026, Cumartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-18/">

--- a/reports/tekrarsiz/2026-07-19/index.html
+++ b/reports/tekrarsiz/2026-07-19/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-19/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-19/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-19/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-19/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-19/">
 <meta property="og:title" content="19 Temmuz 2026, Pazar · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-19/">

--- a/reports/tekrarsiz/2026-07-20/index.html
+++ b/reports/tekrarsiz/2026-07-20/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-20/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-20/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-20/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-20/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-20/">
 <meta property="og:title" content="20 Temmuz 2026, Pazartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-20/">

--- a/reports/tekrarsiz/2026-07-21/index.html
+++ b/reports/tekrarsiz/2026-07-21/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-21/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-21/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-21/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-21/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-21/">
 <meta property="og:title" content="21 Temmuz 2026, Salı · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-21/">

--- a/reports/tekrarsiz/2026-07-22/index.html
+++ b/reports/tekrarsiz/2026-07-22/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-22/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-22/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-22/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-22/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-22/">
 <meta property="og:title" content="22 Temmuz 2026, Çarşamba · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-22/">

--- a/reports/tekrarsiz/2026-07-23/index.html
+++ b/reports/tekrarsiz/2026-07-23/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-23/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-23/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-23/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-23/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-23/">
 <meta property="og:title" content="23 Temmuz 2026, Perşembe · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-23/">

--- a/reports/tekrarsiz/2026-07-24/index.html
+++ b/reports/tekrarsiz/2026-07-24/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-24/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-24/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-24/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-24/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-24/">
 <meta property="og:title" content="24 Temmuz 2026, Cuma · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-24/">

--- a/reports/tekrarsiz/2026-07-25/index.html
+++ b/reports/tekrarsiz/2026-07-25/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-25/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-25/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-25/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-25/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-25/">
 <meta property="og:title" content="25 Temmuz 2026, Cumartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-25/">

--- a/reports/tekrarsiz/2026-07-26/index.html
+++ b/reports/tekrarsiz/2026-07-26/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-26/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-26/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-26/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-26/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-26/">
 <meta property="og:title" content="26 Temmuz 2026, Pazar · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-26/">

--- a/reports/tekrarsiz/2026-07-27/index.html
+++ b/reports/tekrarsiz/2026-07-27/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-27/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-27/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-27/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-27/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-27/">
 <meta property="og:title" content="27 Temmuz 2026, Pazartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-27/">

--- a/reports/tekrarsiz/2026-07-28/index.html
+++ b/reports/tekrarsiz/2026-07-28/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-28/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-28/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-28/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-28/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-28/">
 <meta property="og:title" content="28 Temmuz 2026, Salı · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-28/">

--- a/reports/tekrarsiz/2026-07-29/index.html
+++ b/reports/tekrarsiz/2026-07-29/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-29/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-29/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-29/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-29/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-29/">
 <meta property="og:title" content="29 Temmuz 2026, Çarşamba · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-29/">

--- a/reports/tekrarsiz/2026-07-30/index.html
+++ b/reports/tekrarsiz/2026-07-30/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-30/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-30/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-30/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-30/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-30/">
 <meta property="og:title" content="30 Temmuz 2026, Perşembe · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-30/">

--- a/reports/tekrarsiz/2026-07-31/index.html
+++ b/reports/tekrarsiz/2026-07-31/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-07-31/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-07-31/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-07-31/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-07-31/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-07-31/">
 <meta property="og:title" content="31 Temmuz 2026, Cuma · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-07-31/">

--- a/reports/tekrarsiz/2026-08-01/index.html
+++ b/reports/tekrarsiz/2026-08-01/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-08-01/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-01/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-01/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-01/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-01/">
 <meta property="og:title" content="1 Ağustos 2026, Cumartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-08-01/">

--- a/reports/tekrarsiz/2026-08-02/index.html
+++ b/reports/tekrarsiz/2026-08-02/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-08-02/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-02/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-02/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-02/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-02/">
 <meta property="og:title" content="2 Ağustos 2026, Pazar · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-08-02/">

--- a/reports/tekrarsiz/2026-08-03/index.html
+++ b/reports/tekrarsiz/2026-08-03/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-08-03/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-03/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-03/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-03/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-03/">
 <meta property="og:title" content="3 Ağustos 2026, Pazartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-08-03/">

--- a/reports/tekrarsiz/2026-08-04/index.html
+++ b/reports/tekrarsiz/2026-08-04/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-08-04/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-04/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-04/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-04/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-04/">
 <meta property="og:title" content="4 Ağustos 2026, Salı · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-08-04/">

--- a/reports/tekrarsiz/2026-08-05/index.html
+++ b/reports/tekrarsiz/2026-08-05/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-08-05/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-05/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-05/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-05/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-05/">
 <meta property="og:title" content="5 Ağustos 2026, Çarşamba · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-08-05/">

--- a/reports/tekrarsiz/2026-08-06/index.html
+++ b/reports/tekrarsiz/2026-08-06/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-08-06/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-06/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-06/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-06/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-06/">
 <meta property="og:title" content="6 Ağustos 2026, Perşembe · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-08-06/">

--- a/reports/tekrarsiz/2026-08-07/index.html
+++ b/reports/tekrarsiz/2026-08-07/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-08-07/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-07/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-07/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-07/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-07/">
 <meta property="og:title" content="7 Ağustos 2026, Cuma · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-08-07/">

--- a/reports/tekrarsiz/2026-08-08/index.html
+++ b/reports/tekrarsiz/2026-08-08/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-08-08/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-08/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-08/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-08/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-08/">
 <meta property="og:title" content="8 Ağustos 2026, Cumartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-08-08/">

--- a/reports/tekrarsiz/2026-08-09/index.html
+++ b/reports/tekrarsiz/2026-08-09/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-08-09/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-09/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-09/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-09/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-09/">
 <meta property="og:title" content="9 Ağustos 2026, Pazar · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-08-09/">

--- a/reports/tekrarsiz/2026-08-10/index.html
+++ b/reports/tekrarsiz/2026-08-10/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-08-10/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-10/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-10/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-10/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-10/">
 <meta property="og:title" content="10 Ağustos 2026, Pazartesi · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-08-10/">

--- a/reports/tekrarsiz/2026-08-11/index.html
+++ b/reports/tekrarsiz/2026-08-11/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-08-11/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-11/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-11/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-11/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-11/">
 <meta property="og:title" content="11 Ağustos 2026, Salı · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-08-11/">

--- a/reports/tekrarsiz/2026-08-12/index.html
+++ b/reports/tekrarsiz/2026-08-12/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-08-12/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-12/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-12/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/2026-08-12/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-12/">
 <meta property="og:title" content="12 Ağustos 2026, Çarşamba · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-08-12/">

--- a/reports/tekrarsiz/2026-08-13/index.html
+++ b/reports/tekrarsiz/2026-08-13/index.html
@@ -7,6 +7,9 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/2026-08-13/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/2026-08-13/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/2026-08-13/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/2026-08-13/">
 <meta property="og:title" content="13 Ağustos 2026, Perşembe · TreScout Tekrarsız Rapor">
 <meta property="og:description" content="Bu rapor, son günlerde paylaştıklarımızı tekrarlamadan bugün ilk kez öne çıkan trendleri içerir.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/2026-08-13/">

--- a/reports/tekrarsiz/index.html
+++ b/reports/tekrarsiz/index.html
@@ -7,6 +7,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="description" content="TreScout tekrarsız raporlar · önceki günlerde paylaşılanları tekrarlamadan, her gün yalnızca ilk kez öne çıkan teknoloji trendleri.">
 <link rel="canonical" href="https://trescout.com/reports/tekrarsiz/">
+<link rel="alternate" hreflang="tr" href="https://trescout.com/reports/tekrarsiz/">
+<link rel="alternate" hreflang="en" href="https://trescout.com/en/reports/fresh/">
+<link rel="alternate" hreflang="fr" href="https://trescout.com/fr/reports/fresh/">
+<link rel="alternate" hreflang="x-default" href="https://trescout.com/en/reports/fresh/">
 <meta property="og:title" content="Tekrarsız Raporlar · TreScout">
 <meta property="og:description" content="TreScout tekrarsız raporlar · önceki günlerde paylaşılanları tekrarlamadan, her gün yalnızca ilk kez öne çıkan teknoloji trendleri.">
 <meta property="og:url" content="https://trescout.com/reports/tekrarsiz/">


### PR DESCRIPTION
Bugünkü rapor yayını sayfaları kendi iki dilli şablonuyla bastı; 706 sayfada `hreflang="fr"` düştü ve guard `main`'i kırdı.

**Kaynak app#44 ile kapatıldı** · yayın artık kabuğun yanı sıra hreflang normalize edicisini de çalıştırıyor.

Bu PR yalnız bugün çıkan sayfaları onarıyor (282 sayfa) · yarınki koşudan itibaren gerek kalmayacak.

Beş guard yerelde temiz; hreflang 3181 çok dilli sayfada tutarlı.

🤖 Generated with [Claude Code](https://claude.com/claude-code)