### PR TITLE
fix(i18n): honor provider retry delay

### DIFF
--- a/scripts/dict-sync.py
+++ b/scripts/dict-sync.py
@@ -112,6 +112,24 @@ SYS=("Sen TreScout için Türkçe teknoloji sözlüğü editörüsün; kod bilme
  '"cat"("ai"|"dev"|"data"),"kisa"(verilen açıklamayı temel al, tek cümle),"tanim"(2-4 cümle),"analoji"(günlük benzetme 1-2 cümle),'
  '"nasil"(2-4 cümle),"nerede"(2-3 cümle),"karistirilan"(1-2 cümle veya ""),"sss"([{"soru","cevap"}] 2-3 adet),'
  '"related"(mevcut/yeni slug listesinden 3-5)}. ÇIKTI: SADECE YENİ terimlerin JSON dizisi, başka metin yok.')
+def _http_retry_delay(error, attempt):
+    """Provider'ın Retry-After/retryDelay bilgisini kullan; response body loglama."""
+    header = error.headers.get("Retry-After") if error.headers else None
+    if header:
+        try:
+            return min(max(float(header), 1.0), 90.0)
+        except ValueError:
+            pass
+    try:
+        body = error.read().decode("utf-8", errors="replace")
+        m = re.search(r'"retryDelay"\s*:\s*"([0-9.]+)s"', body)
+        if m:
+            return min(max(float(m.group(1)), 1.0), 90.0)
+    except Exception:
+        pass
+    return min((attempt + 1) * 5.0, 60.0)
+
+
 def gemini(existing, candidates, key):
     payload=("MEVCUT terimler:\n"+json.dumps([{"slug":s,"ad":n} for s,n in existing],ensure_ascii=False)+
              "\n\nADAY terimler:\n"+json.dumps(candidates,ensure_ascii=False))
@@ -127,7 +145,9 @@ def gemini(existing, candidates, key):
             return json.loads(raw)
         except urllib.error.HTTPError as e:
             last=e
-            if e.code in (429,500,502,503) and attempt<4: time.sleep((attempt+1)*5); continue
+            if e.code in (429,500,502,503) and attempt<4:
+                time.sleep(_http_retry_delay(e, attempt))
+                continue
             raise
         except Exception as e:
             last=e

--- a/scripts/discover-sync.py
+++ b/scripts/discover-sync.py
@@ -264,6 +264,24 @@ def start_url(md):
         u=(g[0] or g[1]).rstrip('"\'/.,);]>')
         if u and not BAD.search(u): return u
     return ""
+def _http_retry_delay(error, attempt):
+    """Provider'ın Retry-After/retryDelay bilgisini kullan; response body loglama."""
+    header = error.headers.get("Retry-After") if error.headers else None
+    if header:
+        try:
+            return min(max(float(header), 1.0), 90.0)
+        except ValueError:
+            pass
+    try:
+        body = error.read().decode("utf-8", errors="replace")
+        m = re.search(r'"retryDelay"\s*:\s*"([0-9.]+)s"', body)
+        if m:
+            return min(max(float(m.group(1)), 1.0), 90.0)
+    except Exception:
+        pass
+    return min((attempt + 1) * 4.0, 60.0)
+
+
 def gemini_enrich(title,summary,readme,blocks,key):
     payload=("ARAÇ: "+title+"\nÖZET: "+(summary or "")+"\n\nREADME:\n"+readme[:8000]+
              "\n\nAYIKLANAN GERÇEK KOMUTLAR (komutu yalnızca bunlardan, birebir seç):\n"+json.dumps(blocks,ensure_ascii=False))
@@ -277,7 +295,9 @@ def gemini_enrich(title,summary,readme,blocks,key):
             raw=json.loads(urllib.request.urlopen(req,timeout=120).read().decode())["candidates"][0]["content"]["parts"][0]["text"]
             return json.loads(raw)
         except urllib.error.HTTPError as e:
-            if e.code in (429,500,502,503) and attempt<3: time.sleep((attempt+1)*4); continue
+            if e.code in (429,500,502,503) and attempt<3:
+                time.sleep(_http_retry_delay(e, attempt))
+                continue
             return None
         except Exception:
             if attempt<3: time.sleep((attempt+1)*4); continue
@@ -524,7 +544,9 @@ def gemini_headline(title,tagline,key,extra=""):
             b=normalize_headline((json.loads(raw).get("baslik") or "").strip())
             return b or None
         except urllib.error.HTTPError as e:
-            if e.code in (429,500,502,503) and attempt<3: time.sleep((attempt+1)*4); continue
+            if e.code in (429,500,502,503) and attempt<3:
+                time.sleep(_http_retry_delay(e, attempt))
+                continue
             return None
         except Exception:
             if attempt<3: time.sleep((attempt+1)*4); continue

--- a/scripts/translation_service.py
+++ b/scripts/translation_service.py
@@ -11,12 +11,31 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import re
 
 GEMINI_MODEL = os.environ.get("TREESCOUT_TRANSLATION_MODEL", "gemini-3.1-flash-lite")
 
 
 def _retry_delay(attempt: int) -> float:
     return min(2.0 * (2**attempt), 12.0)
+
+
+def _http_retry_delay(error: urllib.error.HTTPError, attempt: int) -> float:
+    """Honor provider Retry-After/retryDelay without exposing response bodies."""
+    header = error.headers.get('Retry-After') if error.headers else None
+    if header:
+        try:
+            return min(max(float(header), 1.0), 90.0)
+        except ValueError:
+            pass
+    try:
+        body = error.read().decode('utf-8', errors='replace')
+        match = re.search(r'"retryDelay"\s*:\s*"([0-9.]+)s"', body)
+        if match:
+            return min(max(float(match.group(1)), 1.0), 90.0)
+    except Exception:
+        pass
+    return _retry_delay(attempt)
 
 
 def _gemini(text: str, lang: str, key: str) -> str | None:
@@ -65,6 +84,8 @@ def _gemini(text: str, lang: str, key: str) -> str | None:
         except urllib.error.HTTPError as error:
             if error.code not in (429, 500, 502, 503) or attempt == 3:
                 return None
+            time.sleep(_http_retry_delay(error, attempt))
+            continue
         except Exception:
             if attempt == 3:
                 return None
@@ -89,6 +110,8 @@ def _gtx(text: str, lang: str) -> str | None:
         except urllib.error.HTTPError as error:
             if error.code not in (429, 500, 502, 503) or attempt == 2:
                 return None
+            time.sleep(_http_retry_delay(error, attempt))
+            continue
         except Exception:
             if attempt == 2:
                 return None
@@ -171,6 +194,8 @@ def _gemini_batch(texts: list[str], lang: str, key: str) -> dict[str, str] | Non
         except urllib.error.HTTPError as error:
             if error.code not in (429, 500, 502, 503) or attempt == 2:
                 return None
+            time.sleep(_http_retry_delay(error, attempt))
+            continue
         except Exception:
             if attempt == 2:
                 return None


### PR DESCRIPTION
## Summary
- honor Gemini Retry-After/retryDelay in shared Python translation helper
- honor provider retry delay in dictionary growth and discovery enrichment
- preserve fail-closed behavior and avoid logging response bodies

## Validation
- Python compile checks passed
- local retryDelay parser test passed
- git diff --check passed

No email, Resend, owner notification, social post, subscribe request, or IndexNow behavior is changed.