### PR TITLE
fix(i18n): fail closed for generated locale content

### DIFF
--- a/.github/workflows/dict-sync.yml
+++ b/.github/workflows/dict-sync.yml
@@ -121,6 +121,8 @@ jobs:
       # akışında değildi, elle çalıştırılıyordu (2026-08-07 bulgusu).
       # Önbellekli: değişmeyen metin çeviri harcamaz.
       - name: İngilizce tanıtım metinleri (tagline_en · kisa_en)
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: node scripts/translate-i18n.js
 
       # Fransızca · 2026-08-07'de eklendi. Aynı betikler --lang ile çalışıyor,
@@ -134,6 +136,8 @@ jobs:
         run: echo "kodlar=$(python3 scripts/diller.py --liste)" >> "$GITHUB_OUTPUT"
 
       - name: Tanıtım metinleri (tagline_XX · kisa_XX)
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           for d in ${{ steps.diller.outputs.kodlar }}; do
             [ "$d" = "en" ] && continue   # İngilizce çevirisi ayrı adımda
@@ -155,6 +159,8 @@ jobs:
       # (2026-08-13'te Portekizce'de yaşandı · sonraki günler kendiliğinden
       # düzeliyordu, o yüzden görülmemişti).
       - name: Sayfaları üret · her dilde sözlük SONRA keşif
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           for d in ${{ steps.diller.outputs.kodlar }}; do
             echo "── $d"
@@ -171,6 +177,8 @@ jobs:
       # Almanca eklenirken de 353 sözlük sayfası aynı sebeple eksikti).
       # Çeviriler önbellekli · ikinci tur birkaç saniye.
       - name: Sözlük ikinci tur (keşif sayfaları artık diskte)
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           for d in ${{ steps.diller.outputs.kodlar }}; do
             python3 scripts/dictionary-en.py --lang=$d

--- a/scripts/dictionary-en.py
+++ b/scripts/dictionary-en.py
@@ -21,6 +21,7 @@ import os, re, sys, json, html, time, urllib.parse, urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from diller import dil, tarih_yaz, chrome as chrome_kur, dil_dugmeleri_yaz, dil_hedefleri
+from translation_service import translate_text
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TR_DIR = os.path.join(ROOT, "dictionary")
@@ -37,6 +38,7 @@ ONLY = next((a.split("=")[1] for a in sys.argv if a.startswith("--slug=")), None
 
 _cache = json.load(open(CACHE, encoding="utf-8")) if os.path.exists(CACHE) else {}
 _yeni = 0
+_basarisiz = 0
 
 BASLIK = D["bolumler"]
 KATEGORI = {"ai": "AI", "web": "Web", "devops": "DevOps", "mobil": "Mobile",
@@ -44,33 +46,21 @@ KATEGORI = {"ai": "AI", "web": "Web", "devops": "DevOps", "mobil": "Mobile",
 
 
 def tr2en(s):
-    global _yeni
+    global _yeni, _basarisiz
     s = (s or "").strip()
     if not s:
         return ""
     if s in _cache:
         return _cache[s]
-    url = (f"https://translate.googleapis.com/translate_a/single?client=gtx&sl=tr&tl={LANG}&dt=t&q="
-           + urllib.parse.quote(s))
-    out, oldu = s, False
-    for deneme in range(3):
-        try:
-            with urllib.request.urlopen(url, timeout=25) as r:
-                d = json.loads(r.read().decode())
-            out = "".join(p[0] for p in d[0])
-            oldu = True
-            break
-        except Exception:
-            time.sleep(1 + deneme * 2)
-    # Başarısız çeviriyi ÖNBELLEĞE YAZMA · yoksa Türkçe metin kalıcı olarak
-    # İngilizce sayfaya yapışır, sonraki çalıştırmalar da onu kullanır.
-    if oldu:
+    out = translate_text(s, LANG)
+    if out:
         _cache[s] = out
         _yeni += 1
-    else:
-        print(f"  ! çeviri başarısız (önbelleğe yazılmadı): {s[:60]}")
-    time.sleep(0.15)
-    return out
+        time.sleep(0.15)
+        return out
+    _basarisiz += 1
+    print(f"  ! çeviri başarısız (önbelleğe yazılmadı, sayfa korunacak): {s[:60]}")
+    return None
 
 
 
@@ -401,6 +391,9 @@ def main():
             print(f"  · {i}/{len(terms)} sayfa · önbellek {len(_cache)} kayıt")
     if not DRY:
         json.dump(_cache, open(CACHE, "w", encoding="utf-8"), ensure_ascii=False, indent=1, sort_keys=True)
+    if _basarisiz:
+        print(f"✗ {_basarisiz} çeviri başarısız · yeni/yeniden üretilen sözlük sayfaları yazılmadı")
+        raise SystemExit(1)
     print(f"✅ {yazilan} {LANG} sözlük sayfası · {_yeni} yeni çeviri · önbellek {len(_cache)} kayıt")
 
 

--- a/scripts/discover-en.py
+++ b/scripts/discover-en.py
@@ -27,6 +27,7 @@ import os, re, sys, json, html, time, urllib.parse, urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from diller import dil, tarih_yaz, chrome as chrome_kur, dil_dugmeleri_yaz, dil_hedefleri
+from translation_service import translate_text
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TR_DIR = os.path.join(ROOT, "discover")
@@ -44,37 +45,26 @@ CACHE = os.path.join(ROOT, "assets", "discover", f"{LANG}-cache.json")
 # ── çeviri ────────────────────────────────────────────────────────────────────
 _cache = json.load(open(CACHE, encoding="utf-8")) if os.path.exists(CACHE) else {}
 _yeni = 0
+_basarisiz = 0
 
 
 def tr2en(s):
-    """Türkçeden hedef dile · ücretsiz uç nokta, önbellekli, hata olursa Türkçesini bırakır."""
-    global _yeni
+    """Türkçeden hedef dile · Gemini birincil, GTX ikincil; başarısızlıkta None."""
+    global _yeni, _basarisiz
     s = (s or "").strip()
     if not s:
         return ""
     if s in _cache:
         return _cache[s]
-    url = (f"https://translate.googleapis.com/translate_a/single?client=gtx&sl=tr&tl={LANG}&dt=t&q="
-           + urllib.parse.quote(s))
-    out, oldu = s, False
-    for deneme in range(3):
-        try:
-            with urllib.request.urlopen(url, timeout=25) as r:
-                d = json.loads(r.read().decode())
-            out = "".join(p[0] for p in d[0])
-            oldu = True
-            break
-        except Exception:
-            time.sleep(1 + deneme * 2)
-    # Başarısız çeviriyi ÖNBELLEĞE YAZMA · yoksa Türkçe metin kalıcı olarak
-    # İngilizce sayfaya yapışır, sonraki çalıştırmalar da onu kullanır.
-    if oldu:
+    out = translate_text(s, LANG)
+    if out:
         _cache[s] = out
         _yeni += 1
-    else:
-        print(f"  ! çeviri başarısız (önbelleğe yazılmadı): {s[:60]}")
-    time.sleep(0.15)  # uç noktaya nazik ol
-    return out
+        time.sleep(0.15)
+        return out
+    _basarisiz += 1
+    print(f"  ! çeviri başarısız (önbelleğe yazılmadı, sayfa korunacak): {s[:60]}")
+    return None
 
 
 # ── Türkçe sayfadan blok çıkarma ──────────────────────────────────────────────

--- a/scripts/translate-i18n.js
+++ b/scripts/translate-i18n.js
@@ -1,30 +1,15 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
-const https = require('https');
+const { translateText: translateWithProviders } = require('./translation-service');
 
 const ROOT = path.dirname(__dirname);
 const DICT_JSON = path.join(ROOT, 'assets', 'dictionary', 'dictionary.json');
 const CAT_JSON = path.join(ROOT, 'assets', 'discover', 'catalog.json');
 
-function translateText(text) {
-  if (!text) return Promise.resolve('');
-  return new Promise((resolve) => {
-    const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=tr&tl=${LANG}&dt=t&q=${encodeURIComponent(text)}`;
-    https.get(url, { headers: { 'User-Agent': 'Mozilla/5.0' } }, (res) => {
-      let data = '';
-      res.on('data', chunk => data += chunk);
-      res.on('end', () => {
-        try {
-          const parsed = JSON.parse(data);
-          const translated = parsed[0].map(sentence => sentence[0]).join('');
-          resolve(translated || text);
-        } catch (e) {
-          resolve(text);
-        }
-      });
-    }).on('error', () => resolve(text));
-  });
+async function translateText(text) {
+  if (!text) return '';
+  return translateWithProviders(text, LANG);
 }
 
 /* Çeviri önbelleği · scripts/discover-en.py ve dictionary-en.py ile AYNI dosya.
@@ -44,6 +29,7 @@ const CACHE_PATH = path.join(ROOT, 'assets', 'discover', `${LANG}-cache.json`);
 let cache = {};
 try { cache = JSON.parse(fs.readFileSync(CACHE_PATH, 'utf8')); } catch { cache = {}; }
 let yeniCeviri = 0;
+let basarisizCeviri = 0;
 
 async function batchProcess(items, textGetter, textSetter, batchSize = 25) {
   let completed = 0;
@@ -54,7 +40,12 @@ async function batchProcess(items, textGetter, textSetter, batchSize = 25) {
       if (!srcText) return;
       if (cache[srcText]) { textSetter(item, cache[srcText]); return; }
       const translated = await translateText(srcText);
-      if (translated && translated !== srcText) { cache[srcText] = translated; yeniCeviri++; }
+      if (!translated) {
+        basarisizCeviri++;
+        console.warn(`  Translation failed; source text was not written: ${srcText.slice(0, 60)}`);
+        return;
+      }
+      if (translated !== srcText) { cache[srcText] = translated; yeniCeviri++; }
       textSetter(item, translated);
     }));
     completed += chunk.length;
@@ -90,6 +81,9 @@ async function main() {
   console.log('Catalog translation saved.');
 
   fs.writeFileSync(CACHE_PATH, JSON.stringify(cache, null, 1), 'utf8');
+  if (basarisizCeviri) {
+    throw new Error(`${basarisizCeviri} translation(s) failed; no source-language fallback was written.`);
+  }
   console.log(`All translations completed · ${yeniCeviri} new, cache ${Object.keys(cache).length} entries.`);
 }
 

--- a/scripts/translation-service.js
+++ b/scripts/translation-service.js
@@ -1,0 +1,97 @@
+const https = require('https');
+
+const MODEL = process.env.TREESCOUT_TRANSLATION_MODEL || 'gemini-3.1-flash-lite';
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function requestJson(url, options, body, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(url, { ...options, timeout: timeoutMs }, res => {
+      let raw = '';
+      res.setEncoding('utf8');
+      res.on('data', chunk => { raw += chunk; });
+      res.on('end', () => {
+        let data;
+        try { data = JSON.parse(raw); } catch { reject(new Error(`invalid JSON HTTP ${res.statusCode}`)); return; }
+        if ((res.statusCode || 500) < 200 || (res.statusCode || 500) >= 300) {
+          reject(new Error(`HTTP ${res.statusCode}: ${JSON.stringify(data).slice(0, 180)}`));
+          return;
+        }
+        resolve(data);
+      });
+    });
+    req.on('timeout', () => req.destroy(new Error('translation request timeout')));
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function clean(value) {
+  return String(value || '')
+    .trim()
+    .replace(/^```(?:text|plaintext)?\s*/i, '')
+    .replace(/\s*```$/, '')
+    .trim();
+}
+
+async function gemini(text, lang) {
+  const key = (process.env.GEMINI_API_KEY || '').trim();
+  if (!key) return null;
+  const body = JSON.stringify({
+    systemInstruction: { parts: [{ text:
+      'You are a precise professional translator. Translate Turkish into the requested language. ' +
+      'Return only the translation, without quotation marks, commentary, markdown, or language labels. ' +
+      'Do not summarize, omit, or add claims. Preserve product names, repository names, URLs, and numbers.' }] },
+    contents: [{ parts: [{ text:
+      `Translate this Turkish technology-site text into ${lang}. Keep the meaning natural for the target locale.\n\n${text}` }] }],
+    generationConfig: { temperature: 0.1, maxOutputTokens: 2048 },
+  });
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent`;
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    try {
+      const data = await requestJson(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-goog-api-key': key },
+      }, body, 60000);
+      const textParts = data?.candidates?.[0]?.content?.parts || [];
+      const result = clean(textParts.map(part => part?.text || '').join(''));
+      if (result) return result;
+      throw new Error('Gemini empty translation response');
+    } catch (error) {
+      const msg = String(error?.message || error);
+      const retryable = /HTTP (429|500|502|503)|timeout|ECONNRESET|UNAVAILABLE|RESOURCE_EXHAUSTED/i.test(msg);
+      if (!retryable || attempt === 3) return null;
+      await sleep(Math.min(1200 * (2 ** attempt), 12000));
+    }
+  }
+  return null;
+}
+
+async function gtx(text, lang) {
+  const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=tr&tl=${encodeURIComponent(lang)}&dt=t&q=${encodeURIComponent(text)}`;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const data = await requestJson(url, { method: 'GET', headers: { Accept: 'application/json', 'User-Agent': 'TreScout/1.0' } }, '', 20000);
+      const result = clean((data?.[0] || []).map(part => part?.[0] || '').join(''));
+      if (result) return result;
+      throw new Error('GTX empty translation response');
+    } catch (error) {
+      const msg = String(error?.message || error);
+      const retryable = /HTTP (429|500|502|503)|timeout|ECONNRESET/i.test(msg);
+      if (!retryable || attempt === 2) return null;
+      await sleep(Math.min(1500 * (2 ** attempt), 8000));
+    }
+  }
+  return null;
+}
+
+async function translateText(text, lang) {
+  const cleanText = String(text || '').trim();
+  if (!cleanText) return '';
+  return (await gemini(cleanText, lang)) || (await gtx(cleanText, lang));
+}
+
+module.exports = { translateText };

--- a/scripts/translation_service.py
+++ b/scripts/translation_service.py
@@ -1,0 +1,108 @@
+"""Reliable Turkish-to-locale translation for generated landing content.
+
+Gemini is preferred when GEMINI_API_KEY is available. The anonymous GTX endpoint
+is retained as a fallback. A failed call returns None: callers must preserve an
+existing page or stop the generation, never write Turkish into another locale.
+"""
+
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+GEMINI_MODEL = os.environ.get("TREESCOUT_TRANSLATION_MODEL", "gemini-3.1-flash-lite")
+
+
+def _retry_delay(attempt: int) -> float:
+    return min(2.0 * (2**attempt), 12.0)
+
+
+def _gemini(text: str, lang: str, key: str) -> str | None:
+    body = {
+        "systemInstruction": {
+            "parts": [{
+                "text": (
+                    "You are a precise professional translator. Translate Turkish into the requested language. "
+                    "Return only the translation, with no quotation marks, commentary, markdown, or language label. "
+                    "Do not summarize, omit, or add claims. Preserve product names, repository names, URLs and numbers."
+                )
+            }]
+        },
+        "contents": [{
+            "parts": [{
+                "text": (
+                    f"Translate this Turkish technology-site text into {lang}. "
+                    "Keep the meaning and register natural for the target locale.\n\n{text}"
+                )
+            }]
+        }],
+        "generationConfig": {
+            "temperature": 0.1,
+            "maxOutputTokens": 2048,
+        },
+    }
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/{GEMINI_MODEL}:generateContent"
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json", "x-goog-api-key": key},
+        method="POST",
+    )
+    for attempt in range(4):
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            candidates = payload.get("candidates") or []
+            parts = (candidates[0].get("content") or {}).get("parts") or []
+            result = "".join(str(part.get("text") or "") for part in parts).strip()
+            if result:
+                if result.startswith("```") and result.endswith("```"):
+                    result = result.split("\n", 1)[-1][:-3].strip()
+                return result or None
+            raise ValueError("Gemini empty translation response")
+        except urllib.error.HTTPError as error:
+            if error.code not in (429, 500, 502, 503) or attempt == 3:
+                return None
+        except Exception:
+            if attempt == 3:
+                return None
+        time.sleep(_retry_delay(attempt))
+    return None
+
+
+def _gtx(text: str, lang: str) -> str | None:
+    url = (
+        "https://translate.googleapis.com/translate_a/single?client=gtx&sl=tr&"
+        f"tl={urllib.parse.quote(lang)}&dt=t&q={urllib.parse.quote(text)}"
+    )
+    request = urllib.request.Request(url, headers={"Accept": "application/json", "User-Agent": "TreScout/1.0"})
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            if not isinstance(payload, list) or not payload or not isinstance(payload[0], list):
+                return None
+            result = "".join(str(part[0]) for part in payload[0] if isinstance(part, list) and part).strip()
+            return result or None
+        except urllib.error.HTTPError as error:
+            if error.code not in (429, 500, 502, 503) or attempt == 2:
+                return None
+        except Exception:
+            if attempt == 2:
+                return None
+        time.sleep(_retry_delay(attempt))
+    return None
+
+
+def translate_text(text: str, lang: str) -> str | None:
+    clean = (text or "").strip()
+    if not clean:
+        return ""
+    key = os.environ.get("GEMINI_API_KEY", "").strip()
+    if key:
+        translated = _gemini(clean, lang, key)
+        if translated:
+            return translated
+    return _gtx(clean, lang)


### PR DESCRIPTION
## Summary
- use Gemini as the primary provider with GTX fallback for generated dictionary/discovery translations
- never write source Turkish text when a locale translation fails
- pass GEMINI_API_KEY only to translation-generation workflow steps without changing IndexNow gating

## Validation
- Python syntax checks for translation and locale generators
- node --check for translation scripts

No email, Resend, owner notification, social post, subscribe request, or manual IndexNow behavior is added.