### PR TITLE
fix: recover content sync after main advances

### DIFF
--- a/.github/workflows/dict-sync.yml
+++ b/.github/workflows/dict-sync.yml
@@ -290,26 +290,33 @@ jobs:
         run: python3 scripts/check-seo-geo.py
 
       - name: Değişiklik varsa commit'le
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
+          REPROCESS_SLUGS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.reprocess_slugs || '' }}
+          HEADLINES_LIMIT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.headlines_limit || '0' }}
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "TreScout Bot"
             git config user.email "hello@trescout.com"
             git add -A
             git commit -m "chore(content-sync): rapordan yeni sözlük/keşif içeriği eklendi [skip ci]"
-            # PUSH YARIŞI · bu depoya İKİ hat yazıyor: içerik büyümesi (burası)
-            # ve app'teki rapor yayını. Aynı dakikaya denk gelirlerse ikincinin
-            # push'u "fetch first" ile reddediliyor ve O KOŞUNUN TÜM İŞİ ÇÖPE
-            # GİDİYOR · sayfalar üretilmiş, commit atılmış, push düşmüş.
-            # 2026-08-19 ve 2026-08-20'de yaşandı. Rebase edip tekrar dene.
+            # Generated sayfaların üretimi uzun sürebiliyor. Bu sırada main ilerlerse
+            # eski generated ağacı rebase etmek yerine latest main üstünde baştan üret.
+            # Böylece başka bir writer'ın içeriği ezilmez, generated sayfalar da stale kalmaz.
             for deneme in 1 2 3 4 5; do
               if git push; then
                 echo "Yeni içerik eklendi ve push edildi (deneme $deneme)."
                 exit 0
               fi
-              echo "→ push reddedildi · rebase edip tekrar deniyorum ($deneme/5)"
-              git pull --rebase --autostash origin main || {
-                echo "✗ rebase başarısız · elle bakılmalı."; exit 1;
-              }
+              if [ "$deneme" -eq 5 ]; then
+                break
+              fi
+              echo "→ push reddedildi · latest main çekilip generated tree yeniden basılıyor ($deneme/5)"
+              git fetch origin main
+              git reset --hard origin/main
+              git clean -fd
+              bash scripts/recover-content-sync.sh
               sleep $((deneme * 5))
             done
             echo "✗ beş denemede push edilemedi."

--- a/docs/AI_USAGE_LOG.md
+++ b/docs/AI_USAGE_LOG.md
@@ -6,3 +6,4 @@
 | 2026-08-04/05 | Burhan | İngilizce çift dil hattı, Compare sayfası, düzen birleştirme | Antigravity | Skills Agent | main'e doğrudan (PR yok) |
 | 2026-08-06 | Claude | CSP ihlalleri, eskimiş guard'lar, marka yazımı, eksik meta, beş PR'ın taşınması | Claude Code | Denetim | #57 #59 #61 #62 #63 #64 |
 | 2026-08-23 | Manus | SEO/GEO metadata, hreflang, llms index, rapor açıklamaları ve read-only guard · erken erişim kayıt/bildirim akışı korundu | Manus AI | Plan Agent + Manual | `fix/seo-geo-early-access-safe` |
+| 2026-08-24 | Manus | Oto-büyüme workflow'unda stale generated tree rebase çatışması recovery düzeltmesi · e-posta akışına dokunulmadı | Manus AI | Plan Agent + Manual | `fix/dict-sync-stale-main` |

--- a/scripts/recover-content-sync.sh
+++ b/scripts/recover-content-sync.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Rebuild the generated tree after another writer advances main.
+# The caller must reset the checkout to origin/main before invoking this script.
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+
+python3 scripts/dict-sync.py
+python3 scripts/dict-cards.py
+python3 scripts/discover-sync.py
+
+if [[ -n "${REPROCESS_SLUGS:-}" ]]; then
+  python3 scripts/discover-sync.py --reprocess="${REPROCESS_SLUGS}"
+fi
+
+if [[ -n "${HEADLINES_LIMIT:-}" && "${HEADLINES_LIMIT}" != "0" ]]; then
+  python3 scripts/discover-sync.py --headlines --limit="${HEADLINES_LIMIT}"
+fi
+
+python3 scripts/discover-sync.py --refresh || echo "refresh skipped after GitHub API failure"
+python3 scripts/cross-link.py
+python3 scripts/catalog-render.py
+node scripts/translate-i18n.js
+
+LANG_CODES="$(python3 scripts/diller.py --liste)"
+for d in $LANG_CODES; do
+  [[ "$d" == "en" ]] && continue
+  node scripts/translate-i18n.js --lang="$d"
+done
+
+for d in $LANG_CODES; do
+  python3 scripts/kapak-gorselleri.py --lang="$d"
+done
+
+for d in $LANG_CODES; do
+  python3 scripts/dictionary-en.py --lang="$d"
+  python3 scripts/discover-en.py --lang="$d"
+done
+
+for d in $LANG_CODES; do
+  python3 scripts/dictionary-en.py --lang="$d"
+done
+
+for d in $LANG_CODES; do
+  node scripts/build-en.js --lang="$d"
+  if [[ -f "$d/index.html" ]]; then
+    python3 scripts/dil-kabuk-tazele.py --lang="$d"
+  fi
+done
+
+for d in $LANG_CODES; do
+  node scripts/build-reports-en.js --lang="$d"
+done
+
+python3 scripts/discover-index.py
+python3 scripts/discover-md.py
+python3 scripts/llms-txt.py
+python3 scripts/redirect-uret.py
+python3 scripts/sitemap-sync.py
+node scripts/fix-all-headers-and-footers.js
+python3 scripts/hreflang-normalize.py
+
+python3 scripts/check-no-inline-csp.py
+python3 scripts/check-nav-consistency.py
+python3 scripts/check-footer-consistency.py
+python3 scripts/check-logo-consistency.py
+python3 scripts/check-headline-consistency.py
+python3 scripts/check-brand-typography.py
+python3 scripts/check-consent-consistency.py
+python3 scripts/check-sayfa-paritesi.py
+python3 scripts/check-bolum-paritesi.py || true
+python3 scripts/check-birlesmis-terimler.py
+python3 scripts/ikiz-tara.py || true
+python3 scripts/check-hreflang.py
+python3 scripts/check-seo-geo.py

--- a/scripts/recover-content-sync.sh
+++ b/scripts/recover-content-sync.sh
@@ -6,6 +6,8 @@ set -Eeuo pipefail
 ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+git config user.name "TreScout Bot"
+git config user.email "hello@trescout.com"
 export GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 
 python3 scripts/dict-sync.py
@@ -76,3 +78,10 @@ python3 scripts/check-birlesmis-terimler.py
 python3 scripts/ikiz-tara.py || true
 python3 scripts/check-hreflang.py
 python3 scripts/check-seo-geo.py
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  git add -A
+  git commit -m "chore(content-sync): rapordan yeni sözlük/keşif içeriği eklendi [skip ci]"
+else
+  echo "No generated changes after recovery."
+fi


### PR DESCRIPTION
## Kök neden

The 2026-08-24 scheduled content-growth run failed while rebasing a generated tree after another writer advanced `main`. Rebase conflicted across generated multilingual discovery pages.

## Değişiklik

- On push rejection, fetch and reset to the latest `origin/main` instead of rebasing stale generated files.
- Re-run the idempotent content generators from the fresh main checkout before retrying the push.
- Preserve `workflow_dispatch` inputs for reprocess slugs and headline backfill.
- Keep SEO/GEO and content guards in the existing order.
- No email, early-access, Resend, or delivery code is changed.

## Doğrulama

- `bash -n scripts/recover-content-sync.sh`
- `git diff --check`
- SEO/GEO guard: 7016 HTML pages, 468 tools, 535 terms, 891 unique report descriptions
- hreflang guard: 7020 multilingual pages
- consent, merged-term, nav and footer guards passed

## AI Traceability

- Plan Agent: Manus analysis of run 32695711828 and workflow `dict-sync.yml`.
- Skills Agent: not used.
- Türkçe içerik: no user-facing copy changed.
- Manuel: recovery script and workflow patch reviewed manually.
- `docs/AI_USAGE_LOG.md` updated.
