### PR TITLE
fix(claude-code): rapor PDF'lerine kanonik başlık · ?v= çift URL üretiyordu

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -96,7 +96,7 @@
       ]
     },
     {
-      "source": "/reports/(.*\\.pdf)",
+      "source": "/reports/:dosya(.*\\.pdf)",
       "headers": [
         {
           "key": "Content-Disposition",
@@ -105,6 +105,10 @@
         {
           "key": "Cache-Control",
           "value": "public, max-age=3600, stale-while-revalidate=86400"
+        },
+        {
+          "key": "Link",
+          "value": "<https://trescout.com/reports/:dosya>; rel=\"canonical\""
         }
       ]
     },


### PR DESCRIPTION
Search Console'daki **"Tarandı – şu anda dizine eklenmemiş" (153 sayfa)** kovasının bir kısmı PDF:

```
https://trescout.com/reports/trescout-rapor-2026-07-29.pdf?v=2388d752
https://trescout.com/reports/trescout-rapor-2026-07-22.pdf?v=f1e62042
```

**87 rapor sayfası** PDF'lere içerik damgalı (`?v=<sha1>`) bağlanıyor. Google bunları temiz URL'den **ayrı birer sayfa** sayıyor — her PDF fiilen iki URL. PDF'ler sitemap'te olmadığı için tek keşif yolu da bu bağlantılar.

## Damgayı kaldırmıyorum

Gerçek bir işi var: PDF yeniden üretilince (şablon değişikliği, bölüm düzeltmesi) tarayıcı ve CDN bir saat boyunca eskiyi gösteriyordu. Bugün kapakları yeniden ürettik, tam da o durum.

## Bunun yerine · HTTP kanonik başlığı

HTML olmayan dosyalarda `rel=canonical`'ın belgelenmiş yolu bu:

```
Link: <https://trescout.com/reports/DOSYA.pdf>; rel="canonical"
```

`?v=` ile gelen istek de aynı kanoniği bildiriyor → iki URL tek sayfada birleşiyor. Önbellek davranışı değişmiyor.

Vercel'in değişken sözdizimini ezberden yazmamak için adlandırılmış parametre kullandım (`:dosya`); **önizleme dağıtımında başlığı gerçekten ölçeceğim**, merge etmeden önce sonucu buraya yazacağım.

🤖 Generated with [Claude Code](https://claude.com/claude-code)