### PR TITLE
fix(i18n): batch short content translations

### DIFF
--- a/scripts/translate-i18n.js
+++ b/scripts/translate-i18n.js
@@ -1,16 +1,11 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
-const { translateText: translateWithProviders } = require('./translation-service');
+const { translateTexts: translateWithProviders } = require('./translation-service');
 
 const ROOT = path.dirname(__dirname);
 const DICT_JSON = path.join(ROOT, 'assets', 'dictionary', 'dictionary.json');
 const CAT_JSON = path.join(ROOT, 'assets', 'discover', 'catalog.json');
-
-async function translateText(text) {
-  if (!text) return '';
-  return translateWithProviders(text, LANG);
-}
 
 /* Çeviri önbelleği · scripts/discover-en.py ve dictionary-en.py ile AYNI dosya.
    Anahtar kaynak metnin kendisi olduğu için: metin değişmemişse çeviri
@@ -31,28 +26,30 @@ try { cache = JSON.parse(fs.readFileSync(CACHE_PATH, 'utf8')); } catch { cache =
 let yeniCeviri = 0;
 let basarisizCeviri = 0;
 
-async function batchProcess(items, textGetter, textSetter, batchSize = 3) {
+async function batchProcess(items, textGetter, textSetter, batchSize = 12) {
   let completed = 0;
   for (let i = 0; i < items.length; i += batchSize) {
     const chunk = items.slice(i, i + batchSize);
-    await Promise.all(chunk.map(async (item) => {
+    const pending = [];
+    for (const item of chunk) {
       const srcText = (textGetter(item) || '').trim();
-      if (!srcText) return;
-      if (cache[srcText]) { textSetter(item, cache[srcText]); return; }
-      const translated = await translateText(srcText);
-      if (!translated) {
+      if (srcText && !cache[srcText]) pending.push(srcText);
+    }
+    const translated = await translateWithProviders(pending, LANG);
+    for (const item of chunk) {
+      const srcText = (textGetter(item) || '').trim();
+      if (!srcText) continue;
+      const value = cache[srcText] || translated.get(srcText);
+      if (!value) {
         basarisizCeviri++;
         console.warn(`  Translation failed; source text was not written: ${srcText.slice(0, 60)}`);
-        return;
+        continue;
       }
-      if (translated !== srcText) { cache[srcText] = translated; yeniCeviri++; }
-      textSetter(item, translated);
-    }));
+      if (!cache[srcText] && value !== srcText) { cache[srcText] = value; yeniCeviri++; }
+      textSetter(item, value);
+    }
     completed += chunk.length;
     console.log(`  Processed ${completed}/${items.length}...`);
-    if (i + batchSize < items.length) {
-      await new Promise(resolve => setTimeout(resolve, 5000));
-    }
   }
 }
 

--- a/scripts/translation-service.js
+++ b/scripts/translation-service.js
@@ -95,3 +95,69 @@ async function translateText(text, lang) {
 }
 
 module.exports = { translateText };
+
+
+async function geminiBatch(texts, lang) {
+  const key = (process.env.GEMINI_API_KEY || '').trim();
+  if (!key || !texts.length) return null;
+  const body = JSON.stringify({
+    systemInstruction: { parts: [{ text:
+      'You are a precise professional translator. Output valid JSON only. Translate each Turkish item into the requested language. ' +
+      'Preserve every id exactly, do not summarize, omit, merge, or add items. Preserve proper nouns, URLs, numbers, and technical meaning.' }] },
+    contents: [{ parts: [{ text:
+      `Translate every item into ${lang}. Return a JSON array with exactly one object per input, using the same id and the translated text in the text field.\n\n` +
+      JSON.stringify(texts.map((text, index) => ({ id: String(index), text }))) }] }],
+    generationConfig: { temperature: 0.1, maxOutputTokens: 8192, responseMimeType: 'application/json' },
+  });
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent`;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const data = await requestJson(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-goog-api-key': key },
+      }, body, 90000);
+      const raw = clean((data?.candidates?.[0]?.content?.parts || []).map(part => part?.text || '').join(''));
+      const parsed = JSON.parse(raw);
+      const rows = Array.isArray(parsed) ? parsed : parsed?.translations;
+      if (!Array.isArray(rows) || rows.length !== texts.length) throw new Error('Gemini batch shape mismatch');
+      const result = new Map();
+      for (const row of rows) {
+        const index = Number(row?.id);
+        const value = clean(row?.text);
+        if (!Number.isInteger(index) || index < 0 || index >= texts.length || !value) throw new Error('Gemini batch row invalid');
+        result.set(texts[index], value);
+      }
+      if (result.size !== texts.length) throw new Error('Gemini batch ids are not unique');
+      return result;
+    } catch (error) {
+      const msg = String(error?.message || error);
+      const retryable = /HTTP (429|500|502|503)|timeout|ECONNRESET|UNAVAILABLE|RESOURCE_EXHAUSTED/i.test(msg);
+      if (!retryable || attempt === 2) return null;
+      await sleep(Math.min(1500 * (2 ** attempt), 12000));
+    }
+  }
+  return null;
+}
+
+async function translateTexts(texts, lang) {
+  const unique = [...new Set(texts.map(text => String(text || '').trim()).filter(Boolean))];
+  const result = new Map();
+  const batchSize = 12;
+  for (let start = 0; start < unique.length; start += batchSize) {
+    const batch = unique.slice(start, start + batchSize);
+    const translated = await geminiBatch(batch, lang);
+    if (translated) {
+      for (const [source, value] of translated) result.set(source, value);
+    } else {
+      // A failed Gemini batch falls back to bounded GTX calls, never to source text.
+      for (const source of batch) {
+        const value = await gtx(source, lang);
+        if (value) result.set(source, value);
+      }
+    }
+    if (start + batchSize < unique.length) await sleep(5000);
+  }
+  return result;
+}
+
+module.exports = { translateText, translateTexts };


### PR DESCRIPTION
## Summary
- batch short dictionary/discovery tagline translations into bounded Gemini requests
- preserve GTX fallback and fail-closed behavior
- prevent the content-growth workflow from spending 20+ minutes on one-by-one translation calls

## Validation
- node --check scripts/translation-service.js
- node --check scripts/translate-i18n.js
- Python syntax checks

No email, Resend, owner notification, social post, subscribe request, or IndexNow behavior is changed.