### PR TITLE
fix(recovery): seed report content without gemini

### DIFF
--- a/.github/workflows/dict-sync.yml
+++ b/.github/workflows/dict-sync.yml
@@ -31,6 +31,14 @@ on:
         description: "Recovery only · comma-separated discovery slugs to render; empty = all"
         required: false
         default: ''
+      dictionary_seed_terms:
+        description: "Recovery only · comma-separated report glossary slugs to seed without Gemini"
+        required: false
+        default: ''
+      discovery_seed_slugs:
+        description: "Recovery only · comma-separated report discovery slugs to seed as lite without Gemini"
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -59,7 +67,13 @@ jobs:
       - name: Sözlüğü büyüt (yeni rapor terimleri)
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-        run: python3 scripts/dict-sync.py
+          DICTIONARY_SEED_TERMS: ${{ github.event.inputs.dictionary_seed_terms }}
+        run: |
+          if [ -n "$DICTIONARY_SEED_TERMS" ]; then
+            python3 scripts/dict-sync.py --seed="$DICTIONARY_SEED_TERMS"
+          else
+            python3 scripts/dict-sync.py
+          fi
 
       - name: Sözlük kartlarını üret (yeni terimler · marka OG)
         run: python3 scripts/dict-cards.py
@@ -68,7 +82,13 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
-        run: python3 scripts/discover-sync.py
+          DISCOVERY_SEED_SLUGS: ${{ github.event.inputs.discovery_seed_slugs }}
+        run: |
+          if [ -n "$DISCOVERY_SEED_SLUGS" ]; then
+            python3 scripts/discover-sync.py --seed="$DISCOVERY_SEED_SLUGS"
+          else
+            python3 scripts/discover-sync.py
+          fi
 
       # Elle tetiklenirse · catalog'a eklenen cmds'leri sayfaya render et + komutsuz flag'i temizle.
       # Slug listesi env üzerinden geçer (komut enjeksiyonu önlemek için inline interpolasyon yok).

--- a/scripts/dict-sync.py
+++ b/scripts/dict-sync.py
@@ -274,8 +274,60 @@ def update_sitemap(new_slugs):
         lines+=["  <url>",f"    <loc>{u}</loc>",f"    <lastmod>{TODAY_ISO}</lastmod>","    <changefreq>monthly</changefreq>","    <priority>0.6</priority>","  </url>"]
     if lines: open(SITEMAP,"w",encoding="utf-8").write(sm.replace("</urlset>","\n".join(lines)+"\n</urlset>"))
 
+# ---------- manual source-only recovery ----------
+def seed_source_terms(slugs):
+    """Manual-only recovery: render trusted report glossary text without Gemini."""
+    wanted = [slugify(s.strip()) for s in slugs.split(",") if s.strip()]
+    if not wanted:
+        raise SystemExit("--seed requires at least one slug")
+    terms = {slugify(t["term"]): t for t in collect_glossary()}
+    manifest = json.load(open(MANIFEST, encoding="utf-8"))
+    existing = {m["slug"] for m in manifest}
+    missing = [s for s in wanted if s not in terms]
+    if missing:
+        print(f"HATA: rapor glossary kaynağında bulunmayan seed: {', '.join(missing)}")
+        raise SystemExit(1)
+    specs = {
+        "append-only-log": ("Append-only log", "data"),
+        "personal-knowledge-management": ("Personal knowledge management", "data"),
+    }
+    new = []
+    for slug in wanted:
+        if slug in existing:
+            print(f"  · {slug}: manifestte zaten var")
+            continue
+        term = terms[slug]
+        en, cat = specs.get(slug, (term["term"], "data"))
+        source = term["explanation"].strip()
+        new.append({
+            "slug": slug, "en": en, "full": "", "cat": cat,
+            "kisa": source, "tanim": source, "analoji": "", "nasil": "",
+            "nerede": "", "karistirilan": "", "sss": [], "related": [],
+        })
+    if not new:
+        print("kaynak seed’i zaten yayınlanmış · sözlük güncel")
+        return
+    if DRY:
+        print(f"[--dry] source-only seed: {', '.join(n['slug'] for n in new)}")
+        return
+    en_map = {m["slug"]: m["en"] for m in manifest}
+    en_map.update({n["slug"]: n["en"] for n in new})
+    for n in new:
+        render_page(n, en_map)
+    manifest += [{"slug": n["slug"], "en": n["en"], "full": "", "cat": n["cat"],
+                  "kisa": n["kisa"], "date": TODAY_ISO} for n in new]
+    json.dump(manifest, open(MANIFEST, "w", encoding="utf-8"), ensure_ascii=False, indent=2)
+    render_index(manifest)
+    update_sitemap([n["slug"] for n in new])
+    print(f"✅ {len(new)} source-only sözlük terimi eklendi · sonraki zenginleştirme kuyruğuna hazır")
+
+
 # ---------- main ----------
 def main():
+    seed = next((a for a in sys.argv if a.startswith("--seed=")), None)
+    if seed:
+        seed_source_terms(seed.split("=", 1)[1])
+        return
     terms=collect_glossary()
     print(f"raporlardan toplanan glossary terimi: {len(terms)}")
     if not terms: print("glossary bulunamadı (rapor JSON'unda 'glossary' yok, PDF de yok)."); return

--- a/scripts/discover-sync.py
+++ b/scripts/discover-sync.py
@@ -836,7 +836,66 @@ def refresh(cat, by_slug, limit):
     if not DRY: json.dump(cat,open(CATALOG,"w",encoding="utf-8"),ensure_ascii=False,indent=2)
     print(f"✅ {n} sayfaya güncelleme katmanı eklendi · {len(aday)} kayıt incelendi")
 
+def seed_source_discovery(slugs):
+    """Manual-only recovery: add report-sourced repos as safe lite entries."""
+    wanted = [slugify(s.strip()) for s in slugs.split(",") if s.strip()]
+    if not wanted:
+        raise SystemExit("--seed requires at least one slug")
+    cat = json.load(open(CATALOG, encoding="utf-8"))
+    existing = {c["slug"] for c in cat}
+    items = {slugify(it.get("title", "")): it for it in report_items()}
+    missing = [s for s in wanted if s not in items]
+    if missing:
+        print(f"HATA: rapor discovery kaynağında bulunmayan seed: {', '.join(missing)}")
+        raise SystemExit(1)
+    new = []
+    for slug in wanted:
+        if slug in existing:
+            print(f"  · {slug}: catalogda zaten var")
+            continue
+        it = items[slug]
+        title = nice_title(it.get("title", "").split("/")[-1] or it.get("title", ""))
+        lang, stars, momentum = parse_meta(it.get("meta", ""))
+        summary = (it.get("summary") or "").strip()
+        new.append({
+            "slug": slug, "title": title,
+            "tagline": make_tagline(summary, title), "summary": summary,
+            "url": it.get("url", ""), "lang": lang, "stars": stars,
+            "momentum": momentum, "date": it.get("_date", TODAY),
+            "last_seen": it.get("_date", TODAY), "tags": infer_tags(summary),
+        })
+    if not new:
+        print("kaynak seed’i zaten yayınlanmış · keşif güncel")
+        return
+    if DRY:
+        print(f"[--dry] source-only discovery: {', '.join(n['slug'] for n in new)}")
+        return
+    for n in new:
+        os.makedirs(os.path.join(DISC, n["slug"]), exist_ok=True)
+        open(os.path.join(DISC, n["slug"], "index.html"), "w", encoding="utf-8").write(build_page(n, None))
+        card = os.path.join(OGDIR, n["slug"] + ".webp")
+        if not os.path.exists(card):
+            make_card(n["slug"], n["title"], n["tagline"], n["stars"], n["lang"], card)
+    cat.extend(base_entry(n, None, "source_only", None) for n in new)
+    json.dump(cat, open(CATALOG, "w", encoding="utf-8"), ensure_ascii=False, indent=2)
+    sm = open(SITEMAP, encoding="utf-8").read()
+    lines = []
+    for n in new:
+        u = f"https://trescout.com/discover/{n['slug']}/"
+        if u in sm:
+            continue
+        lines += ["  <url>", f"    <loc>{u}</loc>", f"    <lastmod>{n['date']}</lastmod>",
+                  "    <changefreq>monthly</changefreq>", "    <priority>0.6</priority>", "  </url>"]
+    if lines:
+        open(SITEMAP, "w", encoding="utf-8").write(sm.replace("</urlset>", "\n".join(lines) + "\n</urlset>"))
+    print(f"✅ {len(new)} source-only discovery eklendi · lite + zenginleştirme kuyruğu")
+
+
 def main():
+    seed = next((a for a in sys.argv if a.startswith("--seed=")), None)
+    if seed:
+        seed_source_discovery(seed.split("=", 1)[1])
+        return
     key=gemini_key()
     cat=json.load(open(CATALOG,encoding="utf-8"))
     by_slug={c["slug"]:c for c in cat}

--- a/scripts/translation_service.py
+++ b/scripts/translation_service.py
@@ -14,6 +14,7 @@ import urllib.request
 import re
 
 GEMINI_MODEL = os.environ.get("TREESCOUT_TRANSLATION_MODEL", "gemini-3.1-flash-lite")
+_GEMINI_PAUSED_UNTIL = 0.0
 
 
 def _retry_delay(attempt: int) -> float:
@@ -38,7 +39,18 @@ def _http_retry_delay(error: urllib.error.HTTPError, attempt: int) -> float:
     return _retry_delay(attempt)
 
 
+def _pause_gemini(delay: float) -> None:
+    global _GEMINI_PAUSED_UNTIL
+    _GEMINI_PAUSED_UNTIL = max(_GEMINI_PAUSED_UNTIL, time.time() + delay)
+
+
+def _gemini_is_paused() -> bool:
+    return time.time() < _GEMINI_PAUSED_UNTIL
+
+
 def _gemini(text: str, lang: str, key: str) -> str | None:
+    if _gemini_is_paused():
+        return None
     body = {
         "systemInstruction": {
             "parts": [{
@@ -82,7 +94,10 @@ def _gemini(text: str, lang: str, key: str) -> str | None:
                 return result or None
             raise ValueError("Gemini empty translation response")
         except urllib.error.HTTPError as error:
-            if error.code not in (429, 500, 502, 503) or attempt == 3:
+            if error.code == 429:
+                _pause_gemini(_http_retry_delay(error, attempt))
+                return None
+            if error.code not in (500, 502, 503) or attempt == 3:
                 return None
             time.sleep(_http_retry_delay(error, attempt))
             continue
@@ -108,6 +123,9 @@ def _gtx(text: str, lang: str) -> str | None:
             result = "".join(str(part[0]) for part in payload[0] if isinstance(part, list) and part).strip()
             return result or None
         except urllib.error.HTTPError as error:
+            if error.code == 429:
+                _pause_gemini(_http_retry_delay(error, attempt))
+                return None
             if error.code not in (429, 500, 502, 503) or attempt == 2:
                 return None
             time.sleep(_http_retry_delay(error, attempt))
@@ -192,6 +210,9 @@ def _gemini_batch(texts: list[str], lang: str, key: str) -> dict[str, str] | Non
                 raise ValueError("Gemini batch ids are not unique")
             return result
         except urllib.error.HTTPError as error:
+            if error.code == 429:
+                _pause_gemini(_http_retry_delay(error, attempt))
+                return None
             if error.code not in (429, 500, 502, 503) or attempt == 2:
                 return None
             time.sleep(_http_retry_delay(error, attempt))


### PR DESCRIPTION
## Summary
- add manual-only source seed for trusted report glossary terms
- add manual-only source seed for trusted discovery repos as lite entries
- honor Gemini Retry-After/retryDelay and pause repeated calls after 429
- keep scheduled/default growth and fail-closed behavior unchanged

## Validation
- Python compile checks passed
- source-seed dry-runs passed for 2 dictionary and 4 discovery slugs
- git diff --check passed

No email, Resend, owner notification, social post, subscribe request, or IndexNow behavior is changed.