### PR TITLE
feat(claude-code): yeni sözlük ikizlerini tarayıp issue aç

### DIFF
--- a/.github/workflows/dict-sync.yml
+++ b/.github/workflows/dict-sync.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: write
+  issues: write        # ikiz-tara.py bulgu olunca issue açıyor
 
 concurrency:
   group: dict-sync
@@ -194,6 +195,15 @@ jobs:
       # yeniden yaratırsa 301 zinciri kırılır.
       - name: Birleştirilmiş terimler kontrolü
         run: python3 scripts/check-birlesmis-terimler.py
+
+      # YENİ ikiz arar · guard yalnız yapılmış birleşmeleri koruyor. Bulursa
+      # issue açar/günceller, hattı DÜŞÜRMEZ: birleştirme bir içerik kararı
+      # (hangi slug kalacak) · günlük yayını bunun için durdurmak yanlış olur.
+      - name: Yeni sözlük ikizi taraması
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/ikiz-tara.py
 
       # Çok dilli her sayfa diğer dillerdeki sürümünü bildirmeli ·
       # düzeltmesi: python3 scripts/hreflang-normalize.py

--- a/scripts/ikiz-tara.py
+++ b/scripts/ikiz-tara.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Sözlükte YENİ ikiz terim arar · bulursa GitHub issue açar/günceller.
+
+    python3 scripts/ikiz-tara.py [--dry]
+
+Neden gerekli: `check-birlesmis-terimler.py` yalnız YAPILMIŞ birleşmeleri
+koruyor · yenisini bulmuyor. Günlük hat her gün rapor sözlüğünden yeni terim
+ekliyor ve tekil/çoğul ikizleri kendiliğinden oluşuyor: 2026-08-08'de 19 çift
+birleştirildikten sonra ÜÇ GÜNDE iki tane daha çıktı (diffusion-model,
+knowledge-graph). Google bunlara "standart sayfa olmadan kopya" diyor.
+
+Neden guard değil de issue: birleştirme bir İÇERİK kararı · hangi slug kalacak,
+metin nasıl ayrışacak. Günlük hattı bunun için düşürmek yayını durdurur. Bu
+betik bulguyu görünür kılıyor, kararı insana bırakıyor.
+
+Ölçü: aynı kökten tekil/çoğul slug çifti + gövdelerinin benzerliği. Eşik 0.85 ·
+altındakiler gerçekten farklı yazılmış demektir (ör. "agent" kavram,
+"agents" çoklu-ajan sistemi anlatıyorsa sorun yok).
+
+Birleştirme kararı verilince: `assets/dictionary/birlesmis.json`'a satır ekleyin,
+sayfaları silin, `scripts/redirect-uret.py` çalıştırın.
+"""
+import difflib
+import json
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MANIFEST = os.path.join(ROOT, "assets", "dictionary", "dictionary.json")
+BIRLESMIS = os.path.join(ROOT, "assets", "dictionary", "birlesmis.json")
+ESIK = 0.85
+TITLE = "Sözlük · birleştirilmesi gereken ikiz terimler"
+DRY = "--dry" in sys.argv or not os.environ.get("GH_TOKEN")
+
+
+def govde(slug):
+    p = os.path.join(ROOT, "dictionary", slug, "index.html")
+    if not os.path.exists(p):
+        return ""
+    m = re.search(r"<main[\s\S]*?</main>", open(p, encoding="utf-8").read())
+    return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", m.group(0) if m else "")).strip()
+
+
+man = json.load(open(MANIFEST, encoding="utf-8"))
+sluglar = {t["slug"]: t for t in man}
+zaten = set()
+if os.path.exists(BIRLESMIS):
+    e = json.load(open(BIRLESMIS, encoding="utf-8"))["eslesme"]
+    zaten = set(e) | set(e.values())
+
+bulunan = []
+gorulen = set()
+for s in sluglar:
+    for aday in (s + "s", s.rstrip("s")):
+        if aday == s or aday not in sluglar:
+            continue
+        cift = tuple(sorted((s, aday)))
+        if cift in gorulen:
+            continue
+        gorulen.add(cift)
+        a, b = cift
+        ga, gb = govde(a), govde(b)
+        if not (ga and gb):
+            continue
+        oran = difflib.SequenceMatcher(None, ga, gb).quick_ratio()
+        if oran >= ESIK:
+            bulunan.append((a, b, oran))
+
+bulunan.sort(key=lambda x: -x[2])
+print(f"{len(gorulen)} tekil/çoğul çifti tarandı · {len(bulunan)} ikiz eşiği aştı (≥{ESIK})")
+for a, b, o in bulunan:
+    isaret = " (biri zaten birleşme tablosunda!)" if (a in zaten or b in zaten) else ""
+    print(f"   {a} ↔ {b} · benzerlik {o:.2f}{isaret}")
+
+if not bulunan:
+    print("✓ yeni ikiz yok")
+    sys.exit(0)
+
+satirlar = [
+    "Sözlükte aynı metni taşıyan tekil/çoğul terim çiftleri bulundu. Google bunlara",
+    '"kullanıcı tarafından seçilen standart sayfa olmadan kopya" diyor ve birini dizinden düşürüyor.',
+    "",
+    f"Eşik: gövde benzerliği ≥ {ESIK}. Altındakiler listelenmez (gerçekten farklı yazılmış demektir).",
+    "",
+]
+for a, b, o in bulunan:
+    satirlar.append(
+        f"- [ ] **{a}** ↔ **{b}** · benzerlik {o:.2f} · "
+        f"[{a}](https://trescout.com/dictionary/{a}/) · "
+        f"[{b}](https://trescout.com/dictionary/{b}/)"
+    )
+satirlar += [
+    "",
+    "**Nasıl birleştirilir**",
+    "1. Kalacak slug'ı seçin (iç bağlantı sayısı > gövde zenginliği > kısa slug)",
+    "2. `assets/dictionary/birlesmis.json` → `eslesme`'ye `\"giden\": \"kalan\"` ekleyin",
+    "3. Giden slug'ın sayfalarını üç dilde silin (`dictionary/`, `en/`, `fr/` · `.md` dahil)",
+    "4. `python3 scripts/redirect-uret.py` · 301'leri üretir",
+    "5. İç bağlantıları kanonik adrese çevirin, sayfaları yeniden basın",
+    "6. `python3 scripts/check-birlesmis-terimler.py` yeşil olmalı",
+    "",
+    "**Alternatif:** ikisini gerçekten farklı anlamlarla yeniden yazmak da olur "
+    "(ör. tekil = kavram, çoğul = sistem). O zaman benzerlik eşiğin altına iner ve liste temizlenir.",
+]
+body = "\n".join(satirlar)
+
+if DRY:
+    print("\n[dry / GH_TOKEN yok] açılacak issue gövdesi:\n")
+    print("BAŞLIK:", TITLE, "\n")
+    print(body)
+    sys.exit(0)
+
+num = None
+try:
+    out = subprocess.run(["gh", "issue", "list", "--state", "open", "--search", TITLE,
+                          "--json", "number,title"], capture_output=True, text=True,
+                         cwd=ROOT, check=True)
+    for it in json.loads(out.stdout or "[]"):
+        if it.get("title") == TITLE:
+            num = it["number"]
+            break
+except Exception as e:
+    print("uyarı: mevcut issue aranamadı:", e)
+
+if num:
+    subprocess.run(["gh", "issue", "edit", str(num), "--body", body], cwd=ROOT, check=True)
+    print(f"issue #{num} güncellendi · {len(bulunan)} ikiz")
+else:
+    subprocess.run(["gh", "issue", "create", "--title", TITLE, "--body", body], cwd=ROOT, check=True)
+    print(f"yeni issue açıldı · {len(bulunan)} ikiz")


### PR DESCRIPTION
`check-birlesmis-terimler.py` yalnız **yapılmış** birleşmeleri koruyor · yenisini bulmuyor.

Bu boşluk teorik değil: 19 çifti birleştirdikten sonra **üç günde iki tane daha** oluştu (`diffusion-model`, `knowledge-graph`). Günlük hat her gün rapor sözlüğünden terim ekliyor, ikizler kendiliğinden çıkıyor.

## Ne yapıyor

`scripts/ikiz-tara.py` tekil/çoğul slug çiftlerini bulup gövde benzerliğine bakıyor. Eşik **0.85** · altındakiler listelenmiyor, çünkü o durumda terimler gerçekten farklı yazılmış demektir (ör. tekil kavramı, çoğul çoklu-ajan sistemini anlatıyorsa sorun yok).

Bulgu varsa GitHub issue açıyor, sonraki koşularda aynı issue'yu güncelliyor (enrichment-digest'teki desenin aynısı).

## Neden guard değil, issue

Birleştirme bir **içerik kararı**: hangi slug kalacak, metin nasıl ayrışacak. Günlük hattı bunun için düşürmek yayını durdurur — guard adımlarından biri kırılırsa o günün içeriği commit'lenmiyor.

`continue-on-error` ile bağlandı: bulgu görünür oluyor, karar insana kalıyor. Issue gövdesinde adım adım birleştirme yordamı yazılı (hangi slug kalır, birlesmis.json'a nasıl eklenir, redirect-uret.py, hangi guard yeşil olmalı).

## Sınama

Sahte bir `rags` ikizi kurdum · **1.00 benzerlikle yakalandı**, kaldırınca liste temizlendi. Şu an gerçek ikiz yok (hepsi birleştirildi), yani ilk koşuda issue açılmayacak.

`issues: write` izni iş akışına eklendi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)