### PR TITLE
fix(landing): address review findings

### DIFF
--- a/.github/workflows/csp-inline-guard.yml
+++ b/.github/workflows/csp-inline-guard.yml
@@ -29,6 +29,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Rapor snapshot helper testi
         run: node --test scripts/report-snapshot.test.js
+      - name: Erken erişim API sözleşme testi
+        run: node --test scripts/subscribe-contract.test.mjs
       - name: Inline CSS/JS kontrolü
         run: python3 scripts/check-no-inline-csp.py
       - name: Nav tutarlılık kontrolü

--- a/api/subscribe.js
+++ b/api/subscribe.js
@@ -52,12 +52,12 @@ const DISPOSABLE_DOMAINS = new Set([
 
 /**
  * Kullanıcıya dönen hata metinleri · sayfanın dili neyse o.
- * İstemci `lang` gönderiyor (document.documentElement.lang). Gönderilmezse
- * Türkçe · site Türkçe doğdu, varsayılan o.
+ * Dil, istek body'sine güvenmeden referer yolundan seçilir; `code` alanı istemci
+ * için locale-bağımsız hata sözleşmesidir. Referer yoksa Türkçe varsayılandır.
  */
 const MESAJ = {
   tr: {
-    method: 'Method not allowed',
+    method: 'Bu yöntem desteklenmiyor',
     istek: 'İstek geçersiz',
     limit: 'Çok fazla deneme · birkaç dakika sonra tekrar deneyin',
     format: 'Geçersiz istek formatı',
@@ -80,7 +80,61 @@ const MESAJ = {
     kayit: 'Could not sign you up, please try again',
     baglanti: 'Connection error, please try again',
   },
+  fr: {
+    method: 'Méthode non autorisée',
+    istek: 'Requête invalide',
+    limit: 'Trop de tentatives · réessayez dans quelques minutes',
+    format: 'Format de requête invalide',
+    onay: 'Veuillez accepter la notice de confidentialité pour continuer',
+    eposta: 'Saisissez une adresse e-mail valide',
+    gecici: 'Veuillez utiliser une adresse e-mail permanente',
+    sunucu: 'La configuration du serveur est incomplète',
+    kayit: 'Inscription impossible, veuillez réessayer',
+    baglanti: 'Erreur de connexion, veuillez réessayer',
+  },
+  pt: {
+    method: 'Método não permitido',
+    istek: 'Solicitação inválida',
+    limit: 'Muitas tentativas · tente novamente em alguns minutos',
+    format: 'Formato de solicitação inválido',
+    onay: 'Aceite o aviso de privacidade para continuar',
+    eposta: 'Digite um endereço de e-mail válido',
+    gecici: 'Use um endereço de e-mail permanente',
+    sunucu: 'A configuração do servidor está incompleta',
+    kayit: 'Não foi possível fazer sua inscrição; tente novamente',
+    baglanti: 'Erro de conexão; tente novamente',
+  },
+  es: {
+    method: 'Método no permitido',
+    istek: 'Solicitud no válida',
+    limit: 'Demasiados intentos · inténtelo de nuevo en unos minutos',
+    format: 'Formato de solicitud no válido',
+    onay: 'Acepte el aviso de privacidad para continuar',
+    eposta: 'Introduzca una dirección de correo válida',
+    gecici: 'Utilice una dirección de correo permanente',
+    sunucu: 'Falta la configuración del servidor',
+    kayit: 'No se pudo completar el registro; inténtelo de nuevo',
+    baglanti: 'Error de conexión; inténtelo de nuevo',
+  },
+  de: {
+    method: 'Methode nicht erlaubt',
+    istek: 'Ungültige Anfrage',
+    limit: 'Zu viele Versuche · versuchen Sie es in einigen Minuten erneut',
+    format: 'Ungültiges Anfrageformat',
+    onay: 'Stimmen Sie dem Datenschutzhinweis zu, um fortzufahren',
+    eposta: 'Geben Sie eine gültige E-Mail-Adresse ein',
+    gecici: 'Verwenden Sie bitte eine dauerhafte E-Mail-Adresse',
+    sunucu: 'Die Serverkonfiguration fehlt',
+    kayit: 'Die Anmeldung konnte nicht abgeschlossen werden; bitte erneut versuchen',
+    baglanti: 'Verbindungsfehler; bitte erneut versuchen',
+  },
 };
+
+const SUPPORTED_LANGS = new Set(Object.keys(MESAJ));
+
+function errorResponse(messages, code, status) {
+  return jsonResponse({ error: messages[code], code }, status);
+}
 
 function jsonResponse(body, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -153,14 +207,15 @@ function clientIp(req) {
 }
 
 /**
- * Sayfanın dili · Referer yolundan okunur (/en/... → İngilizce).
+ * Sayfanın dili · Referer yolundan okunur (/en/... → İngilizce, /fr/... → Fransızca).
  * Gövde daha ayrıştırılmadan da hata dönebiliyoruz (yöntem, origin, hız sınırı) ·
- * bu yüzden dili başlıktan alıyoruz, gövdedeki `lang` alanına bağlamıyoruz.
+ * bu yüzden dili başlıktan alıyoruz ve gövdedeki herhangi bir `lang` alanına güvenmiyoruz.
  */
 function dilSec(req) {
   const ref = req.headers.get('referer') || '';
   try {
-    return new URL(ref).pathname.startsWith('/en/') ? 'en' : 'tr';
+    const firstSegment = new URL(ref).pathname.split('/').filter(Boolean)[0] || 'tr';
+    return SUPPORTED_LANGS.has(firstSegment) ? firstSegment : 'tr';
   } catch {
     return 'tr';
   }
@@ -170,28 +225,28 @@ export default async function handler(req) {
   const M = MESAJ[dilSec(req)];
 
   if (req.method !== 'POST') {
-    return jsonResponse({ error: M.method }, 405);
+    return errorResponse(M, 'method', 405);
   }
 
   // CSRF · origin check
   const origin = req.headers.get('origin');
   if (!isOriginAllowed(origin)) {
     console.warn('Blocked origin:', origin);
-    return jsonResponse({ error: M.istek }, 403);
+    return errorResponse(M, 'istek', 403);
   }
 
   // Rate limit · pahalı Resend çağrılarından önce
   const ip = clientIp(req);
   if (isRateLimited(ip, Date.now())) {
     console.warn('Rate limited:', ip);
-    return jsonResponse({ error: M.limit }, 429);
+    return errorResponse(M, 'limit', 429);
   }
 
   let body;
   try {
     body = await req.json();
   } catch {
-    return jsonResponse({ error: M.format }, 400);
+    return errorResponse(M, 'format', 400);
   }
 
   // Honeypot · bot filtresi · görünmez input, dolu gelirse bot
@@ -210,18 +265,18 @@ export default async function handler(req) {
   const consent = body.consent === true || body.consent === 'true';
 
   if (!consent) {
-    return jsonResponse({ error: M.onay }, 400);
+    return errorResponse(M, 'onay', 400);
   }
 
   if (!email || email.length > MAX_EMAIL_LENGTH || !EMAIL_REGEX.test(email)) {
-    return jsonResponse({ error: M.eposta }, 400);
+    return errorResponse(M, 'eposta', 400);
   }
 
   // Disposable email check
   const domain = email.split('@')[1];
   if (DISPOSABLE_DOMAINS.has(domain)) {
     return jsonResponse(
-      { error: 'Lütfen kalıcı bir e-posta adresi kullanın' },
+      { error: M.gecici, code: 'gecici' },
       400
     );
   }
@@ -231,7 +286,7 @@ export default async function handler(req) {
 
   if (!apiKey || !audienceId) {
     console.error('Missing env vars: RESEND_API_KEY or RESEND_AUDIENCE_ID');
-    return jsonResponse({ error: M.sunucu }, 500);
+    return errorResponse(M, 'sunucu', 500);
   }
 
   try {
@@ -252,7 +307,7 @@ export default async function handler(req) {
       // 409 = contact zaten var · sorun değil, devam et
       const errText = await audienceRes.text();
       console.error('Resend audience add failed:', audienceRes.status, errText);
-      return jsonResponse({ error: M.kayit }, 502);
+      return errorResponse(M, 'kayit', 502);
     }
 
     // 2. hello@'a bildirim e-postası
@@ -296,6 +351,6 @@ export default async function handler(req) {
     return jsonResponse({ ok: true, duplicate: isDuplicate });
   } catch (err) {
     console.error('Subscribe error:', err);
-    return jsonResponse({ error: M.baglanti }, 502);
+    return errorResponse(M, 'baglanti', 502);
   }
 }

--- a/assets/home-interactions.js
+++ b/assets/home-interactions.js
@@ -69,6 +69,16 @@
     emit('report_tasting_view', { language: language() });
   }
 
+  var FILTER_TAGS = {
+    ai: ['yapay zekâ araçları'],
+    dev: ['geliştirici aracı'],
+    learn: ['öğrenme'],
+    selfhost: ['self-host']
+  };
+
+  // Eski veya eksik katalog kaydı için geriye dönük fallback. Yeni kayıtlarda
+  // filtreleme yalnızca kanonik `tags` alanına dayanır; serbest metin araması
+  // yanlış pozitif üretebildiği için ikinci seçenek olarak tutulur.
   var FILTER_TERMS = {
     ai: ['yapay zek', 'artificial intelligence', 'ai ', 'ia ', 'intelligence artificielle', 'inteligência artificial', 'inteligencia artificial', 'künstliche intelligenz'],
     dev: ['geliştirici', 'developer', 'développeur', 'développement', 'desenvolvedor', 'desenvolvimento', 'desarrollo', 'entwickler', 'entwicklung', 'kod', 'code', 'cli', 'program'],
@@ -102,8 +112,17 @@
       .concat(entry.tags || []).join(' ').toLowerCase();
   }
 
+  function normalizeTag(value) {
+    return String(value || '').trim().toLocaleLowerCase('tr-TR');
+  }
+
   function matches(entry, filter, lang) {
     if (filter === 'all') return true;
+    var tags = Array.isArray(entry.tags) ? entry.tags.map(normalizeTag) : [];
+    var wantedTags = (FILTER_TAGS[filter] || []).map(normalizeTag);
+    if (tags.length) {
+      return tags.some(function (tag) { return wantedTags.indexOf(tag) !== -1; });
+    }
     var text = entryText(entry, lang);
     return (FILTER_TERMS[filter] || []).some(function (term) { return text.indexOf(term) !== -1; });
   }
@@ -117,6 +136,36 @@
       var date = catalogDate(entry);
       return date > latest ? date : latest;
     }, '');
+  }
+
+  var catalogPromise = null;
+
+  function loadCatalog() {
+    if (!catalogPromise) {
+      catalogPromise = fetch('/assets/discover/catalog.json', { credentials: 'same-origin' })
+        .then(function (response) {
+          if (!response.ok) throw new Error('catalog ' + response.status);
+          return response.json();
+        })
+        .then(function (entries) {
+          return Array.isArray(entries) ? entries.slice() : [];
+        });
+    }
+    return catalogPromise;
+  }
+
+  function whenVisible(root, callback) {
+    if (!('IntersectionObserver' in window)) {
+      callback();
+      return;
+    }
+    var observer = new IntersectionObserver(function (entries) {
+      if (entries.some(function (entry) { return entry.isIntersecting; })) {
+        observer.disconnect();
+        callback();
+      }
+    }, { rootMargin: '300px 0px' });
+    observer.observe(root);
   }
 
   function displayDate(value, lang) {
@@ -165,12 +214,12 @@
   }
 
   var FLOW_TEXT = {
-    tr: { step: ['Günün seçkisinden', 'Kısa özet', 'Kaynak bilgisi'], loading: 'Gerçek katalog kayıtları yükleniyor…', empty: 'Bu örnek konu için henüz kayıt bulunamadı.' },
-    en: { step: ['From today’s selection', 'Short summary', 'Source details'], loading: 'Loading real catalog entries…', empty: 'There are no entries for this example topic yet.' },
-    fr: { step: ['Dans la sélection du jour', 'Résumé court', 'Informations sur la source'], loading: 'Chargement des entrées réelles du catalogue…', empty: 'Aucune entrée pour ce sujet d’exemple pour le moment.' },
-    pt: { step: ['Na seleção do dia', 'Resumo curto', 'Informações da fonte'], loading: 'Carregando registros reais do catálogo…', empty: 'Ainda não há registros para este tema de exemplo.' },
-    es: { step: ['En la selección del día', 'Resumen breve', 'Datos de la fuente'], loading: 'Cargando entradas reales del catálogo…', empty: 'Todavía no hay entradas para este tema de ejemplo.' },
-    de: { step: ['Aus der Tagesauswahl', 'Kurze Zusammenfassung', 'Quellenangaben'], loading: 'Echte Katalogeinträge werden geladen…', empty: 'Für dieses Beispielthema gibt es noch keine Einträge.' }
+    tr: { step: ['Günün seçkisinden', 'Kısa özet', 'Kaynak bilgisi'], loading: 'Gerçek katalog kayıtları yükleniyor…', error: 'Katalog şu anda yüklenemedi. Lütfen daha sonra tekrar deneyin.', empty: 'Bu örnek konu için henüz kayıt bulunamadı.' },
+    en: { step: ['From today’s selection', 'Short summary', 'Source details'], loading: 'Loading real catalog entries…', error: 'The catalog could not be loaded right now. Please try again later.', empty: 'There are no entries for this example topic yet.' },
+    fr: { step: ['Dans la sélection du jour', 'Résumé court', 'Informations sur la source'], loading: 'Chargement des entrées réelles du catalogue…', error: 'Le catalogue est indisponible pour le moment. Veuillez réessayer plus tard.', empty: 'Aucune entrée pour ce sujet d’exemple pour le moment.' },
+    pt: { step: ['Na seleção do dia', 'Resumo curto', 'Informações da fonte'], loading: 'Carregando registros reais do catálogo…', error: 'O catálogo não pôde ser carregado agora. Tente novamente mais tarde.', empty: 'Ainda não há registros para este tema de exemplo.' },
+    es: { step: ['En la selección del día', 'Resumen breve', 'Datos de la fuente'], loading: 'Cargando entradas reales del catálogo…', error: 'El catálogo no se pudo cargar ahora. Inténtelo de nuevo más tarde.', empty: 'Todavía no hay entradas para este tema de ejemplo.' },
+    de: { step: ['Aus der Tagesauswahl', 'Kurze Zusammenfassung', 'Quellenangaben'], loading: 'Echte Katalogeinträge werden geladen…', error: 'Der Katalog konnte gerade nicht geladen werden. Bitte versuchen Sie es später erneut.', empty: 'Für dieses Beispielthema gibt es noch keine Einträge.' }
   };
 
   function initDailyFlow(root) {
@@ -264,29 +313,27 @@
       });
     });
 
-    fetch('/assets/discover/catalog.json', { credentials: 'same-origin' })
-      .then(function (response) {
-        if (!response.ok) throw new Error('catalog ' + response.status);
-        return response.json();
-      })
-      .then(function (entries) {
-        catalog = Array.isArray(entries) ? entries.slice() : [];
-        latestDate = latestCatalogDate(catalog);
-        catalog.sort(function (a, b) {
-          return catalogDate(b).localeCompare(catalogDate(a)) || Number(b.stars || 0) - Number(a.stars || 0);
+    whenVisible(root, function () {
+      loadCatalog()
+        .then(function (entries) {
+          catalog = entries;
+          latestDate = latestCatalogDate(catalog);
+          catalog.sort(function (a, b) {
+            return catalogDate(b).localeCompare(catalogDate(a)) || Number(b.stars || 0) - Number(a.stars || 0);
+          });
+          render();
+          emit('daily_flow_catalog_loaded', { language: lang, count: catalog.length });
+        })
+        .catch(function () {
+          list.replaceChildren();
+          var empty = document.createElement('p');
+          empty.className = 'daily-flow-empty';
+          empty.textContent = copy.error || copy.loading;
+          list.appendChild(empty);
+          list.setAttribute('aria-busy', 'false');
+          emit('daily_flow_error', { language: lang });
         });
-        render();
-        emit('daily_flow_catalog_loaded', { language: lang, count: catalog.length });
-      })
-      .catch(function () {
-        list.replaceChildren();
-        var empty = document.createElement('p');
-        empty.className = 'daily-flow-empty';
-        empty.textContent = copy.loading;
-        list.appendChild(empty);
-        list.setAttribute('aria-busy', 'false');
-        emit('daily_flow_error', { language: lang });
-      });
+    });
 
     emit('daily_flow_view', { language: lang });
   }
@@ -350,29 +397,27 @@
       });
     });
 
-    fetch('/assets/discover/catalog.json', { credentials: 'same-origin' })
-      .then(function (response) {
-        if (!response.ok) throw new Error('catalog ' + response.status);
-        return response.json();
-      })
-      .then(function (entries) {
-        catalog = Array.isArray(entries) ? entries.slice() : [];
-        latestDate = latestCatalogDate(catalog);
-        catalog.sort(function (a, b) {
-          return catalogDate(b).localeCompare(catalogDate(a)) || Number(b.stars || 0) - Number(a.stars || 0);
+    whenVisible(root, function () {
+      loadCatalog()
+        .then(function (entries) {
+          catalog = entries;
+          latestDate = latestCatalogDate(catalog);
+          catalog.sort(function (a, b) {
+            return catalogDate(b).localeCompare(catalogDate(a)) || Number(b.stars || 0) - Number(a.stars || 0);
+          });
+          render();
+          emit('discovery_radar_view', { language: lang, count: catalog.length });
+        })
+        .catch(function () {
+          grid.replaceChildren();
+          var empty = document.createElement('p');
+          empty.className = 'radar-empty';
+          empty.textContent = EMPTY_TEXT[contentLanguage(lang)] || EMPTY_TEXT.en;
+          grid.appendChild(empty);
+          grid.setAttribute('aria-busy', 'false');
+          emit('discovery_radar_error', { language: lang });
         });
-        render();
-        emit('discovery_radar_view', { language: lang, count: catalog.length });
-      })
-      .catch(function () {
-        grid.replaceChildren();
-        var empty = document.createElement('p');
-        empty.className = 'radar-empty';
-        empty.textContent = EMPTY_TEXT[contentLanguage(lang)] || EMPTY_TEXT.en;
-        grid.appendChild(empty);
-        grid.setAttribute('aria-busy', 'false');
-        emit('discovery_radar_error', { language: lang });
-      });
+    });
 
     if (loading) loading.setAttribute('aria-live', 'polite');
   }

--- a/assets/index.js
+++ b/assets/index.js
@@ -85,7 +85,7 @@
     var l = (document.documentElement.lang || 'tr');
     return tablo[l] || tablo[l.split('-')[0]] || tablo.tr;
   }
-  var T = _dilSec(METIN);
+      var T = _dilSec(METIN);
 
 
 /* ---------- abone formu · /api/subscribe ---------- */
@@ -157,7 +157,8 @@
             } else {
               button.disabled = false;
               button.textContent = originalText;
-              showError(form, data.error || T.genel);
+              var localError = data.code === 'onay' ? T.onay : data.code === 'baglanti' ? T.baglanti : '';
+              showError(form, localError || data.error || T.genel);
             }
           } catch (err) {
             button.disabled = false;
@@ -204,6 +205,26 @@
       var activeCheckbox = null;
       var activeHint = null;
       var lastFocus = null;
+      var backgroundRoots = [
+        document.querySelector('nav'),
+        document.querySelector('main'),
+        document.querySelector('footer')
+      ].filter(Boolean);
+
+      function setBackgroundInert(inert) {
+        backgroundRoots.forEach(function (root) {
+          if (inert) root.setAttribute('inert', '');
+          else root.removeAttribute('inert');
+        });
+      }
+
+      function focusableElements() {
+        return Array.prototype.slice.call(modal.querySelectorAll(
+          'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), iframe, [tabindex]:not([tabindex="-1"])'
+        )).filter(function (el) {
+          return !el.hidden && el.getAttribute('aria-hidden') !== 'true' && el.offsetParent !== null;
+        });
+      }
 
       function setRead() {
         if (hasRead) return;
@@ -229,6 +250,7 @@
         // zorunda kalmasın (2026-08-07).
         iframe.src = T.metinYolu + '?embed=1&t=' + Date.now();
         modal.setAttribute('aria-hidden', 'false');
+        setBackgroundInert(true);
         // BODY SCROLL LOCK KASTEN YOK · modal zaten position:fixed inset:0
         // ile viewport'u tam kaplıyor; pointer-events:auto ile body
         // dokunulamaz. iOS Safari'de body position:fixed pattern viewport
@@ -238,6 +260,7 @@
 
       function closeModal() {
         modal.setAttribute('aria-hidden', 'true');
+        setBackgroundInert(false);
         // Eski state'ler (önceki version'lardan kalmış olabilir) defensive cleanup
         ['position', 'top', 'left', 'right', 'width', 'overflow'].forEach(function (p) {
           document.body.style.removeProperty(p);
@@ -254,6 +277,8 @@
 
       // Iframe'den "okundu" mesajını dinle
       window.addEventListener('message', function (e) {
+        if (e.origin !== window.location.origin) return;
+        if (e.source !== iframe.contentWindow) return;
         if (e.data && e.data.type === 'trescout-privacy-read') {
           setRead();
         }
@@ -286,10 +311,28 @@
         if (e.target === modal) closeModal();
       });
 
-      // ESC ile kapat
+      // ESC ile kapat + modal içinde focus trap
       document.addEventListener('keydown', function (e) {
-        if (e.key === 'Escape' && modal.getAttribute('aria-hidden') === 'false') {
+        if (modal.getAttribute('aria-hidden') !== 'false') return;
+        if (e.key === 'Escape') {
           closeModal();
+          return;
+        }
+        if (e.key !== 'Tab') return;
+        var focusables = focusableElements();
+        if (!focusables.length) {
+          e.preventDefault();
+          closeX.focus();
+          return;
+        }
+        var first = focusables[0];
+        var last = focusables[focusables.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
         }
       });
 

--- a/assets/privacy.js
+++ b/assets/privacy.js
@@ -9,7 +9,7 @@
         return sh - st - ch < 80;
       }
       function notify() {
-        try { window.parent.postMessage({ type: 'trescout-privacy-read' }, '*'); } catch (e) {}
+        try { window.parent.postMessage({ type: 'trescout-privacy-read' }, window.location.origin); } catch (e) {}
       }
       window.addEventListener('scroll', function () {
         if (nearBottom()) notify();

--- a/assets/site.css
+++ b/assets/site.css
@@ -199,10 +199,30 @@ nav.scrolled {
 }
 @media (max-width: 640px) {
   .container { padding: 0 16px; }
+  .nav-inner {
+    flex-wrap: wrap;
+    gap: 10px 16px;
+    padding: 14px 0 10px;
+  }
   .logo-link { gap: 8px; }
-  /* Mobilde nav taşmasın: bölüm linkleri (ghost) gizlenir, birincil CTA kalır · tüm bölümler footer'da */
-  .nav-actions { gap: 6px; }
-  .nav-actions .btn-ghost { display: none; }
+  /* Mobilde menü linklerini gizlemek yerine ikinci satırda kaydırılabilir tut.
+     Böylece ana bölümlere footer'a kadar inmeden ulaşılabilir. */
+  .nav-actions {
+    flex: 1 1 100%;
+    min-width: 0;
+    width: 100%;
+    gap: 6px;
+    overflow-x: auto;
+    justify-content: flex-start;
+    scrollbar-width: none;
+  }
+  .nav-actions::-webkit-scrollbar { display: none; }
+  .nav-actions .btn-ghost {
+    display: inline-flex;
+    flex: 0 0 auto;
+    padding: 8px 12px;
+    font-size: 12px;
+  }
 }
 
 /* ---------- BUTTONS ---------- */

--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
           <!-- CANLI ARŞİV · statik örneği gerçek/günlük arşive köprüler (sosyal kanıt) -->
           <a class="preview-archive-cta" href="/reports/">
             <span class="pac-live" id="js-arch-badge">CANLI</span>
-            <span class="pac-msg"><strong>Bu bir sabit örnek.</strong> Güncel raporları her gün arşivde yayımlıyoruz · <span class="pac-go">arşivi görün →</span></span></span></span></span></span></span></span></span>
+            <span class="pac-msg"><strong>Bu bir sabit örnek.</strong> Güncel raporları her gün arşivde yayımlıyoruz · <span class="pac-go">arşivi görün →</span></span>
           </a>
 
 

--- a/scripts/subscribe-contract.test.mjs
+++ b/scripts/subscribe-contract.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const source = await readFile(new URL('../api/subscribe.js', import.meta.url), 'utf8');
+const moduleSource = source
+  .replace('export const config =', 'const config =')
+  .replace('export default async function handler', 'async function handler')
+  + '\nexport { handler };';
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(moduleSource).toString('base64')}`;
+const { handler } = await import(moduleUrl);
+
+async function responseFor(language, method = 'POST') {
+  const headers = {
+    origin: 'https://trescout.com',
+    referer: `https://trescout.com/${language === 'tr' ? '' : `${language}/`}`,
+  };
+  const init = { method, headers };
+  if (method === 'POST') {
+    headers['content-type'] = 'application/json';
+    init.body = JSON.stringify({ consent: false });
+  }
+  const response = await handler(new Request('https://trescout.com/api/subscribe', init));
+  return { response, body: await response.json() };
+}
+
+test('localized validation errors use a stable code for every supported language', async () => {
+  const expected = {
+    tr: 'Aydınlatma Metni onayı gerekli',
+    en: 'Please accept the privacy notice to continue',
+    fr: 'Veuillez accepter la notice de confidentialité pour continuer',
+    pt: 'Aceite o aviso de privacidade para continuar',
+    es: 'Acepte el aviso de privacidad para continuar',
+    de: 'Stimmen Sie dem Datenschutzhinweis zu, um fortzufahren',
+  };
+
+  for (const [language, message] of Object.entries(expected)) {
+    const { response, body } = await responseFor(language);
+    assert.equal(response.status, 400, language);
+    assert.equal(body.code, 'onay', language);
+    assert.equal(body.error, message, language);
+  }
+});
+
+test('method errors are localized from the referer path', async () => {
+  const { response, body } = await responseFor('fr', 'GET');
+  assert.equal(response.status, 405);
+  assert.equal(body.code, 'method');
+  assert.equal(body.error, 'Méthode non autorisée');
+});


### PR DESCRIPTION
## Özet

Bu PR, landing incelemesinde tespit edilen mobil kullanılabilirlik, çok dilli form hataları, katalog performansı, filtre doğruluğu ve privacy modal erişilebilirliği sorunlarını giderir.

## Değişiklikler

- Mobilde üst navigasyon linklerinin gizlenmesi kaldırıldı; nav ikinci satırda yatay kaydırılabilir hale getirildi.
- Erken erişim API’sine Türkçe, İngilizce, Fransızca, Portekizce, İspanyolca ve Almanca hata mesajları eklendi.
- API hata yanıtlarına locale-bağımsız `code` alanı eklendi ve dil seçimi Referer yolundan desteklenen diller için genelleştirildi.
- Katalog verisi radar ve günlük akış arasında paylaşılan tek bir promise/cache ile yükleniyor; bölümler görünür alana yaklaşınca yükleme başlıyor.
- Katalog filtreleri kanonik `tags` alanını kullanıyor; eski/eksik kayıtlar için geriye dönük fallback korunuyor.
- Privacy modalında arka plan içeriği inert hale getirildi, keyboard focus trap eklendi ve consent mesajları origin/iframe kaynağı doğruluyor.
- Privacy iframe `postMessage` wildcard hedefinden aynı-origin hedefine taşındı.
- Ana landing HTML’indeki fazladan kapanış etiketleri temizlendi.
- Çok dilli API hata sözleşmesi için CI’da çalışan side-effect’siz testler eklendi.

## Doğrulama

- `node --test scripts/report-snapshot.test.js` — 3/3 geçti.
- `node --test scripts/subscribe-contract.test.mjs` — 2/2 geçti.
- Düzenlenen JavaScript dosyalarında sözdizimi kontrolleri geçti.
- CSP, nav/footer, logo, headline, brand typography, consent, bölüm/sayfa paritesi, birleşmiş terimler, hreflang ve SEO/GEO guard’larının tamamı geçti.
- Mobil ve masaüstü screenshot smoke kontrolleri yapıldı; günlük akış görünür alana geldiğinde gerçek katalog kaydı başarıyla render edildi.

## Not

Bu PR `main` branch’ine otomatik merge edilmemiştir; inceleme sonrası merge edilmelidir.
