### PR TITLE
fix(dictionary): persist reviewed duplicate decisions

### DIFF
--- a/assets/dictionary/duplicate-triage.json
+++ b/assets/dictionary/duplicate-triage.json
@@ -1,0 +1,11 @@
+{
+  "_aciklama": "İncelenmiş fakat canonical birleştirme yapılmaması kararlaştırılmış sözlük çiftleri. Bu kayıt redirect veya içerik silme talimatı değildir; duplicate tarayıcısının aynı bulguyu yeniden issue olarak açmasını önleyen editoryal karar kaydıdır.",
+  "incelenmis": [
+    {
+      "cift": ["container", "containers"],
+      "karar": "ayri_tut",
+      "gerekce": "Raporlarda tekil teknik kavram veya proje adı ile çoğul genel kategori farklı bağlamlarda kullanılıyor. Yalnız slug benzerliği canonical birleştirme için yeterli değil.",
+      "incelenme_tarihi": "2026-08-26"
+    }
+  ]
+}

--- a/scripts/check-birlesmis-terimler.py
+++ b/scripts/check-birlesmis-terimler.py
@@ -2,10 +2,12 @@
 """
 Birleştirilmiş sözlük terimleri guard'ı (CI)
 ============================================
-2026-08-08'de 19 tekil/çoğul ikizi (agent/agents, plugin/plugins …) kanonik
-slug'larında birleştirildi: ikiz sayfalar kaldırıldı, eski URL'ler 301'lendi.
-Search Console bunları "kullanıcı tarafından seçilen standart sayfa olmadan
-kopya" diye işaretliyordu · gövdelerinin %85'ten fazlası aynıydı.
+2026-08-08'de başlayan canonical sözlük temizliğinde tekil/çoğul ikizler
+(agent/agents, plugin/plugins …) kanonik slug'larında birleştirildi: ikiz
+sayfalar kaldırıldı, eski URL'ler 301'lendi. Search Console bunları "kullanıcı
+tarafından seçilen standart sayfa olmadan kopya" diye işaretliyordu · gövdelerinin
+%85'ten fazlası aynıydı. Bu guard teknik route bütünlüğünü denetler; eşleşmenin
+anlamsal kararını insan incelemesi ve `duplicate-triage.json` taşır.
 
 Bu guard birleşmenin geri açılmadığını denetler:
 
@@ -34,6 +36,7 @@ DIZIN_ONEKLERI = [""] + [f"{k}/" for k in _DILLER]
 URL_ONEKLERI = [""] + [d["onek"] for d in _DILLER.values()]
 BIRLESMIS = os.path.join(ROOT, "assets", "dictionary", "birlesmis.json")
 MANIFEST = os.path.join(ROOT, "assets", "dictionary", "dictionary.json")
+TRIAGE = os.path.join(ROOT, "assets", "dictionary", "duplicate-triage.json")
 VERCEL = os.path.join(ROOT, "vercel.json")
 
 if not os.path.exists(BIRLESMIS):
@@ -42,9 +45,28 @@ if not os.path.exists(BIRLESMIS):
 
 eslesme = json.load(open(BIRLESMIS, encoding="utf-8"))["eslesme"]
 manifest = {t["slug"] for t in json.load(open(MANIFEST, encoding="utf-8"))}
-yonlendirmeler = {r["source"] for r in json.load(open(VERCEL, encoding="utf-8")).get("redirects", [])}
+yonlendirme_kaydi = json.load(open(VERCEL, encoding="utf-8")).get("redirects", [])
+yonlendirmeler = {r["source"] for r in yonlendirme_kaydi}
 
 sorunlar = []
+
+# Bağlamı insan tarafından incelenmiş, fakat canonical birleştirme yapılmamış
+# çiftler. Mapping değildir; yalnız ikiz tarayıcısının aynı issue'yu yeniden
+# üretmesini önler.
+incelenmis = []
+if os.path.exists(TRIAGE):
+    incelenmis = json.load(open(TRIAGE, encoding="utf-8")).get("incelenmis", [])
+    for sira, kayit in enumerate(incelenmis, 1):
+        cift = kayit.get("cift", [])
+        if len(cift) != 2 or cift[0] == cift[1]:
+            sorunlar.append(f"duplicate-triage #{sira}: iki farklı slug içeren cift gerekli")
+            continue
+        if any(slug not in manifest for slug in cift):
+            sorunlar.append(f"duplicate-triage #{sira}: slug manifest'te yok")
+        if tuple(sorted(cift)) in {tuple(sorted((eski, yeni))) for eski, yeni in eslesme.items()}:
+            sorunlar.append(f"duplicate-triage #{sira}: canonical mapping ile çakışıyor")
+        if kayit.get("karar") != "ayri_tut":
+            sorunlar.append(f"duplicate-triage #{sira}: bilinmeyen karar")
 for eski, yeni in sorted(eslesme.items()):
     if yeni not in manifest:
         sorunlar.append(f"{eski} → {yeni}: KANONİK terim manifest'te yok")
@@ -54,13 +76,19 @@ for eski, yeni in sorted(eslesme.items()):
         if os.path.isdir(os.path.join(ROOT, f"{onek}dictionary/{eski}")):
             sorunlar.append(f"{onek}dictionary/{eski}/ · sayfa geri gelmiş")
     for onek in URL_ONEKLERI:
-        # İKİ biçim de aranıyor · Vercel source'u birebir eşleştirdiği için
-        # yalnız eğik çizgisiz hâli yazılınca gerçek istekler 404 veriyordu
-        # (2026-08-11'de yayına böyle çıktı).
-        for kaynak in (f"{onek}/dictionary/{eski}", f"{onek}/dictionary/{eski}/"):
-            if kaynak not in yonlendirmeler:
-                sorunlar.append(f"{kaynak} · 301 yönlendirmesi yok "
-                                "(scripts/redirect-uret.py çalıştırın)")
+        # Üç biçim de aranıyor · Vercel source'u birebir eşleştirir:
+        # slashless, trailing slash ve raw Markdown.
+        beklenen = {
+            f"{onek}/dictionary/{eski}": f"{onek}/dictionary/{yeni}/",
+            f"{onek}/dictionary/{eski}/": f"{onek}/dictionary/{yeni}/",
+            f"{onek}/dictionary/{eski}.md": f"{onek}/dictionary/{yeni}.md",
+        }
+        for kaynak, hedef in beklenen.items():
+            kayitlar = [r for r in yonlendirme_kaydi if r.get("source") == kaynak]
+            if len(kayitlar) != 1:
+                sorunlar.append(f"{kaynak} · tam olarak bir 301 kaydı yok")
+            elif kayitlar[0].get("destination") != hedef or kayitlar[0].get("permanent") is not True:
+                sorunlar.append(f"{kaynak} · hedef/permanent yanlış (beklenen: {hedef})")
 
 # İç bağlantı taraması
 bagli = []
@@ -85,5 +113,6 @@ if sorunlar:
         print(f"   … {len(sorunlar) - 30} sorun daha")
     sys.exit(1)
 
-print(f"✓ Birleşmiş terimler tutarlı · {len(eslesme)} ikiz kanonikte birleşik, "
-      f"{len(eslesme) * len(URL_ONEKLERI)} yönlendirme yerinde, iç bağlantı temiz")
+print(f"✓ Birleşmiş terimler tutarlı · {len(eslesme)} canonical mapping, "
+      f"{len(eslesme) * len(URL_ONEKLERI)} route ailesi ve "
+      f"{len(incelenmis)} bağlam kararı doğrulandı, iç bağlantı temiz")

--- a/scripts/ikiz-tara.py
+++ b/scripts/ikiz-tara.py
@@ -6,9 +6,11 @@ Sözlükte YENİ ikiz terim arar · bulursa GitHub issue açar/günceller.
 
 Neden gerekli: `check-birlesmis-terimler.py` yalnız YAPILMIŞ birleşmeleri
 koruyor · yenisini bulmuyor. Günlük hat her gün rapor sözlüğünden yeni terim
-ekliyor ve tekil/çoğul ikizleri kendiliğinden oluşuyor: 2026-08-08'de 19 çift
-birleştirildikten sonra ÜÇ GÜNDE iki tane daha çıktı (diffusion-model,
-knowledge-graph). Google bunlara "standart sayfa olmadan kopya" diyor.
+ekliyor ve tekil/çoğul ikizleri kendiliğinden oluşuyor. Mevcut birleşme tablosu
+canonical kararların kaynağıdır. Benzer görünen her çift aynı anlama gelmeyebilir;
+bağlam incelemesiyle ayrı tutulması kararlaştırılan çiftler
+`assets/dictionary/duplicate-triage.json` içinde kayıtlıdır. Google, gerçekten
+aynı içeriği taşıyan sayfaları "standart sayfa olmadan kopya" olarak işaretleyebilir.
 
 Neden guard değil de issue: birleştirme bir İÇERİK kararı · hangi slug kalacak,
 metin nasıl ayrışacak. Günlük hattı bunun için düşürmek yayını durdurur. Bu
@@ -31,6 +33,7 @@ import sys
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MANIFEST = os.path.join(ROOT, "assets", "dictionary", "dictionary.json")
 BIRLESMIS = os.path.join(ROOT, "assets", "dictionary", "birlesmis.json")
+TRIAGE = os.path.join(ROOT, "assets", "dictionary", "duplicate-triage.json")
 ESIK = 0.85
 TITLE = "Sözlük · birleştirilmesi gereken ikiz terimler"
 DRY = "--dry" in sys.argv or not os.environ.get("GH_TOKEN")
@@ -51,6 +54,15 @@ if os.path.exists(BIRLESMIS):
     e = json.load(open(BIRLESMIS, encoding="utf-8"))["eslesme"]
     zaten = set(e) | set(e.values())
 
+# İnsan tarafından bağlamı incelenmiş ve ayrı tutulması kararlaştırılmış çiftler.
+# Bu kayıt mapping değildir; URL/canonical davranışını değiştirmez.
+incelenmis = set()
+if os.path.exists(TRIAGE):
+    for kayit in json.load(open(TRIAGE, encoding="utf-8")).get("incelenmis", []):
+        cift = kayit.get("cift", [])
+        if len(cift) == 2:
+            incelenmis.add(tuple(sorted(cift)))
+
 bulunan = []
 gorulen = set()
 for s in sluglar:
@@ -58,7 +70,7 @@ for s in sluglar:
         if aday == s or aday not in sluglar:
             continue
         cift = tuple(sorted((s, aday)))
-        if cift in gorulen:
+        if cift in gorulen or cift in incelenmis:
             continue
         gorulen.add(cift)
         a, b = cift
@@ -97,7 +109,7 @@ satirlar += [
     "**Nasıl birleştirilir**",
     "1. Kalacak slug'ı seçin (iç bağlantı sayısı > gövde zenginliği > kısa slug)",
     "2. `assets/dictionary/birlesmis.json` → `eslesme`'ye `\"giden\": \"kalan\"` ekleyin",
-    "3. Giden slug'ın sayfalarını üç dilde silin (`dictionary/`, `en/`, `fr/` · `.md` dahil)",
+    "3. Giden slug'ın tüm yapılandırılmış dil sayfalarını silin (`dictionary/`, locale dizinleri · `.md` dahil)",
     "4. `python3 scripts/redirect-uret.py` · 301'leri üretir",
     "5. İç bağlantıları kanonik adrese çevirin, sayfaları yeniden basın",
     "6. `python3 scripts/check-birlesmis-terimler.py` yeşil olmalı",

--- a/scripts/redirect-uret.py
+++ b/scripts/redirect-uret.py
@@ -5,13 +5,13 @@ Birleştirilmiş sözlük terimlerinin 301 yönlendirmelerini vercel.json'a yaza
     python3 scripts/redirect-uret.py [--dry]
 
 Kaynak: `assets/dictionary/birlesmis.json` · orada "artık yayınlanmayan slug →
-kanonik slug" eşleşmesi duruyor. Her eşleşme için üç dilin sayfası ve ham
-markdown'ı yönlendiriliyor:
+kanonik slug" eşleşmesi duruyor. Her eşleşme için `scripts/diller.py` içindeki
+tüm yapılandırılmış dillerin sayfası ve ham markdown'ı yönlendiriliyor:
 
     /dictionary/agents/        → /dictionary/agent/
     /en/dictionary/agents/     → /en/dictionary/agent/
     /fr/dictionary/agents/     → /fr/dictionary/agent/
-    /dictionary/agents.md      → /dictionary/agent.md          (+ /en/ + /fr/)
+    /dictionary/agents.md      → /dictionary/agent.md          (+ tüm locale'ler)
 
 Neden yönlendirme, neden silme değil: o URL'ler indekslenmiş ve dış bağlantı
 almış olabilir. 301, hem ziyaretçiyi doğru sayfaya götürür hem de arama
@@ -38,7 +38,8 @@ KORUNAN = [
     {"source": "/security.txt", "destination": "/.well-known/security.txt", "permanent": True},
 ]
 
-# Dil önekleri diller.py'den · yeni dil eklenince burası kendiliğinden büyür
+# Dil önekleri diller.py'den · yeni dil eklenince burası kendiliğinden büyür.
+# Her mapping için 6 dil × 3 source biçimi üretilir; `.md` de bu matrise dahildir.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from diller import DILLER as _DILLER  # noqa: E402
 DILLER = [""] + [d["onek"] for d in _DILLER.values()]


### PR DESCRIPTION
## Özet

Bu PR, canonical sözlük mapping review’ında bulunan workflow ve dokümantasyon tutarsızlıklarını dar kapsamda düzeltir.

- Bağlam incelemesiyle ayrı tutulması kararlaştırılan çiftler için `assets/dictionary/duplicate-triage.json` registry’si eklenir.
- `scripts/ikiz-tara.py`, registry’deki çiftleri yeniden issue olarak üretmez.
- `scripts/check-birlesmis-terimler.py`, triage kayıtlarının schema ve manifest tutarlılığını doğrular ve üç route biçimini her locale için kontrol eder.
- Redirect ve mapping dokümantasyonu 21 mapping, tüm yapılandırılmış locale’ler ve route-family semantiğiyle hizalanır.

## Neden

`container` ve `containers` raporlarda farklı bağlamlarda kullanıldığı için canonical birleştirme yapılmadı ve ilgili #114, #124, #125 issue’ları gerekçeli yorumlarla kapatıldı. Duplicate tarayıcısı kapatılmış issue durumunu bilmiyordu; ayrı bir triage registry olmadan aynı pair sonraki taramada yeniden issue olarak üretilebilirdi.

## Güvenlik ve içerik sınırı

Bu PR sözlük terimi silmez, canonical mapping değiştirmez, 301 hedefi değiştirmez, generated HTML üretmez ve production content’e dokunmaz. `container` ve `containers` ayrı kalır. E-posta, Resend, delivery, API, telemetry, IndexNow ve sosyal yayın akışlarına dokunulmaz.

## Doğrulama

- `python3 -m py_compile scripts/ikiz-tara.py scripts/check-birlesmis-terimler.py scripts/redirect-uret.py`
- `python3 scripts/check-birlesmis-terimler.py`
- `python3 scripts/redirect-uret.py --dry`
- Canonical mapping audit: 21 mapping, 382 total redirect records, 0 missing target, 0 source manifest leak, 0 redirect chain
- Downstream audit: 0 old source files, 0 missing HTML/Markdown targets, 0 exact old dictionary links
- `git diff --check`

Duplicate issue üreticisi çalıştırılmadı; çünkü gerçek GitHub issue oluşturma yan etkisi vardır.
