### PR TITLE
security: add distributed signup rate limit

### DIFF
--- a/api/rate-limit.mjs
+++ b/api/rate-limit.mjs
@@ -29,7 +29,7 @@ export function createRateLimiter({
 
   async function checkDistributed(ip) {
     const key = `trescout:subscribe:rate:${encodeURIComponent(ip)}`;
-    const response = await fetchImpl(`${redisUrl}/pipeline`, {
+    const response = await fetchImpl(`${redisUrl}/multi-exec`, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${redisToken}`,

--- a/api/rate-limit.mjs
+++ b/api/rate-limit.mjs
@@ -1,0 +1,81 @@
+const RATE_WINDOW_SECONDS = 10 * 60;
+const RATE_WINDOW_MS = RATE_WINDOW_SECONDS * 1000;
+const RATE_MAX = 5;
+
+function isLocalRateLimited(rateHits, ip, now) {
+  if (!ip) return false;
+  const cutoff = now - RATE_WINDOW_MS;
+  const hits = (rateHits.get(ip) || []).filter((timestamp) => timestamp > cutoff);
+  hits.push(now);
+  rateHits.set(ip, hits);
+
+  if (rateHits.size > 5000) {
+    for (const [key, values] of rateHits) {
+      if (values.every((timestamp) => timestamp <= cutoff)) rateHits.delete(key);
+    }
+  }
+
+  return hits.length > RATE_MAX;
+}
+
+export function createRateLimiter({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  now = () => Date.now(),
+} = {}) {
+  const redisUrl = (env.UPSTASH_REDIS_REST_URL || '').replace(/\/+$/, '');
+  const redisToken = env.UPSTASH_REDIS_REST_TOKEN || '';
+  const rateHits = new Map();
+
+  async function checkDistributed(ip) {
+    const key = `trescout:subscribe:rate:${encodeURIComponent(ip)}`;
+    const response = await fetchImpl(`${redisUrl}/pipeline`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${redisToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify([
+        ['SET', key, '0', 'EX', String(RATE_WINDOW_SECONDS), 'NX'],
+        ['INCR', key],
+      ]),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Upstash rate limit HTTP ${response.status}`);
+    }
+
+    const results = await response.json();
+    const count = Number(results?.[1]?.result);
+    if (!Number.isFinite(count)) {
+      throw new Error('Upstash rate limit response is invalid');
+    }
+
+    return count > RATE_MAX;
+  }
+
+  return {
+    async check(ip) {
+      if (!ip) return { limited: false, unavailable: false };
+
+      if (!redisUrl || !redisToken) {
+        if (env.VERCEL_ENV === 'production') {
+          return { limited: false, unavailable: true };
+        }
+        return {
+          limited: isLocalRateLimited(rateHits, ip, now()),
+          unavailable: false,
+        };
+      }
+
+      try {
+        return { limited: await checkDistributed(ip), unavailable: false };
+      } catch (error) {
+        console.error('Distributed rate limit unavailable:', error);
+        return { limited: false, unavailable: true };
+      }
+    },
+  };
+}
+
+export { RATE_MAX, RATE_WINDOW_SECONDS };

--- a/api/subscribe.js
+++ b/api/subscribe.js
@@ -19,7 +19,11 @@
  * Gerekli env vars (Vercel dashboard'da):
  *   - RESEND_API_KEY · Resend'den "Full access" scope'lu API key
  *   - RESEND_AUDIENCE_ID · Resend Audience UUID
+ *   - UPSTASH_REDIS_REST_URL · production dağıtık rate limit REST URL
+ *   - UPSTASH_REDIS_REST_TOKEN · production dağıtık rate limit REST token
  */
+
+import { createRateLimiter } from './rate-limit.mjs';
 
 export const config = { runtime: 'edge' };
 
@@ -175,34 +179,15 @@ function isOriginAllowed(origin) {
 }
 
 /**
- * Best-effort per-IP rate limit · 10 dakikada 5 istek.
+ * Per-IP rate limit · 10 dakikada 5 istek.
  *
- * Form gönderimi insan için seyrek bir işlem; 5/10dk cömert. Amaç tek kaynaktan
- * burst'ü (inbox flood / audience kirletme / Resend kota tüketimi) kesmek.
- *
- * Sınır: edge isolate-bazlı bellek · birden çok isolate/region'a yayılan
- * dağıtık saldırıyı yakalamaz ve isolate geri dönüşümünde sıfırlanır. Honeypot +
- * origin check + Cloudflare üstüne bir KATMAN. Kalıcı/garanti çözüm için Vercel
- * WAF rate-limit kuralı veya Upstash Ratelimit (kalıcı store) — bkz. docs.
+ * Production’da Upstash Redis REST pipeline kalıcı/dağıtık sayaç olarak kullanılır.
+ * Upstash env’leri yoksa yalnız local/preview geliştirmede process-memory fallback
+ * çalışır; Vercel production’da endpoint fail-closed davranır. Böylece dağıtık
+ * koruma yokken varmış gibi davranıp Resend/Audience çağrılarını açık bırakmayız.
+ * Honeypot + origin check + Cloudflare/WAF katmanları ayrıca korunur.
  */
-const RATE_WINDOW_MS = 10 * 60 * 1000;
-const RATE_MAX = 5;
-const rateHits = new Map(); // ip → number[] (istek timestamp'leri)
-
-function isRateLimited(ip, now) {
-  if (!ip) return false; // IP yoksa limitleyemeyiz · diğer katmanlara bırak
-  const cutoff = now - RATE_WINDOW_MS;
-  const hits = (rateHits.get(ip) || []).filter((t) => t > cutoff);
-  hits.push(now);
-  rateHits.set(ip, hits);
-  // Map'in sınırsız büyümesini engelle · pencere dışı IP'leri ara sıra temizle
-  if (rateHits.size > 5000) {
-    for (const [k, v] of rateHits) {
-      if (v.every((t) => t <= cutoff)) rateHits.delete(k);
-    }
-  }
-  return hits.length > RATE_MAX;
-}
+const rateLimiter = createRateLimiter();
 
 function clientIp(req) {
   const xff = req.headers.get('x-forwarded-for');
@@ -241,7 +226,11 @@ export default async function handler(req) {
 
   // Rate limit · pahalı Resend çağrılarından önce
   const ip = clientIp(req);
-  if (isRateLimited(ip, Date.now())) {
+  const rateLimit = await rateLimiter.check(ip);
+  if (rateLimit.unavailable) {
+    return errorResponse(M, 'baglanti', 503);
+  }
+  if (rateLimit.limited) {
     console.warn('Rate limited request');
     return errorResponse(M, 'limit', 429);
   }

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -8,7 +8,7 @@ Bu repo Vercel'a deploy edildiğinde gerekli olan environment değişkenleri.
 |---|---|---|
 | `RESEND_API_KEY` | ✅ | Resend API key · "Full access" veya minimum `audiences:write` + `emails:send` scope'lu |
 | `RESEND_AUDIENCE_ID` | ✅ | Resend Audience UUID · erken erişim e-postaları buraya kaydedilir |
-| `UPSTASH_REDIS_REST_URL` | ✅ production | Upstash Redis REST URL · dağıtık rate limit için |
+| `UPSTASH_REDIS_REST_URL` | ✅ production | Upstash Redis REST URL · atomik dağıtık rate limit transaction’ı için |
 | `UPSTASH_REDIS_REST_TOKEN` | ✅ production | Upstash Redis REST token · yalnız Vercel server env’de tutulur |
 
 ## Kurulum adımları
@@ -42,7 +42,7 @@ Bu repo Vercel'a deploy edildiğinde gerekli olan environment değişkenleri.
 1. https://console.upstash.com/redis → aynı bölgeye bir Redis database oluşturun.
 2. REST URL ve REST token değerlerini Vercel `trescout-landing` projesinin **Production** ve gerekiyorsa **Preview** environment’larına ekleyin.
 3. `UPSTASH_REDIS_REST_URL` ve `UPSTASH_REDIS_REST_TOKEN` frontend’e, HTML asset’lerine veya GitHub Actions loglarına yazılmamalıdır.
-4. Production’da bu iki değişken yoksa endpoint fail-closed davranır ve yeni kayıtları geçici olarak `503` ile durdurur; bu, dağıtık koruma varmış gibi davranıp rate limit’i sessizce atlatmaktan daha güvenlidir.
+4. Rate limit sayacı Upstash’ın atomik `/multi-exec` transaction endpoint’i üzerinden artırılır. Production’da bu iki değişken yoksa endpoint fail-closed davranır ve yeni kayıtları geçici olarak `503` ile durdurur; bu, dağıtık koruma varmış gibi davranıp rate limit’i sessizce atlatmaktan daha güvenlidir.
 
 5. Redeploy
 

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -8,6 +8,8 @@ Bu repo Vercel'a deploy edildiğinde gerekli olan environment değişkenleri.
 |---|---|---|
 | `RESEND_API_KEY` | ✅ | Resend API key · "Full access" veya minimum `audiences:write` + `emails:send` scope'lu |
 | `RESEND_AUDIENCE_ID` | ✅ | Resend Audience UUID · erken erişim e-postaları buraya kaydedilir |
+| `UPSTASH_REDIS_REST_URL` | ✅ production | Upstash Redis REST URL · dağıtık rate limit için |
+| `UPSTASH_REDIS_REST_TOKEN` | ✅ production | Upstash Redis REST token · yalnız Vercel server env’de tutulur |
 
 ## Kurulum adımları
 
@@ -35,7 +37,14 @@ Bu repo Vercel'a deploy edildiğinde gerekli olan environment değişkenleri.
 4. **Production** + **Preview** environment'larında etkin olduğundan emin ol
 5. Save
 
-### 4. Redeploy
+### 4. Upstash rate limit kurulumu
+
+1. https://console.upstash.com/redis → aynı bölgeye bir Redis database oluşturun.
+2. REST URL ve REST token değerlerini Vercel `trescout-landing` projesinin **Production** ve gerekiyorsa **Preview** environment’larına ekleyin.
+3. `UPSTASH_REDIS_REST_URL` ve `UPSTASH_REDIS_REST_TOKEN` frontend’e, HTML asset’lerine veya GitHub Actions loglarına yazılmamalıdır.
+4. Production’da bu iki değişken yoksa endpoint fail-closed davranır ve yeni kayıtları geçici olarak `503` ile durdurur; bu, dağıtık koruma varmış gibi davranıp rate limit’i sessizce atlatmaktan daha güvenlidir.
+
+5. Redeploy
 
 Env vars değiştiğinde Vercel otomatik redeploy etmez. Manuel tetikle:
 - Vercel Dashboard → Deployments → en son deploy → "Redeploy"
@@ -62,7 +71,8 @@ npx vercel dev    # local server (api/ route'ları dahil)
 
 ## Güvenlik notları
 
-- `RESEND_API_KEY` sadece sunucu tarafında kullanılır (Edge Function). Frontend'e sızmaz.
+- `RESEND_API_KEY`, `UPSTASH_REDIS_REST_URL` ve `UPSTASH_REDIS_REST_TOKEN` sadece sunucu tarafında kullanılır (Edge Function). Frontend'e sızmaz.
+- Production’da Upstash yoksa process-memory fallback kullanılmaz; endpoint kayıt kabul etmez.
 - Vercel env vars şifrelenmiş saklanır.
 - Key sızdığında: Resend Dashboard'dan **revoke** → yeni key oluştur → Vercel'da güncelle → redeploy.
 - API key rotation: 6 ayda bir.

--- a/scripts/subscribe-contract.test.mjs
+++ b/scripts/subscribe-contract.test.mjs
@@ -3,7 +3,10 @@ import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
 const source = await readFile(new URL('../api/subscribe.js', import.meta.url), 'utf8');
+const rateLimitSource = await readFile(new URL('../api/rate-limit.mjs', import.meta.url), 'utf8');
+const rateLimitUrl = `data:text/javascript;base64,${Buffer.from(rateLimitSource).toString('base64')}`;
 const moduleSource = source
+  .replace("import { createRateLimiter } from './rate-limit.mjs';", `const { createRateLimiter } = await import(${JSON.stringify(rateLimitUrl)});`)
   .replace('export const config =', 'const config =')
   .replace('export default async function handler', 'async function handler')
   + '\nexport { handler };';

--- a/tests/subscribe-rate-limit.test.mjs
+++ b/tests/subscribe-rate-limit.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createRateLimiter } from '../api/rate-limit.mjs';
+
+function makeClock() {
+  let current = 1_700_000_000_000;
+  return {
+    now: () => current,
+    advance(milliseconds) {
+      current += milliseconds;
+    },
+  };
+}
+
+test('uses isolate-local fallback only outside production', async () => {
+  const clock = makeClock();
+  const limiter = createRateLimiter({
+    env: { VERCEL_ENV: 'preview' },
+    now: clock.now,
+  });
+
+  const statuses = [];
+  for (let index = 0; index < 6; index += 1) {
+    statuses.push((await limiter.check('203.0.113.20')).limited);
+  }
+  assert.deepEqual(statuses, [false, false, false, false, false, true]);
+
+  clock.advance(10 * 60 * 1000 + 1);
+  assert.equal((await limiter.check('203.0.113.20')).limited, false);
+});
+
+test('fails closed in production when distributed protection is not configured', async () => {
+  const limiter = createRateLimiter({
+    env: { VERCEL_ENV: 'production' },
+  });
+
+  assert.deepEqual(await limiter.check('203.0.113.21'), {
+    limited: false,
+    unavailable: true,
+  });
+});
+
+test('uses Upstash pipeline and enforces the distributed count', async () => {
+  const calls = [];
+  const limiter = createRateLimiter({
+    env: {
+      VERCEL_ENV: 'production',
+      UPSTASH_REDIS_REST_URL: 'https://example.upstash.io/',
+      UPSTASH_REDIS_REST_TOKEN: 'test-token',
+    },
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(JSON.stringify([
+        { result: 'OK' },
+        { result: 6 },
+      ]), { status: 200 });
+    },
+  });
+
+  assert.deepEqual(await limiter.check('203.0.113.22'), {
+    limited: true,
+    unavailable: false,
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, 'https://example.upstash.io/pipeline');
+  assert.equal(calls[0].init.method, 'POST');
+  assert.equal(calls[0].init.headers.Authorization, 'Bearer test-token');
+  const pipeline = JSON.parse(calls[0].init.body);
+  assert.deepEqual(pipeline[0].slice(0, 5), [
+    'SET',
+    'trescout:subscribe:rate:203.0.113.22',
+    '0',
+    'EX',
+    '600',
+  ]);
+  assert.deepEqual(pipeline[1], [
+    'INCR',
+    'trescout:subscribe:rate:203.0.113.22',
+  ]);
+});
+
+test('fails closed when Upstash returns an error', async () => {
+  const limiter = createRateLimiter({
+    env: {
+      VERCEL_ENV: 'production',
+      UPSTASH_REDIS_REST_URL: 'https://example.upstash.io',
+      UPSTASH_REDIS_REST_TOKEN: 'test-token',
+    },
+    fetchImpl: async () => new Response('', { status: 503 }),
+  });
+
+  assert.deepEqual(await limiter.check('203.0.113.23'), {
+    limited: false,
+    unavailable: true,
+  });
+});

--- a/tests/subscribe-rate-limit.test.mjs
+++ b/tests/subscribe-rate-limit.test.mjs
@@ -40,7 +40,7 @@ test('fails closed in production when distributed protection is not configured',
   });
 });
 
-test('uses Upstash pipeline and enforces the distributed count', async () => {
+test('uses an atomic Upstash transaction and enforces the distributed count', async () => {
   const calls = [];
   const limiter = createRateLimiter({
     env: {
@@ -62,18 +62,18 @@ test('uses Upstash pipeline and enforces the distributed count', async () => {
     unavailable: false,
   });
   assert.equal(calls.length, 1);
-  assert.equal(calls[0].url, 'https://example.upstash.io/pipeline');
+  assert.equal(calls[0].url, 'https://example.upstash.io/multi-exec');
   assert.equal(calls[0].init.method, 'POST');
   assert.equal(calls[0].init.headers.Authorization, 'Bearer test-token');
-  const pipeline = JSON.parse(calls[0].init.body);
-  assert.deepEqual(pipeline[0].slice(0, 5), [
+  const transaction = JSON.parse(calls[0].init.body);
+  assert.deepEqual(transaction[0].slice(0, 5), [
     'SET',
     'trescout:subscribe:rate:203.0.113.22',
     '0',
     'EX',
     '600',
   ]);
-  assert.deepEqual(pipeline[1], [
+  assert.deepEqual(transaction[1], [
     'INCR',
     'trescout:subscribe:rate:203.0.113.22',
   ]);


### PR DESCRIPTION
## Summary
- Add a distributed Upstash-backed signup rate limiter to the public landing endpoint.
- Preserve fail-closed behavior when the distributed limiter is unavailable.

## Validation
- Rate-limit tests passed (4/4).

## Review notes
Production deployment must provide the provider configuration. This PR does not change repository visibility or publish secrets.
