### PR TITLE
fix(claude-code): çeviri yedeği kaynak metni göndermiyordu + kota duvarında duraklatma

### DIFF
--- a/.github/workflows/csp-inline-guard.yml
+++ b/.github/workflows/csp-inline-guard.yml
@@ -25,6 +25,8 @@ permissions:
 jobs:
   guard:
     runs-on: ubuntu-latest
+    # Askıda kalan iş 6 saatlik varsayılan sınıra kadar koşmasın · sağlıklı koşu ~1 dk.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Rapor snapshot helper testi

--- a/.github/workflows/deploy-health.yml
+++ b/.github/workflows/deploy-health.yml
@@ -22,6 +22,8 @@ permissions:
 jobs:
   health:
     runs-on: ubuntu-latest
+    # Askıda kalan iş 6 saatlik varsayılan sınıra kadar koşmasın · sağlıklı koşu ~2 dk.
+    timeout-minutes: 15
     steps:
       - name: Vercel production deploy durumu (son main commit)
         env:

--- a/.github/workflows/dict-sync.yml
+++ b/.github/workflows/dict-sync.yml
@@ -51,6 +51,8 @@ concurrency:
 jobs:
   grow:
     runs-on: ubuntu-latest
+    # Askıda kalan iş 6 saatlik varsayılan sınıra kadar koşmasın · en uzun sağlıklı koşu 100 dk (2026-08-24) · iki katı pay.
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/enrichment-digest.yml
+++ b/.github/workflows/enrichment-digest.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   digest:
     runs-on: ubuntu-latest
+    # Askıda kalan iş 6 saatlik varsayılan sınıra kadar koşmasın · sağlıklı koşu ~1 dk.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/scripts/translation_service.py
+++ b/scripts/translation_service.py
@@ -14,7 +14,19 @@ import urllib.request
 import re
 
 GEMINI_MODEL = os.environ.get("GEMINI_MODEL") or os.environ.get("TREESCOUT_TRANSLATION_MODEL") or "gemini-3.1-flash-lite"
+
+# Rate-limit pause state. A quota wall is a property of the whole process, not
+# of one passage: once the provider has refused every retry of a call, later
+# calls in the same run will be refused too. Without this, each of thousands of
+# passages paid the full retry ladder on its own (2026-08-26: a run sat in the
+# page-generation step for five hours before it was cancelled). The pause window
+# doubles on each consecutive exhaustion so a run that has truly hit the daily
+# quota parks itself instead of probing every ninety seconds.
+_PAUSE_CAP = 600.0
 _GEMINI_PAUSED_UNTIL = 0.0
+_GEMINI_PAUSE_STREAK = 0
+_GTX_PAUSED_UNTIL = 0.0
+_GTX_PAUSE_STREAK = 0
 
 
 def _retry_delay(attempt: int) -> float:
@@ -39,13 +51,30 @@ def _http_retry_delay(error: urllib.error.HTTPError, attempt: int) -> float:
     return _retry_delay(attempt)
 
 
+def _pause_span(delay: float, streak: int) -> float:
+    return min(max(delay, 30.0) * (2 ** max(streak - 1, 0)), _PAUSE_CAP)
+
+
 def _pause_gemini(delay: float) -> None:
-    global _GEMINI_PAUSED_UNTIL
-    _GEMINI_PAUSED_UNTIL = max(_GEMINI_PAUSED_UNTIL, time.time() + delay)
+    global _GEMINI_PAUSED_UNTIL, _GEMINI_PAUSE_STREAK
+    _GEMINI_PAUSE_STREAK += 1
+    span = _pause_span(delay, _GEMINI_PAUSE_STREAK)
+    _GEMINI_PAUSED_UNTIL = max(_GEMINI_PAUSED_UNTIL, time.time() + span)
 
 
 def _gemini_is_paused() -> bool:
     return time.time() < _GEMINI_PAUSED_UNTIL
+
+
+def _pause_gtx(delay: float) -> None:
+    global _GTX_PAUSED_UNTIL, _GTX_PAUSE_STREAK
+    _GTX_PAUSE_STREAK += 1
+    span = _pause_span(delay, _GTX_PAUSE_STREAK)
+    _GTX_PAUSED_UNTIL = max(_GTX_PAUSED_UNTIL, time.time() + span)
+
+
+def _gtx_is_paused() -> bool:
+    return time.time() < _GTX_PAUSED_UNTIL
 
 
 def _gemini(text: str, lang: str, key: str) -> str | None:
@@ -63,7 +92,7 @@ def _gemini(text: str, lang: str, key: str) -> str | None:
             "parts": [{
                 "text": (
                     f"Translate this Turkish technology-site text into {lang}. "
-                    "Keep the meaning and register natural for the target locale.\n\n{text}"
+                    f"Keep the meaning and register natural for the target locale.\n\n{text}"
                 )
             }]
         }],
@@ -74,6 +103,8 @@ def _gemini(text: str, lang: str, key: str) -> str | None:
     }
     url = f"https://generativelanguage.googleapis.com/v1beta/models/{GEMINI_MODEL}:generateContent"
     encoded_body = json.dumps(body).encode("utf-8")
+    if _gemini_is_paused():
+        return None
     for attempt in range(4):
         try:
             request = urllib.request.Request(
@@ -95,6 +126,9 @@ def _gemini(text: str, lang: str, key: str) -> str | None:
         except urllib.error.HTTPError as error:
             if error.code == 429:
                 delay = max(_http_retry_delay(error, attempt), (attempt + 1) * 3.0)
+                if attempt == 3:
+                    _pause_gemini(delay)
+                    return None
                 time.sleep(delay)
                 continue
             if error.code not in (500, 502, 503) or attempt == 3:
@@ -113,6 +147,8 @@ def _gtx(text: str, lang: str) -> str | None:
         "https://translate.googleapis.com/translate_a/single?client=gtx&sl=tr&"
         f"tl={urllib.parse.quote(lang)}&dt=t&q={urllib.parse.quote(text)}"
     )
+    if _gtx_is_paused():
+        return None
     for attempt in range(3):
         try:
             request = urllib.request.Request(url, headers={"Accept": "application/json", "User-Agent": "TreScout/1.0"})
@@ -125,6 +161,9 @@ def _gtx(text: str, lang: str) -> str | None:
         except urllib.error.HTTPError as error:
             if error.code == 429:
                 delay = max(_http_retry_delay(error, attempt), (attempt + 1) * 2.0)
+                if attempt == 2:
+                    _pause_gtx(delay)
+                    return None
                 time.sleep(delay)
                 continue
             if error.code not in (500, 502, 503) or attempt == 2:
@@ -178,6 +217,8 @@ def _gemini_batch(texts: list[str], lang: str, key: str) -> dict[str, str] | Non
     }
     url = f"https://generativelanguage.googleapis.com/v1beta/models/{GEMINI_MODEL}:generateContent"
     encoded_body = json.dumps(body, ensure_ascii=False).encode("utf-8")
+    if _gemini_is_paused():
+        return None
     for attempt in range(3):
         try:
             request = urllib.request.Request(
@@ -223,6 +264,9 @@ def _gemini_batch(texts: list[str], lang: str, key: str) -> dict[str, str] | Non
         except urllib.error.HTTPError as error:
             if error.code == 429:
                 delay = max(_http_retry_delay(error, attempt), (attempt + 1) * 5.0)
+                if attempt == 2:
+                    _pause_gemini(delay)
+                    return None
                 time.sleep(delay)
                 continue
             if error.code not in (500, 502, 503) or attempt == 2:


### PR DESCRIPTION
## Özet

Günlük içerik hattı (`İçerik oto-büyüme`) **24 Ağustos 11:05'ten beri hiç başarılı olmadı**, art arda dokuz koşu düştü. 26 Ağustos 22:13'te elle başlatılan koşu ise beş saat boyunca `Sayfaları üret` adımında asılı kaldı ve elle iptal edildi. Üç kusur üst üste biniyor.

### 1. Tek kayıt çevirisinde kaynak metin isteğe hiç girmiyordu

`scripts/translation_service.py` içindeki `_gemini()` istemi iki parçalı bir dize ve **ikinci parçada `f` öneki yoktu**:

```python
f"Translate this Turkish technology-site text into {lang}. "
"Keep the meaning and register natural for the target locale.\n\n{text}"   # ← düz metin
```

Sağlayıcıya çevrilecek metin yerine düz `{text}` yer tutucusu gidiyordu. Bu yol, toplu isteğin kaçırdığı her metnin **tek yedeği**: yedek hiçbir zaman işe yaramıyor, üstelik her denemede boşuna kota harcıyordu.

JavaScript ikizi `scripts/translation-service.js` aynı istemi doğru kuruyor (`${text}`). Sapma yalnız Python tarafında, bu yüzden aynı koşuda `translate-i18n.js` adımları geçerken `dictionary-en.py` düşüyordu.

### 2. Kota duvarında duraklatma kodu yazılmış ama hiç bağlanmamıştı

`_pause_gemini` ve `_gemini_is_paused` tanımlıydı, **hiçbir yerden çağrılmıyordu**. Sağlayıcı 429 döndürmeye başladığında her metin yeniden deneme merdivenini baştan ödüyordu.

Ölçüm (aynı senaryo: 97 başarısız metin, sağlayıcı sürekli 429 · `retryDelay: 38s`):

| | HTTP isteği | toplam uyku |
|---|---|---|
| önce | 706 | 447 dk |
| sonra | 6 | 3 dk |

447 dakika, gözlenen beş saatlik asılmayı tek dilde tek başına açıklıyor. Duraklatma artık bağlı ve ardışık tükenmede pencere ikiye katlanıyor (tavan 10 dk), böylece kotası gerçekten bitmiş bir koşu her doksan saniyede yeniden yoklamak yerine park ediyor. Aynı sınıftaki GTX yedeği de aynı korumayı aldı (anonim GTX uç noktası şu an konut IP'sinden bile 429 dönüyor, yani pratikte ölü bir yedek).

### 3. Hiçbir iş akışında `timeout-minutes` yoktu

Dördü de GitHub'ın altı saatlik varsayılanına kadar koşabiliyordu. `dict-sync` bir de `concurrency: dict-sync` grubunu tutuyor, yani asılan tek koşu tüm içerik yayınını kilitliyor.

| workflow | sağlıklı koşu | konan sınır |
|---|---|---|
| dict-sync | 2 dk – 100 dk | 180 |
| deploy-health | ~2 dk | 15 |
| csp-inline-guard | ~1 dk | 15 |
| enrichment-digest | ~1 dk | 15 |

## Doğrulama

Sağlayıcı taklit edilerek (`urlopen` yerine sahte yanıt) dört senaryo koşuldu:

1. Tek kayıt isteğinin gövdesinde kaynak metin var, `{text}` yer tutucusu yok.
2. 429 duvarında ilk tur 6 istek atıyor, duvardan sonraki tur **0** istek atıyor.
3. Toplu istek bir kaydı eksik döndürdüğünde tek çağrı onu kurtarıyor.
4. Sağlıklı toplu istek gereksiz yere tek çağrıya düşmüyor.

Workflow'un kendi preflight adımı (`py_compile scripts/*.py` + `node --check scripts/*.js`) yerelde geçiyor, dört YAML da geçerli.

## Davranış değişmeyen taraf

Başarısız çeviri hâlâ `None` dönüyor, sayfa korunuyor. Türkçe metnin başka bir dile sızma yolu açılmadı, testte de doğrulandı. Önbelleklerde (`assets/dictionary/*-cache.json`, 5 dil, ~30 bin kayıt) yer tutucu bulaşması taraması yapıldı, **sıfır** bozuk kayıt var.

## Kapsam dışı bıraktığım

- `_gemini_batch`, JS ikizindeki `id` tekilliği kontrolünü taşımıyor. Tek kayıt yedeği artık çalıştığından eksik kayıt zaten kurtarılıyor; toplu isteği tek yinelenen id yüzünden tümden düşürmek daha pahalı olurdu. Sapma bilinsin diye not ediyorum.
- `translation-service.js` dosyasında `module.exports` iki kez yazılmış (satır 97 ve 191). İkincisi kazanıyor, davranış doğru, bu PR'da dokunmadım.

🤖 Generated with [Claude Code](https://claude.com/claude-code)