### PR TITLE
fix(claude-code): günlük hat üç gündür kırık · hreflang normalize adımı eksikti

### DIFF
--- a/.github/workflows/dict-sync.yml
+++ b/.github/workflows/dict-sync.yml
@@ -188,7 +188,16 @@ jobs:
       - name: Chrome normalize (nav + footer kanonik hâle)
         run: node scripts/fix-all-headers-and-footers.js
 
-      # bot commit'lerinde çalışmaz; aynı 6 guard'ı burada üretici çıktısına da uyguluyoruz.
+      # hreflang normalize · ÜRETİMDEN SONRA, GUARD'DAN ÖNCE.
+      # 2026-08-13'te guard eklendi ama bu adım eklenmedi · hat o günden beri
+      # HER GÜN kırıldı. Guard iş akışının SONUNDA olduğu için commit adımına
+      # hiç gelinmedi: üç gün boyunca yeni keşif kaydı, yeni sözlük terimi ve
+      # çapraz-link tazelemesi YAYINLANMADI (katalog 2026-08-12'de durdu).
+      # Guard'ı normalize edici olmadan eklemek, guard'ı hiç eklememekten kötü.
+      - name: hreflang normalize (üretilen sayfalar dahil)
+        run: python3 scripts/hreflang-normalize.py
+
+      # bot commit'lerinde çalışmaz; aynı guard'ları burada üretici çıktısına da uyguluyoruz.
       - name: Inline CSS/JS kontrolü
         run: python3 scripts/check-no-inline-csp.py
       - name: Nav tutarlılık kontrolü
@@ -210,6 +219,9 @@ jobs:
       - name: Sayfa paritesi (diller arası yapı)
         run: python3 scripts/check-sayfa-paritesi.py
 
+      - name: Bölüm paritesi (üretilen sayfalar · h2 sayısı)
+        run: python3 scripts/check-bolum-paritesi.py
+
       # Birleştirilmiş sözlük ikizleri geri açılmasın · günlük hat terimi
       # yeniden yaratırsa 301 zinciri kırılır.
       - name: Birleştirilmiş terimler kontrolü
@@ -224,8 +236,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 scripts/ikiz-tara.py
 
-      # Çok dilli her sayfa diğer dillerdeki sürümünü bildirmeli ·
-      # düzeltmesi: python3 scripts/hreflang-normalize.py
+      # Çok dilli her sayfa diğer dillerdeki sürümünü bildirmeli · normalize
+      # edici yukarıda koştu, burada yalnız DOĞRULUYORUZ.
       - name: hreflang kontrolü
         run: python3 scripts/check-hreflang.py
 


### PR DESCRIPTION
"Keşifte son günlerde sıkıntı var gibi" dedin · haklıydın.

**Katalog 2026-08-12'de durmuş.** 13, 14 ve 15'te hiç yeni keşif kaydı eklenmemiş — oysa o günlerin raporlarında **17'şer GitHub maddesi** vardı ve `discover-sync --dry` şu an **16 yeni repo** bekliyor:

```
rapor GitHub repo: 440 · mevcut (URL): 421 · YENİ: 16
  + diagram-design · macro · ragflow · switchyard · localsend
  + embabel-agent · unsloth · holehe · rustdesk · tooljet …
```

## Sebep · benim hatam

2026-08-13'te hreflang **guard**'ını `dict-sync.yml`'ye ekledim ama **normalize ediciyi eklemedim.** Adımın hemen üstündeki yorumda düzeltmesi yazılıydı:

```yaml
# Çok dilli her sayfa diğer dillerdeki sürümünü bildirmeli ·
# düzeltmesi: python3 scripts/hreflang-normalize.py     ← yazılmış, adım konmamış
- name: hreflang kontrolü
  run: python3 scripts/check-hreflang.py
```

Üretici her gün yeni sayfa basıyor → o sayfaların hreflang'i eksik → guard **20653 sorun** sayıp çıkış kodu 1 veriyor.

Guard iş akışının **sonunda**, commit adımından **önce**. Yani hat üç gündür hiçbir şeyi yayınlamadı:

| | |
|---|---|
| yeni keşif kaydı | yok |
| yeni sözlük terimi | yok |
| çapraz-link tazelemesi | yok |
| depo (yıldız/sürüm) tazeleme | yok |

Rapor yayını **ayrı** iş akışında olduğu için raporlar çıkmaya devam etti · arıza bu yüzden dışarıdan görünmedi.

## Ders

**Guard'ı düzelticisi olmadan hatta eklemek, guard'ı hiç eklememekten kötü.** Guard yeşil yanmıyor — hattı kilitliyor, ve kilit sessiz. Bunu guard değil kullanıcı fark etti; bedeli üç gün.

## Değişiklik

- `hreflang-normalize.py` adımı chrome normalize'ın hemen ardına (üretimden **sonra**, guard'dan **önce** · `fix-all-headers-and-footers.js` ile aynı yer)
- `check-bolum-paritesi.py` günlük hatta da koşuyor (dün eklenmişti ama yalnız `csp-inline-guard.yml`'deydi · aynı sınıf eksiklik)

Merge sonrası hattı elle tetikleyip üç günü kapatacağım · yerelde Gemini anahtarı yok, buradan koşarsam 16 kayıt zenginleştirilmeden "lite" girerdi ve `catalog-render.py` anahtarsızken metin siliyor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)