### PR TITLE
fix(claude-code): içerik push'u yarışta kaybedince tüm koşu çöpe gidiyordu

### DIFF
--- a/.github/workflows/dict-sync.yml
+++ b/.github/workflows/dict-sync.yml
@@ -295,8 +295,24 @@ jobs:
             git config user.email "hello@trescout.com"
             git add -A
             git commit -m "chore(content-sync): rapordan yeni sözlük/keşif içeriği eklendi [skip ci]"
-            git push
-            echo "Yeni içerik eklendi ve push edildi."
+            # PUSH YARIŞI · bu depoya İKİ hat yazıyor: içerik büyümesi (burası)
+            # ve app'teki rapor yayını. Aynı dakikaya denk gelirlerse ikincinin
+            # push'u "fetch first" ile reddediliyor ve O KOŞUNUN TÜM İŞİ ÇÖPE
+            # GİDİYOR · sayfalar üretilmiş, commit atılmış, push düşmüş.
+            # 2026-08-19 ve 2026-08-20'de yaşandı. Rebase edip tekrar dene.
+            for deneme in 1 2 3 4 5; do
+              if git push; then
+                echo "Yeni içerik eklendi ve push edildi (deneme $deneme)."
+                exit 0
+              fi
+              echo "→ push reddedildi · rebase edip tekrar deniyorum ($deneme/5)"
+              git pull --rebase --autostash origin main || {
+                echo "✗ rebase başarısız · elle bakılmalı."; exit 1;
+              }
+              sleep $((deneme * 5))
+            done
+            echo "✗ beş denemede push edilemedi."
+            exit 1
           else
             echo "Eklenecek yeni içerik yok · güncel."
           fi


### PR DESCRIPTION
Bugün 20 Ağustos'un çevrilmiş rapor sayfalarını basmak için hattı tetikledim. Sayfalar üretildi, commit atıldı, **push reddedildi** ve koşu düştü:

```
create mode 100644 pt/reports/2026-08-20/index.html
To https://github.com/trescout/landing
 ! [rejected]  main -> main (fetch first)
##[error]Process completed with exit code 1.
```

Aynı şey **19 Ağustos'ta da** olmuştu — o gün de "Değişiklik varsa commit'le" adımı failure vermişti; o zaman "eşzamanlı koşu" deyip geçmiştim, sebebini kazmadım.

## Sebep

`landing/main`'e **iki hat** yazıyor: buradaki içerik büyümesi ve `app`'teki rapor yayını. Aynı dakikaya denk gelirlerse ikincinin push'u reddediliyor ve **o koşunun tüm işi çöpe gidiyor** — sayfalar üretilmiş, commit atılmış, push düşmüş.

Burada rebase bile yoktu, düz `git push`.

## Değişiklik

Beş denemelik rebase+push döngüsü, artan bekleme (5·10·15·20 sn). **Gerçek çakışmada** (rebase'in kendisi düşerse) hata veriyor — sessizce ezmiyoruz.

`app` tarafında `git pull --rebase` vardı ama **tek deneme**; rebase ile push arasındaki pencere aynı riski taşıyor. O da [app#55](https://github.com/trescout/app/pull/55) ile döngüye alındı.

🤖 Generated with [Claude Code](https://claude.com/claude-code)