### PR TITLE
fix(claude-code): kısmi çeviri hatası günün başarılı işini yakmasın

### DIFF
--- a/.github/workflows/dict-sync.yml
+++ b/.github/workflows/dict-sync.yml
@@ -203,7 +203,26 @@ jobs:
       # bir dilin ilk gününde 400+ keşif sayfası çapraz bağlantısız çıkıyor
       # (2026-08-13'te Portekizce'de yaşandı · sonraki günler kendiliğinden
       # düzeliyordu, o yüzden görülmemişti).
+      # KISMİ BAŞARISIZLIK HATTI DURDURMAMALI · dictionary-en.py bir çeviri
+      # başarısız olduğunda SystemExit(1) veriyor. Sayfayı yazmaması doğru
+      # (yarım çeviri yayına gitmesin), ama çıkış kodu tüm iş akışını
+      # düşürüyordu: guard'lar, sitemap ve COMMIT adımına hiç gelinmiyordu.
+      #
+      # Bedeli: o koşuda başarıyla çevrilen her şey de çöpe gidiyordu. Çeviri
+      # önbelleği (assets/*/XX-cache.json) diske çıkış kodundan ÖNCE yazılıyor,
+      # ama commit olmadığı için runner'la birlikte siliniyordu. Ertesi gün
+      # aynı metinler baştan çevriliyor, aynı yerde tükeniyor, hat hiç
+      # ilerlemiyordu · 24-27 Ağustos arası dört koşu tam olarak böyle geçti.
+      # 27 Ağustos koşusunda en/fr/pt sıfır hatayla bitti, es ve de kotada
+      # tükendi ve ÜÇ DİLİN 33 dakikalık işi de silindi.
+      #
+      # Artık adım yumuşak: başarılı sayfalar ve önbellek commit'leniyor,
+      # eksik kalanlar ertesi koşuda kaldığı yerden devam ediyor. Koşunun
+      # kırmızı kalması için en sonda ayrı bir adım var · sessizce yeşile
+      # dönmesin.
       - name: Sayfaları üret · her dilde sözlük SONRA keşif
+        id: sayfalar
+        continue-on-error: true
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           DICTIONARY_SLUGS: ${{ github.event.inputs.dictionary_slugs }}
@@ -243,7 +262,10 @@ jobs:
       # (2026-08-15: "svg" terimi beş dilde "İlgili araçlar" olmadan çıktı;
       # Almanca eklenirken de 353 sözlük sayfası aynı sebeple eksikti).
       # Çeviriler önbellekli · ikinci tur birkaç saniye.
+      # Aynı gerekçe · ikinci tur da kısmi başarısızlıkta hattı düşürmesin.
       - name: Sözlük ikinci tur (keşif sayfaları artık diskte)
+        id: ikinci_tur
+        continue-on-error: true
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           DICTIONARY_SLUGS: ${{ github.event.inputs.dictionary_slugs }}
@@ -444,6 +466,19 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_indexnow != 'true' }}
         continue-on-error: true
         run: node scripts/indexnow.js
+
+      # Yumuşatılan adımlar koşuyu sessizce yeşile döndürmesin · içerik
+      # commit'lendikten SONRA burada kırmızıya çekiyoruz. Böylece hem günün
+      # işi yayına giriyor hem de eksik çeviri gözden kaçmıyor.
+      - name: Çeviri eksikleri raporlansın (içerik yayınlandıktan sonra)
+        if: ${{ steps.sayfalar.outcome == 'failure' || steps.ikinci_tur.outcome == 'failure' }}
+        run: |
+          echo "✗ Bazı çeviriler tamamlanamadı · üretilen sayfalar ve önbellek commit'lendi."
+          echo "  sayfa üretimi: ${{ steps.sayfalar.outcome }}"
+          echo "  ikinci tur   : ${{ steps.ikinci_tur.outcome }}"
+          echo "  Eksik kalan diller bir sonraki koşuda kaldığı yerden devam eder."
+          echo "  Üst üste tekrar ediyorsa sağlayıcı günlük kotasına bakın."
+          exit 1
 
       - name: IndexNow recovery için atlandı
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_indexnow == 'true' }}

--- a/scripts/translation_service.py
+++ b/scripts/translation_service.py
@@ -55,10 +55,23 @@ def _pause_span(delay: float, streak: int) -> float:
     return min(max(delay, 30.0) * (2 ** max(streak - 1, 0)), _PAUSE_CAP)
 
 
+def _duyur(saglayici: str, span: float, streak: int) -> None:
+    """Kota duvarını loga yaz · yoksa koşu "neden çeviremedi" diye okunamıyor.
+
+    27 Ağustos koşusunda en/fr/pt sıfır hatayla bitti, es ortasında tükendi.
+    Duraklatma çalıştı ama log bunu söylemediği için tükenme mi yoksa başka
+    bir hata mı olduğu ancak zaman damgalarından çıkarılabildi.
+    """
+    if streak == 1:
+        print(f"  ! {saglayici} kota duvarı · çeviri {span:.0f} sn duraklatıldı "
+              f"(tekrarında pencere ikiye katlanır)", flush=True)
+
+
 def _pause_gemini(delay: float) -> None:
     global _GEMINI_PAUSED_UNTIL, _GEMINI_PAUSE_STREAK
     _GEMINI_PAUSE_STREAK += 1
     span = _pause_span(delay, _GEMINI_PAUSE_STREAK)
+    _duyur("Gemini", span, _GEMINI_PAUSE_STREAK)
     _GEMINI_PAUSED_UNTIL = max(_GEMINI_PAUSED_UNTIL, time.time() + span)
 
 
@@ -70,6 +83,7 @@ def _pause_gtx(delay: float) -> None:
     global _GTX_PAUSED_UNTIL, _GTX_PAUSE_STREAK
     _GTX_PAUSE_STREAK += 1
     span = _pause_span(delay, _GTX_PAUSE_STREAK)
+    _duyur("GTX", span, _GTX_PAUSE_STREAK)
     _GTX_PAUSED_UNTIL = max(_GTX_PAUSED_UNTIL, time.time() + span)
 
 


### PR DESCRIPTION
## Dünkü koşu neyi gösterdi

[#212](https://github.com/trescout/landing/pull/212) sonrası ilk koşu ([33038104919](https://github.com/trescout/landing/actions/runs/33038104919)) hattın **asıl kilidini** ortaya çıkardı. Dil dil sonuç:

| dil | başarısız çeviri | süre |
|---|---|---|
| en | **0** | 11 dk |
| fr | **0** | 11 dk |
| pt | **0** | 11 dk |
| es | 37 | 5 dk |
| de | 44 | 37 sn |

İlk üç dil üç gündür ilk kez sorunsuz çevrildi, yani #212'deki düzeltmeler işini yaptı. Sonra `es` ortasında sağlayıcı kotası tükendi ve duraklatma devreye girdi (bu yüzden `de` 37 saniyede bitti · eskiden saatler sürerdi).

## Asıl sorun: koşu, başardığı işi de siliyordu

`dictionary-en.py` bir çeviri başarısız olduğunda `SystemExit(1)` veriyor. Sayfayı yazmaması doğru, yarım çeviri yayına gitmemeli. Ama çıkış kodu **tüm iş akışını** düşürüyordu: guard'lara, sitemap'e ve `Değişiklik varsa commit'le` adımına hiç gelinmiyordu.

Bedeli: o koşuda başarıyla çevrilen her şey de çöpe gidiyordu. Çeviri önbelleği (`assets/*/XX-cache.json`) diske çıkış kodundan **önce** yazılıyor, ama commit olmadığı için runner'la birlikte siliniyordu.

Sonuç bir kısır döngü: ertesi gün aynı metinler baştan çevriliyor, aynı kota duvarına aynı yerde çarpılıyor, hat bir gün bile ilerlemiyor. 24-27 Ağustos arası dört koşu tam olarak böyle geçti. Dün üç dilin 33 dakikalık çevirisi silindi.

## Değişiklik

`Sayfaları üret` ve `Sözlük ikinci tur` adımları `continue-on-error: true` oldu. Başarılı sayfalar ve önbellek commit'leniyor, eksik kalan diller ertesi koşuda kaldığı yerden devam ediyor · her gün bir adım ileri.

Koşu bu yüzden sessizce yeşile dönmesin diye, **içerik yayınlandıktan sonra** çalışan ayrı bir adım çıkış kodunu 1 yapıyor ve hangi adımın düştüğünü yazıyor. Yani hem günün işi yayına giriyor hem de eksik çeviri gözden kaçmıyor.

Bu, deponun kendi yazılı politikasının aynısı (`Bölüm paritesi` adımındaki yorum): *"tek bir sayfanın eksik bölümü için 6500 sayfalık yayını durdurmak orantısız"*.

## Görünürlük

Duraklatma artık loga bir satır yazıyor:

```
! Gemini kota duvarı · çeviri 38 sn duraklatıldı (tekrarında pencere ikiye katlanır)
```

Dün duraklatma çalıştı ama log bunu söylemediği için kota tükenmesi mi başka bir hata mı olduğu ancak dil dil zaman damgası çıkarılarak anlaşılabildi. Bir sonraki koşuda bu tek satır cevabı verecek.

## Yan bulgu

`discover-en.py` aynı durumda çıkış kodu vermiyor, `dictionary-en.py` veriyordu. Aynı işi yapan iki üretici aynı politikada değildi ve fark hiçbir yerde yazılı değil. Betiklerin davranışını değiştirmedim; bu PR ikisini de tek yerden (iş akışı) yönetiyor.

## Sıradaki soru

Kota her koşuda beşinci dile yetmiyor. Bu PR hattı ilerletiyor ama kotayı büyütmüyor · birikmiş çeviri borcu birkaç koşuda kapanacak, sonra günlük hacim tek koşuya sığmalı. Kapanmazsa dilleri koşulara bölmek (her koşuda iki dil) sonraki adım olur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)