### PR TITLE
fix(dictionary): use Turkish reports for enrichment

### DIFF
--- a/.github/workflows/dict-sync.yml
+++ b/.github/workflows/dict-sync.yml
@@ -64,6 +64,9 @@ jobs:
           sudo apt-get update && sudo apt-get install -y poppler-utils fonts-dejavu-core
           pip install Pillow
 
+      - name: Sözlük kaynak filtresi kontratı
+        run: python3 scripts/check-dict-sync-source-filter.py
+
       - name: Sözlüğü büyüt (yeni rapor terimleri)
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/scripts/check-dict-sync-source-filter.py
+++ b/scripts/check-dict-sync-source-filter.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Contract test for dict-sync glossary source selection.
+
+This test is local-only: it imports definitions, creates temporary JSON fixtures,
+and never calls Gemini, GitHub, Resend, or any endpoint.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location('dict_sync', root / 'scripts' / 'dict-sync.py')
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+assert module.is_turkish_report_json('/tmp/trescout-rapor-2026-08-25.json')
+assert module.is_turkish_report_json('/tmp/trescout-rapor-tekrarsiz-2026-08-25.json')
+assert not module.is_turkish_report_json('/tmp/trescout-report-2026-08-25-en.json')
+assert not module.is_turkish_report_json('/tmp/trescout-report-fresh-2026-08-25-fr.json')
+assert module.is_turkish_report_pdf('/tmp/trescout-rapor-2026-08-25.pdf')
+assert not module.is_turkish_report_pdf('/tmp/trescout-report-2026-08-25-de.pdf')
+
+with tempfile.TemporaryDirectory() as directory:
+    reports = Path(directory)
+    (reports / 'trescout-rapor-2026-08-25.json').write_text(json.dumps({
+        'glossary': [{'term': 'same term', 'explanation': 'Türkçe kaynak açıklaması.'}],
+    }, ensure_ascii=False), encoding='utf-8')
+    (reports / 'trescout-report-2026-08-25-en.json').write_text(json.dumps({
+        'glossary': [{'term': 'same term', 'explanation': 'A much longer English explanation that must not be selected by the Turkish dictionary enrichment source.'}],
+    }), encoding='utf-8')
+    (reports / 'trescout-report-2026-08-25-fr.json').write_text(json.dumps({
+        'glossary': [{'term': 'French-only term', 'explanation': 'Une explication qui ne doit pas entrer dans la source turque.'}],
+    }), encoding='utf-8')
+    original_reports = module.REPORTS
+    module.REPORTS = str(reports)
+    try:
+        selected = module.collect_glossary()
+    finally:
+        module.REPORTS = original_reports
+    assert selected == [{'term': 'same term', 'explanation': 'Türkçe kaynak açıklaması.'}], selected
+
+print('✓ dict-sync glossary source filter contract passed')

--- a/scripts/dict-sync.py
+++ b/scripts/dict-sync.py
@@ -51,6 +51,22 @@ def slugify(t):
 
 # ---------- 1) glossary toplama ----------
 TR = re.compile(r"[çğışöüâÇĞİŞÖÜ]")
+# Enrichment kaynağı yalnız Türkçe canonical rapor JSON/PDF'leridir.
+# Locale raporları aynı glossary'yi farklı dillerde tekrarlar; bunları seçmek
+# Türkçe sayfaya yabancı dil açıklaması taşıyabilir. İsim kalıbı kasıtlı olarak
+# strict tutulur: trescout-report-*-XX dosyaları bu akışa giremez.
+TR_REPORT_JSON = re.compile(r"^trescout-rapor-(?:tekrarsiz-)?\d{4}-\d{2}-\d{2}\.json$")
+TR_REPORT_PDF = re.compile(r"^trescout-rapor-(?:tekrarsiz-)?\d{4}-\d{2}-\d{2}\.pdf$")
+
+def is_turkish_report_file(path, pattern):
+    return bool(pattern.fullmatch(os.path.basename(path)))
+
+def is_turkish_report_json(path):
+    return is_turkish_report_file(path, TR_REPORT_JSON)
+
+def is_turkish_report_pdf(path):
+    return is_turkish_report_file(path, TR_REPORT_PDF)
+
 def parse_pdf_glossary(pdf):
     try:
         txt = subprocess.run(["pdftotext","-layout",pdf,"-"],capture_output=True,text=True).stdout
@@ -83,7 +99,8 @@ def parse_pdf_glossary(pdf):
 
 def collect_glossary():
     seen={}
-    for jp in sorted(glob.glob(os.path.join(REPORTS,"*.json"))):
+    source_jsons = [jp for jp in glob.glob(os.path.join(REPORTS,"*.json")) if is_turkish_report_json(jp)]
+    for jp in sorted(source_jsons):
         try: d=json.load(open(jp,encoding="utf-8"))
         except Exception: continue
         g=d.get("glossary") or []
@@ -94,7 +111,8 @@ def collect_glossary():
                 if k not in seen or len(ex)>len(seen[k][1]): seen[k]=(t,ex)
     # JSON'da yoksa PDF yedeği
     if not seen:
-        for pp in sorted(glob.glob(os.path.join(REPORTS,"*.pdf"))):
+        source_pdfs = [pp for pp in glob.glob(os.path.join(REPORTS,"*.pdf")) if is_turkish_report_pdf(pp)]
+        for pp in sorted(source_pdfs):
             for e in parse_pdf_glossary(pp):
                 k=e["term"].lower()
                 if k not in seen or len(e["explanation"])>len(seen[k][1]): seen[k]=(e["term"],e["explanation"])
@@ -352,8 +370,8 @@ def main():
         render_index(manifest)
         print("✅ eski sözlük kayıtlarının tarih alanı backfill edildi")
     existing_slugs={m["slug"] for m in manifest}
-    # BİRLEŞTİRİLMİŞ terimler · 2026-08-08'de 19 tekil/çoğul ikizi kanonik
-    # sluglarında birleştirildi ve eski URL'ler 301'lendi. O sluglar burada
+    # BİRLEŞTİRİLMİŞ terimler · mapping registry'deki eski slug'lar kanonik
+    # slug'larda birleştirildi ve eski URL'ler 301'lendi. O sluglar burada
     # "zaten var" sayılmazsa hat onları ertesi gün yeniden yaratır ve
     # yönlendirme kırılır. Bkz. assets/dictionary/birlesmis.json
     _birlesmis=os.path.join(os.path.dirname(MANIFEST),"birlesmis.json")


### PR DESCRIPTION
## Özet

Bu PR, sözlük enrichment adaylarının yalnız Türkçe canonical raporlardan toplanmasını sağlar ve locale raporlarının Türkçe enrichment akışına karışmasını engeller.

## Bulgu

`reports/` altında 984 JSON raporu bulunuyor: Türkçe canonical raporların yanı sıra EN, FR, PT, ES ve DE kopyaları. Önceki `dict-sync.py` tüm `reports/*.json` dosyalarını aynı glossary havuzuna alıyor ve aynı terimde en uzun açıklamayı seçiyordu. Salt-okunur emülasyonda 490 unique adayın yalnız 14’ü Türkçe dosyadan, 476’sı ise locale dosyalarından seçildi. Örneklerde Fransızca ve Almanca açıklamalar Türkçe sözlük enrichment girdisi olarak seçilebiliyordu.

## Düzeltme

- `dict-sync.py`, yalnız `trescout-rapor-YYYY-MM-DD.json` ve `trescout-rapor-tekrarsiz-YYYY-MM-DD.json` dosyalarını canonical JSON kaynağı kabul eder.
- PDF fallback de aynı Türkçe filename filtresini kullanır.
- Locale dosyaları (`trescout-report-...-en/fr/pt/es/de.json`) aday havuzuna girmez.
- Yeni ağsız kontrat testi gerçek filename örnekleriyle filtreyi ve seçim davranışını doğrular.
- Workflow, Gemini çağrısından önce bu kontrat testini çalıştırır.

## Sınırlar

Bu PR mevcut 537 sözlük terimini yeniden üretmez, mevcut çevirileri değiştirmez, canonical mapping veya redirect’lere dokunmaz. E-posta, Resend, delivery, telemetry, IndexNow ve sosyal yayın akışlarına dokunulmaz.

## Doğrulama

- `python3 -m py_compile scripts/dict-sync.py scripts/check-dict-sync-source-filter.py`
- `python3 scripts/check-dict-sync-source-filter.py`
- `python3 scripts/check-birlesmis-terimler.py`
- `git diff --check`
- Mevcut repo glossary seçim emülasyonu: önceki davranışta 476/490 seçimin locale kaynaklı olduğu doğrulandı.

Bu PR, enrichment üretiminde kaynak dil doğruluğu için açılmıştır. Gemini veya herhangi bir dış endpoint local doğrulama sırasında çağrılmamıştır.
