### PR TITLE
fix(i18n): batch content translations within provider limits

### DIFF
--- a/scripts/dictionary-en.py
+++ b/scripts/dictionary-en.py
@@ -21,7 +21,7 @@ import os, re, sys, json, html, time, urllib.parse, urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from diller import dil, tarih_yaz, chrome as chrome_kur, dil_dugmeleri_yaz, dil_hedefleri
-from translation_service import translate_text
+from translation_service import translate_text, translate_texts
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TR_DIR = os.path.join(ROOT, "dictionary")
@@ -39,6 +39,7 @@ ONLY = next((a.split("=")[1] for a in sys.argv if a.startswith("--slug=")), None
 _cache = json.load(open(CACHE, encoding="utf-8")) if os.path.exists(CACHE) else {}
 _yeni = 0
 _basarisiz = 0
+_basarisiz_metni = set()
 
 BASLIK = D["bolumler"]
 KATEGORI = {"ai": "AI", "web": "Web", "devops": "DevOps", "mobil": "Mobile",
@@ -52,6 +53,8 @@ def tr2en(s):
         return ""
     if s in _cache:
         return _cache[s]
+    if s in _basarisiz_metni:
+        return None
     out = translate_text(s, LANG)
     if out:
         _cache[s] = out
@@ -59,6 +62,7 @@ def tr2en(s):
         time.sleep(0.15)
         return out
     _basarisiz += 1
+    _basarisiz_metni.add(s)
     print(f"  ! çeviri başarısız (önbelleğe yazılmadı, sayfa korunacak): {s[:60]}")
     return None
 
@@ -78,7 +82,7 @@ def toplu_isit(metinler):
     tr2en tek tek devam eder · yanlış hizalanmış çeviri yazmaktansa yavaş olmak
     yeğdir.
     """
-    global _yeni
+    global _yeni, _basarisiz
     eksik = []
     for s in metinler:
         s = (s or "").strip()
@@ -86,29 +90,16 @@ def toplu_isit(metinler):
             eksik.append(s)
     if not eksik:
         return
-    BLOK = 25          # satır · daha büyüğünde uç nokta segmentleri birleştiriyor
-    for i in range(0, len(eksik), BLOK):
-        grup = eksik[i:i + BLOK]
-        blok = "\n".join(grup)
-        if len(blok) > 4000:            # URL sınırı · grubu ikiye böl
-            toplu_isit(grup[:len(grup) // 2]); toplu_isit(grup[len(grup) // 2:])
-            continue
-        url = (f"https://translate.googleapis.com/translate_a/single?client=gtx&sl=tr&tl={LANG}&dt=t&q="
-               + urllib.parse.quote(blok))
-        try:
-            with urllib.request.urlopen(url, timeout=25) as r:
-                d = json.loads(r.read().decode())
-            satirlar = "".join(p[0] for p in d[0]).split("\n")
-        except Exception:
-            continue                     # tr2en tek tek halleder
-        if len(satirlar) != len(grup):
-            continue                     # hizalama bozuk · bloğu at
-        for kaynak, cevrilen in zip(grup, satirlar):
-            cevrilen = cevrilen.strip()
-            if cevrilen:
-                _cache[kaynak] = cevrilen
-                _yeni += 1
-        time.sleep(0.3)
+    translated = translate_texts(eksik, LANG)
+    for kaynak in eksik:
+        cevrilen = translated.get(kaynak)
+        if cevrilen:
+            _cache[kaynak] = cevrilen
+            _yeni += 1
+        else:
+            _basarisiz += 1
+            _basarisiz_metni.add(kaynak)
+            print(f"  ! batch çeviri başarısız (önbelleğe yazılmadı, sayfa korunacak): {kaynak[:60]}")
 
 
 def sayfa_metinleri(tr_html):

--- a/scripts/discover-en.py
+++ b/scripts/discover-en.py
@@ -27,7 +27,7 @@ import os, re, sys, json, html, time, urllib.parse, urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from diller import dil, tarih_yaz, chrome as chrome_kur, dil_dugmeleri_yaz, dil_hedefleri
-from translation_service import translate_text
+from translation_service import translate_text, translate_texts
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TR_DIR = os.path.join(ROOT, "discover")
@@ -46,6 +46,7 @@ CACHE = os.path.join(ROOT, "assets", "discover", f"{LANG}-cache.json")
 _cache = json.load(open(CACHE, encoding="utf-8")) if os.path.exists(CACHE) else {}
 _yeni = 0
 _basarisiz = 0
+_basarisiz_metni = set()
 
 
 def tr2en(s):
@@ -56,6 +57,8 @@ def tr2en(s):
         return ""
     if s in _cache:
         return _cache[s]
+    if s in _basarisiz_metni:
+        return None
     out = translate_text(s, LANG)
     if out:
         _cache[s] = out
@@ -63,6 +66,7 @@ def tr2en(s):
         time.sleep(0.15)
         return out
     _basarisiz += 1
+    _basarisiz_metni.add(s)
     print(f"  ! çeviri başarısız (önbelleğe yazılmadı, sayfa korunacak): {s[:60]}")
     return None
 
@@ -83,7 +87,7 @@ def toplu_isit(metinler):
     tr2en tek tek devam eder · yanlış hizalanmış çeviri yazmaktansa yavaş olmak
     yeğdir.
     """
-    global _yeni
+    global _yeni, _basarisiz
     eksik = []
     for s in metinler:
         s = (s or "").strip()
@@ -91,29 +95,16 @@ def toplu_isit(metinler):
             eksik.append(s)
     if not eksik:
         return
-    BLOK = 25          # satır · daha büyüğünde uç nokta segmentleri birleştiriyor
-    for i in range(0, len(eksik), BLOK):
-        grup = eksik[i:i + BLOK]
-        blok = "\n".join(grup)
-        if len(blok) > 4000:            # URL sınırı · grubu ikiye böl
-            toplu_isit(grup[:len(grup) // 2]); toplu_isit(grup[len(grup) // 2:])
-            continue
-        url = (f"https://translate.googleapis.com/translate_a/single?client=gtx&sl=tr&tl={LANG}&dt=t&q="
-               + urllib.parse.quote(blok))
-        try:
-            with urllib.request.urlopen(url, timeout=25) as r:
-                d = json.loads(r.read().decode())
-            satirlar = "".join(p[0] for p in d[0]).split("\n")
-        except Exception:
-            continue                     # tr2en tek tek halleder
-        if len(satirlar) != len(grup):
-            continue                     # hizalama bozuk · bloğu at
-        for kaynak, cevrilen in zip(grup, satirlar):
-            cevrilen = cevrilen.strip()
-            if cevrilen:
-                _cache[kaynak] = cevrilen
-                _yeni += 1
-        time.sleep(0.3)
+    translated = translate_texts(eksik, LANG)
+    for kaynak in eksik:
+        cevrilen = translated.get(kaynak)
+        if cevrilen:
+            _cache[kaynak] = cevrilen
+            _yeni += 1
+        else:
+            _basarisiz += 1
+            _basarisiz_metni.add(kaynak)
+            print(f"  ! batch çeviri başarısız (önbelleğe yazılmadı, sayfa korunacak): {kaynak[:60]}")
 
 
 def sayfa_metinleri(tr_html):

--- a/scripts/translate-i18n.js
+++ b/scripts/translate-i18n.js
@@ -31,7 +31,7 @@ try { cache = JSON.parse(fs.readFileSync(CACHE_PATH, 'utf8')); } catch { cache =
 let yeniCeviri = 0;
 let basarisizCeviri = 0;
 
-async function batchProcess(items, textGetter, textSetter, batchSize = 25) {
+async function batchProcess(items, textGetter, textSetter, batchSize = 3) {
   let completed = 0;
   for (let i = 0; i < items.length; i += batchSize) {
     const chunk = items.slice(i, i + batchSize);
@@ -50,6 +50,9 @@ async function batchProcess(items, textGetter, textSetter, batchSize = 25) {
     }));
     completed += chunk.length;
     console.log(`  Processed ${completed}/${items.length}...`);
+    if (i + batchSize < items.length) {
+      await new Promise(resolve => setTimeout(resolve, 5000));
+    }
   }
 }
 

--- a/scripts/translation_service.py
+++ b/scripts/translation_service.py
@@ -106,3 +106,97 @@ def translate_text(text: str, lang: str) -> str | None:
         if translated:
             return translated
     return _gtx(clean, lang)
+
+
+def _gemini_batch(texts: list[str], lang: str, key: str) -> dict[str, str] | None:
+    items = [{"id": str(index), "text": text} for index, text in enumerate(texts)]
+    body = {
+        "systemInstruction": {
+            "parts": [{
+                "text": (
+                    "You are a precise professional translator. Output valid JSON only. Translate each Turkish "
+                    "item into the requested language. Preserve every id exactly, do not summarize, omit, merge, "
+                    "or add items, and preserve proper nouns, URLs, numbers, and technical meaning."
+                )
+            }]
+        },
+        "contents": [{
+            "parts": [{
+                "text": (
+                    f"Translate every item into {lang}. Return a JSON array with exactly one object per input, "
+                    "using the same id and the translated text in the text field.\n\n" + json.dumps(items, ensure_ascii=False)
+                )
+            }]
+        }],
+        "generationConfig": {
+            "temperature": 0.1,
+            "maxOutputTokens": 8192,
+            "responseMimeType": "application/json",
+        },
+    }
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/{GEMINI_MODEL}:generateContent"
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(body, ensure_ascii=False).encode("utf-8"),
+        headers={"Content-Type": "application/json", "x-goog-api-key": key},
+        method="POST",
+    )
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(request, timeout=90) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            candidates = payload.get("candidates") or []
+            parts = (candidates[0].get("content") or {}).get("parts") or []
+            raw = "".join(str(part.get("text") or "") for part in parts).strip()
+            if raw.startswith("```"):
+                raw = raw.split("\n", 1)[-1].removesuffix("```").strip()
+            parsed = json.loads(raw)
+            rows = parsed if isinstance(parsed, list) else parsed.get("translations")
+            if not isinstance(rows, list) or len(rows) != len(items):
+                raise ValueError("Gemini batch translation shape mismatch")
+            result: dict[str, str] = {}
+            for row in rows:
+                if not isinstance(row, dict):
+                    raise ValueError("Gemini batch row is not an object")
+                index = int(str(row.get("id", "")))
+                if index < 0 or index >= len(items):
+                    raise ValueError("Gemini batch id is invalid")
+                value = str(row.get("text") or "").strip()
+                if not value:
+                    raise ValueError("Gemini batch item is empty")
+                result[items[index]["text"]] = value
+            if len(result) != len(items):
+                raise ValueError("Gemini batch ids are not unique")
+            return result
+        except urllib.error.HTTPError as error:
+            if error.code not in (429, 500, 502, 503) or attempt == 2:
+                return None
+        except Exception:
+            if attempt == 2:
+                return None
+        time.sleep(_retry_delay(attempt))
+    return None
+
+
+def translate_texts(texts: list[str], lang: str) -> dict[str, str | None]:
+    """Translate passages in paced batches; never return source text on failure."""
+    unique = list(dict.fromkeys((text or "").strip() for text in texts if (text or "").strip()))
+    result: dict[str, str | None] = {}
+    key = os.environ.get("GEMINI_API_KEY", "").strip()
+    batch_size = 12
+    for start in range(0, len(unique), batch_size):
+        batch = unique[start:start + batch_size]
+        translated = _gemini_batch(batch, lang, key) if key else None
+        if translated is None:
+            # Do not immediately fire Gemini once per item after a batch quota
+            # failure. GTX is bounded and failures remain explicit as None.
+            translated = {}
+            for text in batch:
+                value = _gtx(text, lang)
+                if value:
+                    translated[text] = value
+        for text in batch:
+            result[text] = translated.get(text)
+        if start + batch_size < len(unique):
+            time.sleep(5.0)
+    return result


### PR DESCRIPTION
## Summary
- batch generated dictionary/discovery passages with bounded Gemini requests
- pace Node translation calls and preserve fail-closed behavior
- avoid writing Turkish source text into another locale when translation fails

## Validation
- Python syntax checks
- node --check for translation scripts

No email, Resend, owner notification, social post, subscribe request, or IndexNow behavior is changed.